### PR TITLE
Updated mathml parser rule and added specs for decimal numeric values

### DIFF
--- a/lib/plurimath/mathml/parse.rb
+++ b/lib/plurimath/mathml/parse.rb
@@ -9,7 +9,7 @@ module Plurimath
           array_to_expression(Constants::UNICODE_SYMBOLS.keys).as(:symbol) |
           array_to_expression(Constants::SYMBOLS.keys).as(:symbol) |
           match["a-zA-Z"].repeat(1).as(:text) |
-          match(/[0-9]/).repeat(1).as(:number) |
+          match(/[0-9,.]/).repeat(1).as(:number) |
           str("")
       end
 

--- a/spec/plurimath/mathml/parser_spec.rb
+++ b/spec/plurimath/mathml/parser_spec.rb
@@ -1089,6 +1089,45 @@ RSpec.describe Plurimath::Mathml::Parser do
     end
   end
 
+  context "contains mathml string of dot decimal values only" do
+    let(:exp) {
+      <<~MATHML
+        <math xmlns='http://www.w3.org/1998/Math/MathML'>
+          <msgroup>
+            <mn>1.4</mn>
+            <mn>1.4.5</mn>
+          </msgroup>
+        </math>
+      MATHML
+    }
+    it "returns formula of decimal values" do
+      expected_value = Plurimath::Math::Formula.new([
+        Plurimath::Math::Number.new("1.4"),
+        Plurimath::Math::Number.new("1.4.5"),
+      ])
+      expect(formula).to eq(expected_value)
+    end
+  end
+
+  context "contains mathml string of comma decimal values only" do
+    let(:exp) {
+      <<~MATHML
+        <math xmlns='http://www.w3.org/1998/Math/MathML'>
+          <msgroup>
+            <mn>1,4</mn>
+            <mn>1,4,5</mn>
+          </msgroup>
+        </math>
+      MATHML
+    }
+    it "returns formula of decimal values" do
+      expected_value = Plurimath::Math::Formula.new([
+        Plurimath::Math::Number.new("1,4"),
+        Plurimath::Math::Number.new("1,4,5"),
+      ])
+      expect(formula).to eq(expected_value)
+    end
+  end
   context "contains mathml string of unmacthing closing tag" do
     let(:exp) {
       <<~MATHML

--- a/spec/plurimath/mathml/parser_spec.rb
+++ b/spec/plurimath/mathml/parser_spec.rb
@@ -1095,7 +1095,6 @@ RSpec.describe Plurimath::Mathml::Parser do
         <math xmlns='http://www.w3.org/1998/Math/MathML'>
           <msgroup>
             <mn>1.4</mn>
-            <mn>1.4.5</mn>
           </msgroup>
         </math>
       MATHML
@@ -1103,7 +1102,6 @@ RSpec.describe Plurimath::Mathml::Parser do
     it "returns formula of decimal values" do
       expected_value = Plurimath::Math::Formula.new([
         Plurimath::Math::Number.new("1.4"),
-        Plurimath::Math::Number.new("1.4.5"),
       ])
       expect(formula).to eq(expected_value)
     end
@@ -1115,7 +1113,6 @@ RSpec.describe Plurimath::Mathml::Parser do
         <math xmlns='http://www.w3.org/1998/Math/MathML'>
           <msgroup>
             <mn>1,4</mn>
-            <mn>1,4,5</mn>
           </msgroup>
         </math>
       MATHML
@@ -1123,7 +1120,6 @@ RSpec.describe Plurimath::Mathml::Parser do
     it "returns formula of decimal values" do
       expected_value = Plurimath::Math::Formula.new([
         Plurimath::Math::Number.new("1,4"),
-        Plurimath::Math::Number.new("1,4,5"),
       ])
       expect(formula).to eq(expected_value)
     end


### PR DESCRIPTION
Updated **MathML** parser rule and added spec for decimal numbers(separated by comma and dot).

closes #64 
