### PR TITLE
Fixed failing Mathml parsing for empty text tag

### DIFF
--- a/lib/plurimath/math/function/text.rb
+++ b/lib/plurimath/math/function/text.rb
@@ -37,7 +37,7 @@ module Plurimath
 
         def parse_text(lang)
           html_value = first_value(lang)
-          html_value.gsub!(PARSER_REGEX) do |_text|
+          html_value&.gsub!(PARSER_REGEX) do |_text|
             last_match = Regexp.last_match
             if ["mathml", "html"].include?(lang)
               symbol_value(last_match[:unicode]) || last_match[:mbox]

--- a/lib/plurimath/mathml/parse.rb
+++ b/lib/plurimath/mathml/parse.rb
@@ -4,13 +4,16 @@ require "parslet"
 module Plurimath
   class Mathml
     class Parse < Parslet::Parser
+      rule(:text) { match["a-zA-Z"].repeat(1).as(:text) }
+      rule(:symbol) { match(/[^<]/).repeat(1).as(:symbol) }
+      rule(:number) { match(/[0-9,.]/).repeat(1).as(:number) }
+      rule(:symbol_text_or_integer) { text | number | symbol }
+
       rule(:parse_record) do
         array_to_expression(Constants::CLASSES).as(:class) |
           array_to_expression(Constants::UNICODE_SYMBOLS.keys).as(:symbol) |
           array_to_expression(Constants::SYMBOLS.keys).as(:symbol) |
-          match["a-zA-Z"].repeat(1).as(:text) |
-          match(/[0-9,.]/).repeat(1).as(:number) |
-          match(/[^<]/).repeat(1).as(:symbol) |
+          symbol_text_or_integer.repeat(1) |
           str("")
       end
 
@@ -62,7 +65,8 @@ module Plurimath
       end
 
       def parse_text_tag
-        str("<mtext>") >> match("[^<]").repeat.as(:quoted_text) >> str("</mtext>")
+        (str("<mtext>") >> match("[^<]").repeat.as(:quoted_text) >> str("</mtext>")) |
+          (str("<mtext/>") >> str("").as(:quoted_text))
       end
     end
   end

--- a/lib/plurimath/mathml/transform.rb
+++ b/lib/plurimath/mathml/transform.rb
@@ -9,6 +9,10 @@ module Plurimath
       rule(class: simple(:string))  { Utility.get_class(string).new }
       rule(number: simple(:number)) { Math::Number.new(number) }
 
+      rule(quoted_text: sequence(:quoted_text)) do
+        Math::Function::Text.new("".dup)
+      end
+
       rule(tag: sequence(:tag), sequence: simple(:sequence)) do
         tag + [sequence]
       end
@@ -44,12 +48,35 @@ module Plurimath
 
       rule(
         tag: sequence(:tag),
+        sequence: sequence(:sequence),
+        iteration: sequence(:iteration),
+      ) do
+        new_arr = []
+        new_arr += tag unless tag.compact.empty?
+        new_arr += sequence unless sequence.compact.empty?
+        new_arr += iteration unless iteration.compact.empty?
+        new_arr
+      end
+
+      rule(
+        tag: sequence(:tag),
         sequence: simple(:sequence),
         iteration: simple(:iteration),
       ) do
         new_arr = tag
         new_arr << sequence unless sequence.to_s.empty?
         new_arr << iteration unless iteration.to_s.empty?
+        Math::Formula.new(new_arr)
+      end
+
+      rule(
+        tag: sequence(:tag),
+        sequence: simple(:sequence),
+        iteration: sequence(:iteration),
+      ) do
+        new_arr = tag
+        new_arr << sequence unless sequence.to_s.empty?
+        new_arr += iteration unless iteration.compact.empty?
         Math::Formula.new(new_arr)
       end
 

