### PR TITLE
Added Html transformation rules for syntax tree

### DIFF
--- a/lib/plurimath/html/parser.rb
+++ b/lib/plurimath/html/parser.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "json"
+require_relative "parse"
+require_relative "constants"
+require_relative "transform"
+module Plurimath
+  class Html
+    class Parser
+      attr_accessor :text
+
+      def initialize(text)
+        @text = CGI.unescapeHTML(text)
+      end
+
+      def parse
+        nodes = Parse.new.parse(text)
+        nodes = JSON.parse(nodes.to_json, symbolize_names: true)
+        transformed_tree = Transform.new.apply(nodes)
+        return transformed_tree if transformed_tree.is_a?(Math::Formula)
+
+        Math::Formula.new(transformed_tree)
+      end
+    end
+  end
+end

--- a/lib/plurimath/html/transform.rb
+++ b/lib/plurimath/html/transform.rb
@@ -1,0 +1,359 @@
+# frozen_string_literal: true
+
+module Plurimath
+  class Html
+    class Transform < Parslet::Transform
+      rule(text: simple(:text))     { Math::Function::Text.new(text) }
+      rule(unary: simple(:unary))   { Transform.get_class(unary).new }
+      rule(symbol: simple(:symbol)) { Math::Symbol.new(symbol) }
+      rule(number: simple(:number)) { Math::Number.new(number) }
+
+      rule(sequence: simple(:sequence))   { sequence }
+      rule(tr_value: simple(:tr_value))   { Math::Function::Tr.new([tr_value]) }
+      rule(td_value: simple(:td_value))   { Math::Function::Td.new([td_value]) }
+      rule(sequence: sequence(:sequence)) { Math::Formula.new(sequence) }
+      rule(td_value: sequence(:td_value)) { Math::Function::Td.new(td_value) }
+
+      rule(parse_parenthesis: simple(:parse_paren)) { parse_paren }
+      rule(unary_function: simple(:unary_function)) { unary_function }
+
+      rule(table_value: simple(:table_value)) do
+        Math::Function::Table.new([table_value])
+      end
+
+      rule(table_value: sequence(:table_value)) do
+        Math::Function::Table.new(table_value)
+      end
+
+      rule(sum_prod: simple(:sum_prod)) do
+        Transform.get_class(
+          Constants::SUB_SUP_CLASSES[sum_prod.to_sym],
+        ).new
+      end
+
+      rule(sequence: simple(:sequence),
+           expression: simple(:expr)) do
+        [sequence, expr]
+      end
+
+      rule(sequence: simple(:sequence),
+           expression: sequence(:expr)) do
+        expr.insert(0, sequence)
+      end
+
+      rule(sequence: sequence(:sequence),
+           expression: simple(:expr)) do
+        sequence << expr
+      end
+
+      rule(tr_value: simple(:tr_value),
+           expression: simple(:expr)) do
+        [Math::Function::Tr.new([tr_value]), expr]
+      end
+
+      rule(tr_value: simple(:tr_value),
+           expression: sequence(:expr)) do
+        expr.insert(0, Math::Function::Tr.new([tr_value]))
+      end
+
+      rule(unary_function: simple(:unary_function),
+           sequence: simple(:sequence)) do
+        Math::Formula.new([unary_function, sequence])
+      end
+
+      rule(text: simple(:text),
+           expression: simple(:expr)) do
+        [Math::Function::Text.new(text), expr]
+      end
+
+      rule(text: simple(:text),
+           expression: sequence(:expr)) do
+        [Math::Function::Text.new(text)] + expr
+      end
+
+      rule(symbol: simple(:symbol),
+           expression: simple(:expr)) do
+        [Math::Symbol.new(symbol), expr]
+      end
+
+      rule(symbol: simple(:symbol),
+           expression: sequence(:expr)) do
+        [Math::Symbol.new(symbol)] + expr
+      end
+
+      rule(number: simple(:number),
+           expression: sequence(:expr)) do
+        [Math::Number.new(number)] + expr
+      end
+
+      rule(number: simple(:number),
+           expression: simple(:expr)) do
+        [Math::Number.new(number), expr]
+      end
+
+      rule(text: simple(:text),
+           parse_parenthesis: simple(:parse_paren)) do
+        Math::Formula.new(
+          [
+            Math::Function::Text.new(text),
+            parse_paren,
+          ],
+        )
+      end
+
+      rule(unary: simple(:unary),
+           first_value: simple(:first_value)) do
+        Transform.get_class(unary).new(first_value)
+      end
+
+      rule(symbol: simple(:symbol),
+           parse_parenthesis: simple(:parse_paren)) do
+        [
+          Math::Symbol.new(symbol),
+          parse_paren,
+        ]
+      end
+
+      rule(sub_sup: simple(:sub_sup),
+           sub_value: simple(:sub_value)) do
+        if Transform.sub_sup_method?(sub_sup)
+          sub_sup.parameter_one = sub_value
+          sub_sup
+        else
+          Math::Function::Base.new(
+            sub_sup,
+            sub_value,
+          )
+        end
+      end
+
+      rule(sub_sup: simple(:sub_sup),
+           sub_value: sequence(:sub_value)) do
+        if Transform.sub_sup_method?(sub_sup)
+          sub_sup.parameter_one = Math::Formula.new(sub_value)
+          sub_sup
+        else
+          Math::Function::Base.new(
+            sub_sup,
+            Math::Formula.new(sub_value),
+          )
+        end
+      end
+
+      rule(sub_sup: simple(:sub_sup),
+           sup_value: simple(:sup_value)) do
+        if Transform.sub_sup_method?(sub_sup)
+          sub_sup.parameter_two = sup_value
+          sub_sup
+        else
+          Math::Function::Power.new(
+            sub_sup,
+            sup_value,
+          )
+        end
+      end
+
+      rule(sub_sup: simple(:sub_sup),
+           sup_value: sequence(:sup_value)) do
+        if Transform.sub_sup_method?(sub_sup)
+          sub_sup.parameter_two = Math::Formula.new(sup_value)
+          sub_sup
+        else
+          Math::Function::Power.new(
+            sub_sup,
+            Math::Formula.new(sup_value),
+          )
+        end
+      end
+
+      rule(sub_sup: simple(:sub_sup),
+           sub_value: simple(:sub_value),
+           sup_value: simple(:sup_value)) do
+        if Transform.sub_sup_method?(sub_sup)
+          sub_sup.parameter_one = sub_value
+          sub_sup.parameter_two = sup_value
+          sub_sup
+        else
+          Math::Function::PowerBase.new(
+            sub_sup,
+            sub_value,
+            sup_value,
+          )
+        end
+      end
+
+      rule(sub_sup: simple(:sub_sup),
+           sub_value: simple(:sub_value),
+           sup_value: sequence(:sup_value)) do
+        if Transform.sub_sup_method?(sub_sup)
+          sub_sup.parameter_one = sub_value
+          sub_sup.parameter_two = Math::Formula.new(sup_value)
+          sub_sup
+        else
+          Math::Function::PowerBase.new(
+            sub_sup,
+            sub_value,
+            Math::Formula.new(sup_value),
+          )
+        end
+      end
+
+      rule(sub_sup: simple(:sub_sup),
+           sub_value: sequence(:sub_value),
+           sup_value: simple(:sup_value)) do
+        if Transform.sub_sup_method?(sub_sup)
+          sub_sup.parameter_one = Math::Formula.new(sub_value)
+          sub_sup.parameter_two = sup_value
+          sub_sup
+        else
+          Math::Function::PowerBase.new(
+            sub_sup,
+            Math::Formula.new(sub_value),
+            sup_value,
+          )
+        end
+      end
+
+      rule(sub_sup: simple(:sub_sup),
+           sub_value: sequence(:sub_value),
+           sup_value: sequence(:sup_value)) do
+        if Transform.sub_sup_method?(sub_sup)
+          sub_sup.parameter_one = Math::Formula.new(sub_value)
+          sub_sup.parameter_two = Math::Formula.new(sup_value)
+          sub_sup
+        else
+          Math::Function::PowerBase.new(
+            sub_sup,
+            Math::Formula.new(sub_value),
+            Math::Formula.new(sup_value),
+          )
+        end
+      end
+
+      rule(lparen: simple(:lparen),
+           text: simple(:text),
+           rparen: simple(:rparen)) do
+        Math::Formula.new([
+                            Math::Symbol.new(lparen),
+                            Math::Function::Text.new(text),
+                            Math::Symbol.new(rparen),
+                          ])
+      end
+
+      rule(lparen: simple(:lparen),
+           sequence: simple(:sequence),
+           rparen: simple(:rparen)) do
+        Math::Formula.new([
+                            Math::Symbol.new(lparen),
+                            sequence,
+                            Math::Symbol.new(rparen),
+                          ])
+      end
+
+      rule(lparen: simple(:lparen),
+           sequence: sequence(:sequence),
+           rparen: simple(:rparen)) do
+        Math::Formula.new([
+                            Math::Symbol.new(lparen),
+                            Math::Formula.new(sequence),
+                            Math::Symbol.new(rparen),
+                          ])
+      end
+
+      rule(lparen: simple(:lparen),
+           number: simple(:number),
+           rparen: simple(:rparen)) do
+        Math::Formula.new([
+                            Math::Symbol.new(lparen),
+                            Math::Number.new(number),
+                            Math::Symbol.new(rparen),
+                          ])
+      end
+
+      rule(lparen: simple(:lparen),
+           unary_function: simple(:unary_function),
+           rparen: simple(:rparen)) do
+        Math::Formula.new([
+                            Math::Symbol.new(lparen),
+                            unary_function,
+                            Math::Symbol.new(rparen),
+                          ])
+      end
+
+      rule(binary: simple(:binary),
+           first_value: simple(:first_value),
+           second_value: simple(:second_value)) do
+        Transform.get_class(binary).new(first_value, second_value)
+      end
+
+      rule(lparen: simple(:lparen),
+           text: simple(:text),
+           expression: sequence(:expression),
+           rparen: simple(:rparen)) do
+        Math::Formula.new(
+          (
+            [
+              Math::Symbol.new(lparen),
+              Math::Function::Text.new(text),
+            ] + expression
+          ) << Math::Symbol.new(rparen),
+        )
+      end
+
+      rule(lparen: simple(:lparen),
+           text: simple(:text),
+           expression: simple(:expression),
+           rparen: simple(:rparen)) do
+        Math::Formula.new([
+                            Math::Symbol.new(lparen),
+                            Math::Function::Text.new(text),
+                            expression,
+                            Math::Symbol.new(rparen),
+                          ])
+      end
+
+      rule(lparen: simple(:lparen),
+           number: simple(:number),
+           expression: simple(:expression),
+           rparen: simple(:rparen)) do
+        Math::Formula.new([
+                            Math::Symbol.new(lparen),
+                            Math::Number.new(number),
+                            expression,
+                            Math::Symbol.new(rparen),
+                          ])
+      end
+
+      rule(lparen: simple(:lparen),
+           number: simple(:number),
+           expression: sequence(:expression),
+           rparen: simple(:rparen)) do
+        Math::Formula.new(
+          (
+            [
+              Math::Symbol.new(lparen),
+              Math::Number.new(number),
+            ] +
+            expression
+          ) << Math::Symbol.new(rparen),
+        )
+      end
+
+      class << self
+        def sub_sup_method?(sub_sup)
+          if sub_sup.methods.include?(:class_name)
+            Constants::SUB_SUP_CLASSES.value?(
+              sub_sup.class_name.to_sym,
+            )
+          end
+        end
+
+        def get_class(text)
+          Object.const_get(
+            "Plurimath::Math::Function::#{text.capitalize}",
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/plurimath/math.rb
+++ b/lib/plurimath/math.rb
@@ -14,6 +14,7 @@ require_relative "math/symbol"
 require_relative "asciimath/parser"
 require_relative "mathml/parser"
 require_relative "latex/parser"
+require_relative "html/parser"
 module Plurimath
   module Math
     class Error < StandardError; end

--- a/spec/plurimath/html/parser_spec.rb
+++ b/spec/plurimath/html/parser_spec.rb
@@ -1,0 +1,1157 @@
+require_relative "../../../lib/plurimath/math"
+
+RSpec.describe Plurimath::Html::Parser do
+
+  describe ".parse" do
+    subject(:formula) {
+      described_class.new(string.gsub(/\s/, "")).parse
+    }
+
+    context "basic parse rules for single character tag" do
+      let(:string) { "<i>&sum;</i>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Sum.new
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "basic parse rules for multiple character tag" do
+      let(:string) { "<div>&sum;</div>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Sum.new
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains sum with sub and sup values" do
+      let(:string) { "&sum;<sub>d</sub><sup>prod</sup>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Sum.new(
+            Plurimath::Math::Function::Text.new("d"),
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Function::Text.new("p"),
+              Plurimath::Math::Function::Text.new("r"),
+              Plurimath::Math::Function::Text.new("o"),
+              Plurimath::Math::Function::Text.new("d")
+            ])
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains sub tag" do
+      let(:string) { "<div>&sum;<sub>&prod;</sub></div>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Sum.new(
+            Plurimath::Math::Function::Prod.new,
+            nil
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains sub and sup tag" do
+      let(:string) { "<div>&sum;<sub>&prod;</sub><sup>prod</sup></div>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Sum.new(
+            Plurimath::Math::Function::Prod.new,
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Function::Text.new("p"),
+              Plurimath::Math::Function::Text.new("r"),
+              Plurimath::Math::Function::Text.new("o"),
+              Plurimath::Math::Function::Text.new("d")
+            ])
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains complex sub and sup tag" do
+      let(:string) {
+        <<~HTML
+          <div>
+            some
+            <sup><span>(</span><span>S</span><span>)</span></sup>
+            <sub>g</sub>
+          </div>
+        HTML
+      }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Text.new("s"),
+          Plurimath::Math::Function::Text.new("o"),
+          Plurimath::Math::Function::Text.new("m"),
+          Plurimath::Math::Function::PowerBase.new(
+            Plurimath::Math::Function::Text.new("e"),
+            Plurimath::Math::Function::G.new,
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Symbol.new("("),
+              Plurimath::Math::Function::Text.new("S"),
+              Plurimath::Math::Symbol.new(")")
+            ]),
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #1" do
+      let(:string) { "abs(3)" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Abs.new(
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Symbol.new("("),
+              Plurimath::Math::Number.new("3"),
+              Plurimath::Math::Symbol.new(")")
+            ])
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #2" do
+      let(:string) { "abc[0]" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Text.new("a"),
+          Plurimath::Math::Function::Text.new("b"),
+          Plurimath::Math::Formula.new([
+            Plurimath::Math::Function::Text.new("c"),
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Symbol.new("["),
+              Plurimath::Math::Number.new("0"),
+              Plurimath::Math::Symbol.new("]")
+            ])
+          ])
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #3" do
+      let(:string) { "abc{0}" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Text.new("a"),
+          Plurimath::Math::Function::Text.new("b"),
+          Plurimath::Math::Formula.new([
+            Plurimath::Math::Function::Text.new("c"),
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Symbol.new("{"),
+              Plurimath::Math::Number.new("0"),
+              Plurimath::Math::Symbol.new("}")
+            ])
+          ])
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #4" do
+      let(:string) { "abc(weatever text [and things])" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Text.new("a"),
+          Plurimath::Math::Function::Text.new("b"),
+          Plurimath::Math::Formula.new([
+            Plurimath::Math::Function::Text.new("c"),
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Symbol.new("("),
+              Plurimath::Math::Function::Text.new("w"),
+              Plurimath::Math::Function::Text.new("e"),
+              Plurimath::Math::Function::Text.new("a"),
+              Plurimath::Math::Function::Text.new("t"),
+              Plurimath::Math::Function::Text.new("e"),
+              Plurimath::Math::Function::Text.new("v"),
+              Plurimath::Math::Function::Text.new("e"),
+              Plurimath::Math::Function::Text.new("r"),
+              Plurimath::Math::Function::Text.new("t"),
+              Plurimath::Math::Function::Text.new("e"),
+              Plurimath::Math::Function::Text.new("x"),
+              Plurimath::Math::Formula.new([
+                Plurimath::Math::Function::Text.new("t"),
+                Plurimath::Math::Formula.new([
+                  Plurimath::Math::Symbol.new("["),
+                  Plurimath::Math::Function::Text.new("a"),
+                  Plurimath::Math::Function::Text.new("n"),
+                  Plurimath::Math::Function::Text.new("d"),
+                  Plurimath::Math::Function::Text.new("t"),
+                  Plurimath::Math::Function::Text.new("h"),
+                  Plurimath::Math::Function::Text.new("i"),
+                  Plurimath::Math::Function::Text.new("n"),
+                  Plurimath::Math::Function::G.new(
+                    Plurimath::Math::Function::Text.new("s")
+                  ),
+                  Plurimath::Math::Symbol.new("]")
+                ])
+              ]),
+              Plurimath::Math::Symbol.new(")")
+            ])
+          ])
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #5" do
+      let(:string) { "ϑ(t)" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Symbol.new("ϑ"),
+          Plurimath::Math::Formula.new([
+            Plurimath::Math::Symbol.new("("),
+            Plurimath::Math::Function::Text.new("t"),
+            Plurimath::Math::Symbol.new(")")
+          ])
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #6" do
+      let(:string) { "<i>a</i><sup>2</sup>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Power.new(
+            Plurimath::Math::Function::Text.new("a"),
+            Plurimath::Math::Number.new("2")
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #7" do
+      let(:string) { "<i>a</i><sub>2</sub>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Base.new(
+            Plurimath::Math::Function::Text.new("a"),
+            Plurimath::Math::Number.new("2")
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #8" do
+      let(:string) { "<i>a</i><sup><i>n</i></sup>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Power.new(
+            Plurimath::Math::Function::Text.new("a"),
+            Plurimath::Math::Function::Text.new("n")
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #9" do
+      let(:string) { "<i>a</i><sub><i>n</i></sub>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Base.new(
+            Plurimath::Math::Function::Text.new("a"),
+            Plurimath::Math::Function::Text.new("n")
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #10" do
+      let(:string) { "2<sup>3</sup>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Power.new(
+            Plurimath::Math::Number.new("2"),
+            Plurimath::Math::Number.new("3")
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #11" do
+      let(:string) { "2<sup>3+4</sup>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Power.new(
+            Plurimath::Math::Number.new("2"),
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Number.new("3"),
+              Plurimath::Math::Symbol.new("+"),
+              Plurimath::Math::Number.new("4")
+            ])
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #12" do
+      let(:string) { "2<sub>3+4</sub>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Base.new(
+            Plurimath::Math::Number.new("2"),
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Number.new("3"),
+              Plurimath::Math::Symbol.new("+"),
+              Plurimath::Math::Number.new("4")
+            ])
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #13" do
+      let(:string) { "<i>a</i><sub><i>b</i>+2</sub>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Base.new(
+            Plurimath::Math::Function::Text.new("a"),
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Function::Text.new("b"),
+              Plurimath::Math::Symbol.new("+"),
+              Plurimath::Math::Number.new("2")
+            ])
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #14" do
+      let(:string) { "<i>a</i><sup>-2</sup>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Power.new(
+            Plurimath::Math::Function::Text.new("a"),
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Symbol.new("-"),
+              Plurimath::Math::Number.new("2")
+            ])
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #15" do
+      let(:string) { "<i>a</i><sub>-2</sub>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Base.new(
+            Plurimath::Math::Function::Text.new("a"),
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Symbol.new("-"),
+              Plurimath::Math::Number.new("2")
+            ])
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #16" do
+      let(:string) { "<i>a</i><sup>-<i>n</i></sup>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Power.new(
+            Plurimath::Math::Function::Text.new("a"),
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Symbol.new("-"),
+              Plurimath::Math::Function::Text.new("n")
+            ])
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #17" do
+      let(:string) { "<i>a</i><sub>-<i>n</i></sub>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Base.new(
+            Plurimath::Math::Function::Text.new("a"),
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Symbol.new("-"),
+              Plurimath::Math::Function::Text.new("n")
+            ])
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #18" do
+      let(:string) { "<i>a</i><sub><i>n</i></sub><sup>2</sup>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::PowerBase.new(
+            Plurimath::Math::Function::Text.new("a"),
+            Plurimath::Math::Function::Text.new("n"),
+            Plurimath::Math::Number.new("2"),
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #19" do
+      let(:string) do
+        <<~HTML
+          <i>a</i>
+          <sub>
+            <i>n+1</i>
+          </sub>
+          <sup>
+            <i>b</i>+<i>c</i>
+          </sup>
+        HTML
+      end
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::PowerBase.new(
+            Plurimath::Math::Function::Text.new("a"),
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Function::Text.new("n"),
+              Plurimath::Math::Symbol.new("+"),
+              Plurimath::Math::Number.new("1")
+            ]),
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Function::Text.new("b"),
+              Plurimath::Math::Symbol.new("+"),
+              Plurimath::Math::Function::Text.new("c")
+            ]),
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #20" do
+      let(:string) { "<i>f</i>(<i>x</x>)" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::F.new(
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Symbol.new("("),
+              Plurimath::Math::Function::Text.new("x"),
+              Plurimath::Math::Symbol.new(")")
+            ])
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #21" do
+      let(:string) { "<i>f</i>(<i>g</i>(<i>x</x>))" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::F.new(
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Symbol.new("("),
+              Plurimath::Math::Function::G.new(
+                Plurimath::Math::Formula.new([
+                  Plurimath::Math::Symbol.new("("),
+                  Plurimath::Math::Function::Text.new("x"),
+                  Plurimath::Math::Symbol.new(")")
+                ])
+              ),
+              Plurimath::Math::Symbol.new(")")
+            ])
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #22" do
+      let(:string) { "f&sum;(<i>n</i>)(<i>2</i>)" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Formula.new([
+            Plurimath::Math::Function::F.new(
+              Plurimath::Math::Function::Sum.new
+            ),
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Symbol.new("("),
+              Plurimath::Math::Function::Text.new("n"),
+              Plurimath::Math::Symbol.new(")")
+            ])
+          ]),
+          Plurimath::Math::Formula.new([
+            Plurimath::Math::Symbol.new("("),
+            Plurimath::Math::Number.new("2"),
+            Plurimath::Math::Symbol.new(")")
+          ])
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #23" do
+      let(:string) { "fib(<i>n</i>)" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::F.new(
+            Plurimath::Math::Function::Text.new("i")
+          ),
+          Plurimath::Math::Formula.new([
+            Plurimath::Math::Function::Text.new("b"),
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Symbol.new("("),
+              Plurimath::Math::Function::Text.new("n"),
+              Plurimath::Math::Symbol.new(")")
+            ])
+          ])
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #24" do
+      let(:string) { "<i>f</i><sub>max</sub>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Base.new(
+            Plurimath::Math::Function::F.new,
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Function::Text.new("m"),
+              Plurimath::Math::Function::Text.new("a"),
+              Plurimath::Math::Function::Text.new("x")
+            ])
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #25" do
+      let(:string) { "<i>&omega;</i>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Symbol.new("&omega;")
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #26" do
+      let(:string) { "<i>&Omega;</i>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Symbol.new("&Omega;")
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #27" do
+      let(:string) { "αβγ" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Symbol.new("α"),
+          Plurimath::Math::Symbol.new("β"),
+          Plurimath::Math::Symbol.new("γ")
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #28" do
+      let(:string) { "абг" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Symbol.new("а"),
+          Plurimath::Math::Symbol.new("б"),
+          Plurimath::Math::Symbol.new("г")
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #29" do
+      let(:string) { "<i>f</i><sup>-1</sup>(<i>x</x>)" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::F.new(
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Symbol.new("-"),
+              Plurimath::Math::Number.new("1")
+            ])
+          ),
+          Plurimath::Math::Formula.new([
+            Plurimath::Math::Symbol.new("("),
+            Plurimath::Math::Function::Text.new("x"),
+            Plurimath::Math::Symbol.new(")")
+          ])
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #30" do
+      let(:string) { "<sub>sth</sub>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Text.new("s"),
+          Plurimath::Math::Function::Text.new("t"),
+          Plurimath::Math::Function::Text.new("h")
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #31" do
+      let(:string) { "root(<i>sth</i>)" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Text.new("r"),
+          Plurimath::Math::Function::Text.new("o"),
+          Plurimath::Math::Function::Text.new("o"),
+          Plurimath::Math::Formula.new([
+            Plurimath::Math::Function::Text.new("t"),
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Symbol.new("("),
+              Plurimath::Math::Formula.new([
+                Plurimath::Math::Function::Text.new("s"),
+                Plurimath::Math::Function::Text.new("t"),
+                Plurimath::Math::Function::Text.new("h")
+              ]),
+              Plurimath::Math::Symbol.new(")")
+            ])
+          ])
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #32" do
+      let(:string) { "<table><tr><td>Something</td></tr></table>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Table.new([
+            Plurimath::Math::Function::Tr.new([
+              Plurimath::Math::Function::Td.new([
+                Plurimath::Math::Function::Text.new("S"),
+                Plurimath::Math::Function::Text.new("o"),
+                Plurimath::Math::Function::Text.new("m"),
+                Plurimath::Math::Function::Text.new("e"),
+                Plurimath::Math::Function::Text.new("t"),
+                Plurimath::Math::Function::Text.new("h"),
+                Plurimath::Math::Function::Text.new("i"),
+                Plurimath::Math::Function::Text.new("n"),
+                Plurimath::Math::Function::G.new
+              ])
+            ])
+          ])
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #33" do
+      let(:string) do
+        <<~HTML
+          <table>
+            <tr>
+              <td>4</td>
+            </tr>
+            <tr>
+              <td>3</td>
+            </tr>
+            <tr>
+              <td>2</td>
+            </tr>
+            <tr>
+              <td>1</td>
+            </tr>
+          </table>
+        HTML
+      end
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Table.new([
+            Plurimath::Math::Function::Tr.new([
+              Plurimath::Math::Function::Td.new([
+                Plurimath::Math::Number.new("4")
+              ])
+            ]),
+            Plurimath::Math::Function::Tr.new([
+              Plurimath::Math::Function::Td.new([
+                Plurimath::Math::Number.new("3")
+              ])
+            ]),
+            Plurimath::Math::Function::Tr.new([
+              Plurimath::Math::Function::Td.new([
+                Plurimath::Math::Number.new("2")
+              ])
+            ]),
+            Plurimath::Math::Function::Tr.new([
+              Plurimath::Math::Function::Td.new([
+                Plurimath::Math::Number.new("1")
+              ])
+            ])
+          ])
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #34" do
+      let(:string) do
+        <<~HTML
+          <table>
+            <tr>
+              <td>so</td>
+            </tr>
+            <tr>
+              <td>es</td>
+            </tr>
+            <tr>
+              <td>&sum;</td>
+            </tr>
+            <tr>
+              <td>&prod;</td>
+            </tr>
+          </table>
+        HTML
+      end
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Table.new([
+            Plurimath::Math::Function::Tr.new([
+              Plurimath::Math::Function::Td.new([
+                Plurimath::Math::Function::Text.new("s"),
+                Plurimath::Math::Function::Text.new("o")
+              ])
+            ]),
+            Plurimath::Math::Function::Tr.new([
+              Plurimath::Math::Function::Td.new([
+                Plurimath::Math::Function::Text.new("e"),
+                Plurimath::Math::Function::Text.new("s")
+              ])
+            ]),
+            Plurimath::Math::Function::Tr.new([
+              Plurimath::Math::Function::Td.new([
+                Plurimath::Math::Function::Sum.new
+              ])
+            ]),
+            Plurimath::Math::Function::Tr.new([
+              Plurimath::Math::Function::Td.new([
+                Plurimath::Math::Function::Prod.new
+              ])
+            ])
+          ])
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #35" do
+      let(:string) { "&sum;<sub>drop</sub><sup>prod</sup>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Sum.new(
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Function::Text.new("d"),
+              Plurimath::Math::Function::Text.new("r"),
+              Plurimath::Math::Function::Text.new("o"),
+              Plurimath::Math::Function::Text.new("p")
+            ]),
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Function::Text.new("p"),
+              Plurimath::Math::Function::Text.new("r"),
+              Plurimath::Math::Function::Text.new("o"),
+              Plurimath::Math::Function::Text.new("d")
+            ])
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #36" do
+      let(:string) { "&sum;<sub>drop</sub><sup>p</sup>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Sum.new(
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Function::Text.new("d"),
+              Plurimath::Math::Function::Text.new("r"),
+              Plurimath::Math::Function::Text.new("o"),
+              Plurimath::Math::Function::Text.new("p")
+            ]),
+            Plurimath::Math::Function::Text.new("p")
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #37" do
+      let(:string) { "&sum;<sup>p</sup>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Sum.new(
+            nil,
+            Plurimath::Math::Function::Text.new("p")
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #38" do
+      let(:string) { "&sum;<sup>prod</sup>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Sum.new(
+            nil,
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Function::Text.new("p"),
+              Plurimath::Math::Function::Text.new("r"),
+              Plurimath::Math::Function::Text.new("o"),
+              Plurimath::Math::Function::Text.new("d")
+            ])
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #39" do
+      let(:string) { "&sum;<sub>prod</sub>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Sum.new(
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Function::Text.new("p"),
+              Plurimath::Math::Function::Text.new("r"),
+              Plurimath::Math::Function::Text.new("o"),
+              Plurimath::Math::Function::Text.new("d")
+            ])
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #40" do
+      let(:string) { "2<sub>3</sub>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Base.new(
+            Plurimath::Math::Number.new("2"),
+            Plurimath::Math::Number.new("3")
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #41" do
+      let(:string) { "&sum;<sub>3</sub><sup>5</sup>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Sum.new(
+            Plurimath::Math::Number.new("3"),
+            Plurimath::Math::Number.new("5")
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #42" do
+      let(:string) { "2<sub>3</sub><sup>5</sup>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::PowerBase.new(
+            Plurimath::Math::Number.new("2"),
+            Plurimath::Math::Number.new("3"),
+            Plurimath::Math::Number.new("5"),
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #43" do
+      let(:string) { "2<sub>so</sub><sup>we</sup>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::PowerBase.new(
+            Plurimath::Math::Number.new("2"),
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Function::Text.new("s"),
+              Plurimath::Math::Function::Text.new("o")
+            ]),
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Function::Text.new("w"),
+              Plurimath::Math::Function::Text.new("e")
+            ]),
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #44" do
+      let(:string) { "2<sub>s</sub><sup>we</sup>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::PowerBase.new(
+            Plurimath::Math::Number.new("2"),
+            Plurimath::Math::Function::Text.new("s"),
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Function::Text.new("w"),
+              Plurimath::Math::Function::Text.new("e")
+            ]),
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #45" do
+      let(:string) { "2<sub>so</sub><sup>w</sup>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::PowerBase.new(
+            Plurimath::Math::Number.new("2"),
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Function::Text.new("s"),
+              Plurimath::Math::Function::Text.new("o")
+            ]),
+            Plurimath::Math::Function::Text.new("w"),
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #46" do
+      let(:string) { "s<sub>so</sub><sup>w</sup>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::PowerBase.new(
+            Plurimath::Math::Function::Text.new("s"),
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Function::Text.new("s"),
+              Plurimath::Math::Function::Text.new("o")
+            ]),
+            Plurimath::Math::Function::Text.new("w"),
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #47" do
+      let(:string) { "s<sub>so</sub><sup>we</sup>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::PowerBase.new(
+            Plurimath::Math::Function::Text.new("s"),
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Function::Text.new("s"),
+              Plurimath::Math::Function::Text.new("o")
+            ]),
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Function::Text.new("w"),
+              Plurimath::Math::Function::Text.new("e")
+            ]),
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #48" do
+      let(:string) { "s<sub>s</sub><sup>we</sup>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::PowerBase.new(
+            Plurimath::Math::Function::Text.new("s"),
+            Plurimath::Math::Function::Text.new("s"),
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Function::Text.new("w"),
+              Plurimath::Math::Function::Text.new("e")
+            ]),
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #49" do
+      let(:string) { "<i>lim</i>(3)(e)" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Lim.new(
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Symbol.new("("),
+              Plurimath::Math::Number.new("3"),
+              Plurimath::Math::Symbol.new(")")
+            ]),
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Symbol.new("("),
+              Plurimath::Math::Function::Text.new("e"),
+              Plurimath::Math::Symbol.new(")")
+            ])
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #50" do
+      let(:string) { "<i>lim</i>(3e)(em)" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Lim.new(
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Symbol.new("("),
+              Plurimath::Math::Number.new("3"),
+              Plurimath::Math::Function::Text.new("e"),
+              Plurimath::Math::Symbol.new(")")
+            ]),
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Symbol.new("("),
+              Plurimath::Math::Function::Text.new("e"),
+              Plurimath::Math::Function::Text.new("m"),
+              Plurimath::Math::Symbol.new(")")
+            ])
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #51" do
+      let(:string) { "<i>lim</i>(3am)(rest)" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Lim.new(
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Symbol.new("("),
+              Plurimath::Math::Number.new("3"),
+              Plurimath::Math::Function::Text.new("a"),
+              Plurimath::Math::Function::Text.new("m"),
+              Plurimath::Math::Symbol.new(")")
+            ]),
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Symbol.new("("),
+              Plurimath::Math::Function::Text.new("r"),
+              Plurimath::Math::Function::Text.new("e"),
+              Plurimath::Math::Function::Text.new("s"),
+              Plurimath::Math::Function::Text.new("t"),
+              Plurimath::Math::Symbol.new(")")
+            ])
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #52" do
+      let(:string) { "<i>log</i><sub>3</sub><sup>e</sup>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Log.new(
+            Plurimath::Math::Number.new("3"),
+            Plurimath::Math::Function::Text.new("e")
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #53" do
+      let(:string) { "2<i>mod</i>e" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Mod.new(
+            Plurimath::Math::Number.new("2"),
+            Plurimath::Math::Function::Text.new("e")
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #54" do
+      let(:string) { "<i>2</i><i>mod</i><i>e</i>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Mod.new(
+            Plurimath::Math::Number.new("2"),
+            Plurimath::Math::Function::Text.new("e")
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #55" do
+      let(:string) { "<i>2a</i><i>mod</i><i>em</i>" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Mod.new(
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Number.new("2"),
+              Plurimath::Math::Function::Text.new("a")
+            ]),
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Function::Text.new("e"),
+              Plurimath::Math::Function::Text.new("m")
+            ])
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML math example #55" do
+      let(:string) { "2a<i>mod</i>em" }
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Number.new("2"),
+          Plurimath::Math::Function::Mod.new(
+            Plurimath::Math::Function::Text.new("a"),
+            Plurimath::Math::Function::Text.new("e")
+          ),
+          Plurimath::Math::Function::Text.new("m")
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "should fail when a tag is not closed" do
+      let(:string) { "<sup>sth" }
+      it "returns abstract parsed tree" do
+        expect{formula}.to raise_error(Parslet::ParseFailed)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added **```HTML transformation ```** rules for the ``` syntax tree ```.

closes #44  