--- a/spec/plurimath/mathml/parse_spec.rb
+++ b/spec/plurimath/mathml/parse_spec.rb
@@ -54,8 +54,9 @@ RSpec.describe Plurimath::Mathml::Parse do
     it "returns formula of sum and prod" do
       iteration = formula[:iteration][:tag][:iteration]
       sequence = iteration[:sequence]
+
       expect(iteration[:tag][:iteration][:symbol]).to eq("&#x2211;")
-      expect(sequence[:tag][:iteration][:tag][:iteration][:number]).to eq("1")
+      expect(sequence[:tag][:iteration][:tag][:iteration][0][:number]).to eq("1")
       expect(sequence[:sequence][:tag][:iteration][:symbol]).to eq("&#x22c1;")
     end
   end
@@ -75,8 +76,9 @@ RSpec.describe Plurimath::Mathml::Parse do
     }
     it "should match values" do
       iteration = formula[:iteration][:tag][:iteration][:tag][:iteration]
-      expect(iteration[:tag][:iteration][:text]).to eq("xyz")
-      expect(iteration[:sequence][:tag][:iteration][:text]).to eq("s")
+
+      expect(iteration[:tag][:iteration][0][:text]).to eq("xyz")
+      expect(iteration[:sequence][:tag][:iteration][0][:text]).to eq("s")
     end
   end
 end

--- a/spec/plurimath/mathml/parser_spec.rb
+++ b/spec/plurimath/mathml/parser_spec.rb
@@ -1165,6 +1165,49 @@ RSpec.describe Plurimath::Mathml::Parser do
     end
   end
 
+  context "contains mathml empty text tag with slash" do
+    let(:exp) {
+      <<~MATHML
+        <math xmlns='http://www.w3.org/1998/Math/MathML'>
+          <msup>
+            <mtext/>
+            <mn>12</mn>
+          </msup>
+        </math>
+      MATHML
+    }
+    it "returns formula of decimal values" do
+      expected_value = Plurimath::Math::Formula.new([
+        Plurimath::Math::Function::Power.new(
+          Plurimath::Math::Function::Text.new(""),
+          Plurimath::Math::Number.new("12"),
+        )
+      ])
+      expect(formula).to eq(expected_value)
+    end
+  end
+
+  context "contains mathml empty text tag" do
+    let(:exp) {
+      <<~MATHML
+        <math xmlns='http://www.w3.org/1998/Math/MathML'>
+          <msup>
+            <mtext></mtext>
+            <mn>12</mn>
+          </msup>
+        </math>
+      MATHML
+    }
+    it "returns formula of decimal values" do
+      expected_value = Plurimath::Math::Formula.new([
+        Plurimath::Math::Function::Power.new(
+          Plurimath::Math::Function::Text.new(""),
+          Plurimath::Math::Number.new("12"),
+        )
+      ])
+      expect(formula).to eq(expected_value)
+    end
+  end
 
   context "contains mathml string of comma decimal values only" do
     let(:exp) {
@@ -1184,6 +1227,27 @@ RSpec.describe Plurimath::Mathml::Parser do
           Plurimath::Math::Formula.new([
             Plurimath::Math::Symbol.new("ν")
           ])
+        ])
+      ])
+      expect(formula).to eq(expected_value)
+    end
+  end
+
+  context "contains mathml string of comma decimal values only" do
+    let(:exp) {
+      <<~MATHML
+        <math>
+          <mrow xref="U_GOhm">
+            <mi mathvariant="normal">GΩ</mi>
+          </mrow>
+        </math>
+      MATHML
+    }
+    it "returns formula of decimal values" do
+      expected_value = Plurimath::Math::Formula.new([
+        Plurimath::Math::Formula.new([
+          Plurimath::Math::Symbol.new("G"),
+          Plurimath::Math::Symbol.new("Ω")
         ])
       ])
       expect(formula).to eq(expected_value)


### PR DESCRIPTION
Fixed failing Mathml parsing for an empty text tag.
Fixed parsing multiple values inside tags.

closes #71 