### PR TITLE
Comparison specs for MathML from Plurimath and LatexMath outputs

### DIFF
--- a/lib/plurimath/asciimath/parse.rb
+++ b/lib/plurimath/asciimath/parse.rb
@@ -53,7 +53,7 @@ module Plurimath
 
       rule(:left_right) do
         (str("left") >> left_right_open_paren.as(:left) >> iteration.as(:left_right_value) >> str("right") >> left_right_close_paren.as(:right)) |
-          (table.as(:numerator) >> space.maybe >> match(/(?<!\/)\/(?!\/)/) >> space.maybe >> iteration.as(:denominator)).as(:frac) |
+          ((table.as(:numerator) >> space.maybe >> match(/(?<!\/)\/(?!\/)/) >> space.maybe >> iteration.as(:denominator)).as(:frac) >> expression) |
           (table.as(:table) >> expression.maybe)
       end
 

--- a/lib/plurimath/asciimath/transform.rb
+++ b/lib/plurimath/asciimath/transform.rb
@@ -19,6 +19,7 @@ module Plurimath
       rule(left_right: simple(:left_right)) { left_right }
       rule(table_left: simple(:table_left)) { table_left }
 
+      rule(left_right: sequence(:left_right))      { left_right }
       rule(power_base: sequence(:power_base))      { power_base }
       rule(table_right: simple(:table_right))      { table_right }
       rule(intermediate_exp: simple(:int_exp))     { int_exp }
@@ -124,6 +125,12 @@ module Plurimath
         new_arr = [sequence]
         new_arr << left_right unless left_right.to_s.strip.empty?
         new_arr
+      end
+
+      rule(sequence: simple(:sequence),
+           left_right: sequence(:left_right)) do
+        left_right.insert(0, sequence)
+        left_right
       end
 
       rule(table_row: simple(:table_row),

--- a/lib/plurimath/html/parse.rb
+++ b/lib/plurimath/html/parse.rb
@@ -76,7 +76,7 @@ module Plurimath
           (str("&") >> match["a-zA-Z0-9"].repeat(2) >> str(";")).as(:symbol) |
           match["0-9"].as(:number) |
           match["a-zA-Z"].as(:text) |
-          match["^0-9a-zA-Z<>\/(){}\\[\\]"].as(:symbol)
+          match["^0-9a-zA-Z<>/(){}\\[\\]"].as(:symbol)
       end
 
       rule(:intermediate_exp) do

--- a/lib/plurimath/latex/constants.rb
+++ b/lib/plurimath/latex/constants.rb
@@ -3715,6 +3715,13 @@ module Plurimath
         "(" => ")",
         "\\{" => "\\}",
       }.freeze
+      MATRICES_PARENTHESIS = {
+        "norm[": :"]",
+        "|": :"|",
+        "(": :")",
+        "{": :"}",
+        "[": :"]",
+      }.freeze
       MATRICES = {
         multline: nil,
         Vmatrix: "norm[",

--- a/lib/plurimath/latex/parse.rb
+++ b/lib/plurimath/latex/parse.rb
@@ -131,14 +131,12 @@ module Plurimath
 
       rule(:left_right) do
         (
-         str("\\left").as(:left) >>
-         lparen.maybe >>
+         str("\\left").as(:left) >> lparen.maybe >>
          (
            (expression.repeat.as(:dividend) >> str("\\over") >> expression.repeat.as(:divisor)) |
            expression.as(:expression).maybe
          ) >>
-         str("\\right").as(:right).maybe >>
-         rparen.maybe
+         str("\\right").as(:right).maybe >> (rparen | str(".").maybe)
        )
       end
 

--- a/lib/plurimath/latex/transform.rb
+++ b/lib/plurimath/latex/transform.rb
@@ -576,10 +576,12 @@ module Plurimath
       rule(environment: simple(:environment),
            table_data: sequence(:table_data),
            ending: simple(:ending)) do
+        open_paren = Constants::MATRICES[environment.to_sym]
         Utility.get_table_class(environment).new(
-          Utility.organize_table(table_data).first,
-          Constants::MATRICES[environment.to_sym],
-          [],
+          Utility.organize_table(table_data),
+          open_paren,
+          Constants::MATRICES_PARENTHESIS[open_paren&.to_sym]&.to_s,
+          {},
         )
       end
 
@@ -587,20 +589,28 @@ module Plurimath
            args: simple(:args),
            table_data: simple(:table_data),
            ending: simple(:ending)) do
+        third_value = args ? [args] : []
+        open_paren = Constants::MATRICES[environment.to_sym]
+        table = Utility.organize_table(
+          [table_data],
+          column_align: third_value,
+        )
         Utility.get_table_class(environment).new(
-          Utility.organize_table([table_data]).first,
-          nil,
-          [args],
+          table,
+          open_paren,
+          Constants::MATRICES_PARENTHESIS[open_paren&.to_sym]&.to_s,
+          Utility.table_options(table),
         )
       end
 
       rule(environment: simple(:environment),
            table_data: simple(:table_data),
            ending: simple(:ending)) do
+        open_paren = Constants::MATRICES[environment.to_sym]
         Utility.get_table_class(environment).new(
-          Utility.organize_table([table_data]).first,
-          Constants::MATRICES[environment.to_sym],
-          [],
+          Utility.organize_table([table_data]),
+          open_paren,
+          Constants::MATRICES_PARENTHESIS[open_paren&.to_sym]&.to_s,
         )
       end
 
@@ -608,10 +618,13 @@ module Plurimath
            args: sequence(:args),
            table_data: sequence(:table_data),
            ending: simple(:ending)) do
+        open_paren = Constants::MATRICES[environment.to_sym]
+        table = Utility.organize_table(table_data, column_align: args)
         Utility.get_table_class(environment).new(
-          Utility.organize_table(table_data).first,
-          nil,
-          args,
+          table,
+          open_paren,
+          Constants::MATRICES_PARENTHESIS[open_paren&.to_sym]&.to_s,
+          Utility.table_options(table),
         )
       end
 
@@ -619,10 +632,14 @@ module Plurimath
            args: simple(:args),
            table_data: sequence(:table_data),
            ending: simple(:ending)) do
+        third_value = args ? [args] : []
+        open_paren = Constants::MATRICES[environment.to_sym]
+        table = Utility.organize_table(table_data, column_align: third_value)
         Utility.get_table_class(environment).new(
-          Utility.organize_table(table_data).first,
-          nil,
-          [args],
+          table,
+          open_paren,
+          Constants::MATRICES_PARENTHESIS[open_paren&.to_sym]&.to_s,
+          Utility.table_options(table),
         )
       end
 
@@ -632,15 +649,17 @@ module Plurimath
            table_data: sequence(:table_data),
            ending: simple(:ending)) do
         third_value = options ? [options] : []
+        open_paren = Constants::MATRICES[environment.to_sym]
         table = Utility.organize_table(
           table_data,
           column_align: third_value,
+          options: true,
         )
-        third_value = table.last ? [Math::Symbol.new(table.last)] : []
         Utility.get_table_class(environment).new(
-          table.first,
-          Constants::MATRICES[environment.to_sym],
-          third_value,
+          table,
+          open_paren,
+          Constants::MATRICES_PARENTHESIS[open_paren&.to_sym]&.to_s,
+          { asterisk: true },
         )
       end
 
@@ -648,30 +667,34 @@ module Plurimath
            asterisk: simple(:asterisk),
            table_data: sequence(:table_data),
            ending: simple(:ending)) do
+        open_paren = Constants::MATRICES[environment.to_sym]
         Utility.get_table_class(environment).new(
-          Utility.organize_table(table_data).first,
-          Constants::MATRICES[environment.to_sym],
-          [],
+          Utility.organize_table(table_data),
+          open_paren,
+          Constants::MATRICES_PARENTHESIS[open_paren&.to_sym]&.to_s,
+          { asterisk: true },
         )
       end
 
       rule(environment: simple(:env),
            expression: simple(:expr)) do
-        expression = expr.nil? ? [] : [expr]
+        open_paren = Constants::MATRICES[env.to_sym]
         Utility.get_table_class(env).new(
-          Utility.organize_table(expression).first,
-          Constants::MATRICES[env.to_sym],
-          [],
+          Utility.organize_table(expr.nil? ? [] : [expr]),
+          open_paren,
+          Constants::MATRICES_PARENTHESIS[open_paren&.to_sym]&.to_s,
+          {},
         )
       end
 
       rule(environment: simple(:env),
            expression: sequence(:expr)) do
-        expression = expr.compact
+        open_paren = Constants::MATRICES[env.to_sym]
         Utility.get_table_class(env).new(
-          Utility.organize_table(expression).first,
-          Constants::MATRICES[env.to_sym],
-          [],
+          Utility.organize_table(expr.compact),
+          open_paren,
+          Constants::MATRICES_PARENTHESIS[open_paren&.to_sym]&.to_s,
+          {},
         )
       end
 

--- a/lib/plurimath/math/function/base.rb
+++ b/lib/plurimath/math/function/base.rb
@@ -13,7 +13,8 @@ module Plurimath
         end
 
         def to_mathml_without_math_tag
-          tag_name = (["ubrace", "obrace"].include?(parameter_one&.class_name) ? "under" : "sub")
+          under_classes = ["ubrace", "obrace"] + Utility::UNARY_CLASSES
+          tag_name = (under_classes.include?(parameter_one&.class_name) ? "under" : "sub")
           sub_tag = Utility.ox_element("m#{tag_name}")
           mathml_value = []
           mathml_value << parameter_one&.to_mathml_without_math_tag

--- a/lib/plurimath/math/function/binary_function.rb
+++ b/lib/plurimath/math/function/binary_function.rb
@@ -81,16 +81,13 @@ module Plurimath
         end
 
         def validate_function_formula(field)
+          unary_classes = (Utility::UNARY_CLASSES + ["obrace", "ubrace", "hat"])
           if field.is_a?(Formula)
-            field.value.any?(Left) || field.value.any?(Right) ? false : true
-          elsif ["obrace", "ubrace", "hat"].include?(field.class_name)
+            !(field.value.any?(Left) || field.value.any?(Right))
+          elsif unary_classes.include?(field.class_name)
             false
-          elsif Utility::UNARY_CLASSES.include?(field.class_name) || field.is_a?(FontStyle)
-            false
-          elsif field.class.name.include?("Function")
-            field.is_a?(Text) ? false : true
-          else
-            false
+          elsif field.class.name.include?("Function") || field.is_a?(FontStyle)
+            !field.is_a?(Text)
           end
         end
 

--- a/lib/plurimath/math/function/color.rb
+++ b/lib/plurimath/math/function/color.rb
@@ -7,7 +7,7 @@ module Plurimath
     module Function
       class Color < BinaryFunction
         def to_asciimath
-          first_value = "(#{parameter_one&.to_asciimath.gsub(/\s/, "")})"
+          first_value = "(#{parameter_one&.to_asciimath&.gsub(/\s/, '')})"
           second_value = "(#{parameter_two&.to_asciimath})"
           "color#{first_value}#{second_value}"
         end
@@ -16,14 +16,14 @@ module Plurimath
           Utility.update_nodes(
             Utility.ox_element(
               "mstyle",
-              attributes: { mathcolor: parameter_one&.to_asciimath.gsub(/\s/, "")&.gsub(/"/, "") },
+              attributes: { mathcolor: parameter_one&.to_asciimath&.gsub(/\s/, "")&.gsub(/"/, "") },
             ),
             [parameter_two&.to_mathml_without_math_tag],
           )
         end
 
         def to_latex
-          first_value = parameter_one&.to_asciimath.gsub(/\s/, "")
+          first_value = parameter_one&.to_asciimath&.gsub(/\s/, "")
           second_value = parameter_two&.to_latex
           "{\\#{class_name}{#{first_value}} #{second_value}}"
         end

--- a/lib/plurimath/math/function/inf.rb
+++ b/lib/plurimath/math/function/inf.rb
@@ -11,6 +11,27 @@ module Plurimath
           second_value = "^{#{parameter_two.to_latex}}" if parameter_two
           "\\#{class_name}#{first_value}#{second_value}"
         end
+
+        def to_mathml_without_math_tag
+          first_value = Utility.ox_element("mo") << class_name
+          if parameter_one || parameter_two
+            value_array = [first_value]
+            value_array << parameter_one&.to_mathml_without_math_tag
+            value_array << parameter_two&.to_mathml_without_math_tag
+            tag_name = if parameter_two && parameter_one
+                         "underover"
+                       else
+                         parameter_one ? "under" : "over"
+                       end
+            munderover_tag = Utility.ox_element("m#{tag_name}")
+            Utility.update_nodes(
+              munderover_tag,
+              value_array,
+            )
+          else
+            first_value
+          end
+        end
       end
     end
   end

--- a/lib/plurimath/math/function/left.rb
+++ b/lib/plurimath/math/function/left.rb
@@ -12,7 +12,7 @@ module Plurimath
 
         def to_mathml_without_math_tag
           mo = Utility.ox_element("mo")
-          mo << parameter_one if parameter_one
+          mo << left_paren if parameter_one
           mo
         end
 
@@ -29,6 +29,14 @@ module Plurimath
         def to_latex
           prefix = "\\" if parameter_one == "{"
           "\\left #{prefix}#{parameter_one}"
+        end
+
+        protected
+
+        def left_paren
+          return "{" if parameter_one == "\\{"
+
+          parameter_one
         end
       end
     end

--- a/lib/plurimath/math/function/lim.rb
+++ b/lib/plurimath/math/function/lim.rb
@@ -19,15 +19,20 @@ module Plurimath
         end
 
         def to_mathml_without_math_tag
-          munderover  = Utility.ox_element("munderover")
           first_value = (Utility.ox_element("mo") << "lim")
           if parameter_one || parameter_two
-            value_array = []
+            value_array = [first_value]
             value_array << parameter_one&.to_mathml_without_math_tag
             value_array << parameter_two&.to_mathml_without_math_tag
+            tag_name = if parameter_two && parameter_one
+                         "underover"
+                       else
+                         parameter_one ? "under" : "over"
+                       end
+            munderover_tag = Utility.ox_element("m#{tag_name}")
             Utility.update_nodes(
-              munderover,
-              value_array.insert(0, first_value),
+              munderover_tag,
+              value_array,
             )
           else
             first_value

--- a/lib/plurimath/math/function/mod.rb
+++ b/lib/plurimath/math/function/mod.rb
@@ -7,8 +7,8 @@ module Plurimath
     module Function
       class Mod < BinaryFunction
         def to_asciimath
-          first_value = parameter_one.to_asciimath
-          second_value = parameter_two.to_asciimath
+          first_value = parameter_one&.to_asciimath
+          second_value = parameter_two&.to_asciimath
           "#{first_value} mod #{second_value}"
         end
 

--- a/lib/plurimath/math/function/over.rb
+++ b/lib/plurimath/math/function/over.rb
@@ -13,7 +13,7 @@ module Plurimath
         end
 
         def to_mathml_without_math_tag
-          mover_tag    = Utility.ox_element("mover")
+          mover_tag    = Utility.ox_element("mfrac")
           first_value  = parameter_one&.to_mathml_without_math_tag
           second_value = parameter_two&.to_mathml_without_math_tag
           Utility.update_nodes(

--- a/lib/plurimath/math/function/right.rb
+++ b/lib/plurimath/math/function/right.rb
@@ -12,7 +12,7 @@ module Plurimath
 
         def to_mathml_without_math_tag
           mo = Utility.ox_element("mo")
-          mo << parameter_one if parameter_one
+          mo << right_paren if parameter_one
           mo
         end
 
@@ -29,6 +29,14 @@ module Plurimath
         def to_latex
           prefix = "\\" if parameter_one == "}"
           "\\right #{prefix}#{parameter_one}"
+        end
+
+        protected
+
+        def right_paren
+          return "}" if parameter_one == "\\}"
+
+          parameter_one
         end
       end
     end

--- a/lib/plurimath/math/function/substack.rb
+++ b/lib/plurimath/math/function/substack.rb
@@ -11,6 +11,13 @@ module Plurimath
           second_value = "\\\\#{parameter_two.to_latex}" if parameter_two
           "\\#{class_name}{#{first_value}#{second_value}}"
         end
+
+        def to_mathml_without_math_tag
+          value_array = []
+          value_array << parameter_one.to_mathml_without_math_tag if parameter_one
+          value_array << parameter_two.to_mathml_without_math_tag if parameter_two
+          Utility.update_nodes(Utility.ox_element("mtable"), value_array)
+        end
       end
     end
   end

--- a/lib/plurimath/math/function/sup.rb
+++ b/lib/plurimath/math/function/sup.rb
@@ -6,6 +6,9 @@ module Plurimath
   module Math
     module Function
       class Sup < UnaryFunction
+        def to_mathml_without_math_tag
+          Utility.ox_element("mo") << "sup"
+        end
       end
     end
   end

--- a/lib/plurimath/math/function/table/align.rb
+++ b/lib/plurimath/math/function/table/align.rb
@@ -7,14 +7,15 @@ module Plurimath
     module Function
       class Table
         class Align < Table
-          def initialize(parameter_one,
-                         parameter_two = "[",
-                         parameter_three = "]")
+          def initialize(value,
+                         open_paren = "[",
+                         close_paren = "]",
+                         options = {})
             super
           end
 
           def to_latex
-            "\\begin#{opening}#{latex_content}\\end#{ending}"
+            "\\begin#{opening}#{latex_content}\\end#{matrix_class}"
           end
         end
       end

--- a/lib/plurimath/math/function/table/array.rb
+++ b/lib/plurimath/math/function/table/array.rb
@@ -7,15 +7,35 @@ module Plurimath
     module Function
       class Table
         class Array < Table
-          def initialize(parameter_one = [],
-                         parameter_two = "[",
-                         parameter_three = "]")
+          def initialize(value = [],
+                         open_paren = "[",
+                         close_paren = "]",
+                         options = {})
             super
           end
 
           def to_latex
-            divider = parameter_three&.map(&:to_latex)&.join
-            "\\begin{array}{#{divider}}#{latex_content}\\end{array}"
+            "\\begin{array}#{array_args}#{latex_content}\\end{array}"
+          end
+
+          def array_args
+            args = []
+            value.first.parameter_one.each do |td|
+              args << if Utility.symbol_value(td.parameter_one.first, "|")
+                        "|"
+                      else
+                        Utility::ALIGNMENT_LETTERS.invert[Hash(td.parameter_two)[:columnalign]]&.to_s
+                      end
+            end
+            "{#{args.join}}" unless args.compact.empty?
+          end
+
+          def to_mathml_without_math_tag
+            table_tag = Utility.ox_element("mtable", attributes: table_attribute)
+            Utility.update_nodes(
+              table_tag,
+              value&.map(&:to_mathml_without_math_tag),
+            )
           end
         end
       end

--- a/lib/plurimath/math/function/table/bmatrix.rb
+++ b/lib/plurimath/math/function/table/bmatrix.rb
@@ -7,14 +7,28 @@ module Plurimath
     module Function
       class Table
         class Bmatrix < Table
-          def initialize(parameter_one,
-                         parameter_two = "[",
-                         parameter_three = "]")
+          def initialize(value,
+                         open_paren = "[",
+                         close_paren = "]",
+                         options = {})
             super
           end
 
           def to_latex
-            "\\begin#{opening}#{latex_content}\\end#{ending}"
+            "\\begin#{opening}#{latex_content}\\end#{matrix_class}"
+          end
+
+          def to_mathml_without_math_tag
+            table_tag = Utility.ox_element("mtable", attributes: table_attribute)
+            Utility.update_nodes(
+              table_tag,
+              value&.map(&:to_mathml_without_math_tag),
+            )
+            attributes = {
+              open: mathml_parenthesis(open_paren),
+              close: mathml_parenthesis(close_paren),
+            }
+            Utility.ox_element("mfenced", attributes: attributes) << table_tag
           end
         end
       end

--- a/lib/plurimath/math/function/table/matrix.rb
+++ b/lib/plurimath/math/function/table/matrix.rb
@@ -7,14 +7,23 @@ module Plurimath
     module Function
       class Table
         class Matrix < Table
-          def initialize(parameter_one = [],
-                         parameter_two = "(",
-                         parameter_three = ")")
+          def initialize(value = [],
+                         open_paren = "(",
+                         close_paren = ")",
+                         options = {})
             super
           end
 
           def to_latex
-            "\\begin#{opening}#{latex_content}\\end#{ending}"
+            "\\begin#{opening}#{latex_content}\\end#{matrix_class}"
+          end
+
+          def to_mathml_without_math_tag
+            table_tag = Utility.ox_element("mtable", attributes: table_attribute)
+            Utility.update_nodes(
+              table_tag,
+              value&.map(&:to_mathml_without_math_tag),
+            )
           end
         end
       end

--- a/lib/plurimath/math/function/table/multline.rb
+++ b/lib/plurimath/math/function/table/multline.rb
@@ -7,14 +7,15 @@ module Plurimath
     module Function
       class Table
         class Multline < Table
-          def initialize(parameter_one,
-                         parameter_two = "[",
-                         parameter_three = "]")
+          def initialize(value,
+                         open_paren = "[",
+                         close_paren = "]",
+                         options = {})
             super
           end
 
           def to_latex
-            "\\begin#{opening}#{latex_content}\\end#{ending}"
+            "\\begin#{opening}#{latex_content}\\end#{matrix_class}"
           end
         end
       end

--- a/lib/plurimath/math/function/table/pmatrix.rb
+++ b/lib/plurimath/math/function/table/pmatrix.rb
@@ -7,14 +7,15 @@ module Plurimath
     module Function
       class Table
         class Pmatrix < Table
-          def initialize(parameter_one,
-                         parameter_two = "(",
-                         parameter_three = ")")
+          def initialize(value,
+                         open_paren = "(",
+                         close_paren = ")",
+                         options = {})
             super
           end
 
           def to_latex
-            "\\begin#{opening}#{latex_content}\\end#{ending}"
+            "\\begin#{opening}#{latex_content}\\end#{matrix_class}"
           end
         end
       end

--- a/lib/plurimath/math/function/table/split.rb
+++ b/lib/plurimath/math/function/table/split.rb
@@ -7,14 +7,15 @@ module Plurimath
     module Function
       class Table
         class Split < Table
-          def initialize(parameter_one,
-                         parameter_two = "[",
-                         parameter_three = "]")
+          def initialize(value,
+                         open_paren = "[",
+                         close_paren = "]",
+                         options = {})
             super
           end
 
           def to_latex
-            "\\begin#{opening}#{latex_content}\\end#{ending}"
+            "\\begin#{opening}#{latex_content}\\end#{matrix_class}"
           end
         end
       end

--- a/lib/plurimath/math/function/table/vmatrix.rb
+++ b/lib/plurimath/math/function/table/vmatrix.rb
@@ -7,15 +7,15 @@ module Plurimath
     module Function
       class Table
         class Vmatrix < Table
-          def initialize(parameter_one,
-                         parameter_two = "|",
-                         parameter_three = "|")
-            parameter_three = nil if parameter_two == "norm["
+          def initialize(value,
+                         open_paren = "|",
+                         close_paren = "|",
+                         options = {})
             super
           end
 
           def to_latex
-            "\\begin#{opening}#{latex_content}\\end#{ending}"
+            "\\begin#{opening}#{latex_content}\\end#{matrix_class}"
           end
         end
       end

--- a/lib/plurimath/math/function/td.rb
+++ b/lib/plurimath/math/function/td.rb
@@ -13,7 +13,7 @@ module Plurimath
         def to_mathml_without_math_tag
           return "" if Utility.symbol_value(parameter_one.first, "|")
 
-          td_attribute = { columnalign: parameter_two } if parameter_two
+          td_attribute = parameter_two if parameter_two&.any?
 
           Utility.update_nodes(
             Utility.ox_element("mtd", attributes: td_attribute),

--- a/lib/plurimath/math/function/ternary_function.rb
+++ b/lib/plurimath/math/function/ternary_function.rb
@@ -90,9 +90,9 @@ module Plurimath
 
         def ascii_wrap(field)
           asciimath = field.to_asciimath
+          return latex if ["obrace", "ubrace"].include?(field.class_name)
+
           case field
-          when ["obrace", "ubrace"].include?(field.class_name)
-            asciimath
           when Formula || field.class.name.include?("Function")
             "(#{asciimath})"
           else
@@ -102,9 +102,9 @@ module Plurimath
 
         def latex_wrap(field)
           latex = field.to_latex
+          return latex if ["obrace", "ubrace"].include?(field.class_name)
+
           case field
-          when ["obrace", "ubrace"].include?(field.class_name)
-            latex
           when Formula || field.class.name.include?("Function")
             "{#{latex}}"
           else

--- a/lib/plurimath/math/function/tr.rb
+++ b/lib/plurimath/math/function/tr.rb
@@ -11,9 +11,12 @@ module Plurimath
         end
 
         def to_mathml_without_math_tag
+          first_value = parameter_one.dup
+          row_lines = first_value.first.parameter_one
+          row_lines.shift if Utility.symbol_value(row_lines.first, "&#x23af;")
           Utility.update_nodes(
             Utility.ox_element("mtr"),
-            parameter_one.map(&:to_mathml_without_math_tag).compact,
+            first_value.map(&:to_mathml_without_math_tag).compact,
           )
         end
 

--- a/spec/plurimath/asciimath_spec.rb
+++ b/spec/plurimath/asciimath_spec.rb
@@ -702,7 +702,8 @@ RSpec.describe Plurimath::Asciimath do
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
             <mstyle displaystyle="true">
-              <mfenced open="[" close="]">
+              <mrow>
+                <mo>[</mo>
                 <mtable>
                   <mtr>
                     <mtd>
@@ -729,7 +730,8 @@ RSpec.describe Plurimath::Asciimath do
                     </mtd>
                   </mtr>
                 </mtable>
-              </mfenced>
+                <mo>]</mo>
+              </mrow>
               <mrow>
                 <mo>(</mo>
                 <munderover>
@@ -1086,7 +1088,8 @@ RSpec.describe Plurimath::Asciimath do
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
             <mstyle displaystyle="true">
-              <mfenced open="(" close=")">
+              <mrow>
+                <mo>(</mo>
                 <mtable>
                   <mtr>
                     <mtd>
@@ -1099,7 +1102,8 @@ RSpec.describe Plurimath::Asciimath do
                     </mtd>
                   </mtr>
                 </mtable>
-              </mfenced>
+                <mo>)</mo>
+              </mrow>
             </mstyle>
           </math>
         MATHML
@@ -1118,7 +1122,8 @@ RSpec.describe Plurimath::Asciimath do
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
             <mstyle displaystyle="true">
-              <mfenced open="|" close="|">
+              <mrow>
+                <mo>|</mo>
                 <mtable>
                   <mtr>
                     <mtd>
@@ -1137,7 +1142,8 @@ RSpec.describe Plurimath::Asciimath do
                     </mtd>
                   </mtr>
                 </mtable>
-              </mfenced>
+                <mo>|</mo>
+              </mrow>
               <mo>=</mo>
               <mi>a</mi>
               <mi>d</mi>
@@ -1162,7 +1168,8 @@ RSpec.describe Plurimath::Asciimath do
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
             <mstyle displaystyle="true">
-              <mfenced open="(" close=")">
+              <mrow>
+                <mo>(</mo>
                 <mtable>
                   <mtr>
                     <mtd>
@@ -1219,7 +1226,8 @@ RSpec.describe Plurimath::Asciimath do
                     </mtd>
                   </mtr>
                 </mtable>
-              </mfenced>
+                <mo>)</mo>
+              </mrow>
             </mstyle>
           </math>
         MATHML
@@ -1357,7 +1365,8 @@ RSpec.describe Plurimath::Asciimath do
                 <mi>i</mi>
               </msub>
               <mo>=</mo>
-              <mfenced close="" open="{">
+              <mrow>
+                <mo></mo>
                 <mtable>
                   <mtr>
                     <mtd>
@@ -1404,7 +1413,8 @@ RSpec.describe Plurimath::Asciimath do
                     </mtd>
                   </mtr>
                 </mtable>
-              </mfenced>
+                <mo>{</mo>
+              </mrow>
             </mstyle>
           </math>
         MATHML
@@ -1574,7 +1584,8 @@ RSpec.describe Plurimath::Asciimath do
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
             <mstyle displaystyle="true">
-              <mfenced open="[" close="]">
+              <mrow>
+                <mo>[</mo>
                 <mtable>
                   <mtr>
                     <mtd>
@@ -1607,7 +1618,8 @@ RSpec.describe Plurimath::Asciimath do
                     </mtd>
                   </mtr>
                 </mtable>
-              </mfenced>
+                <mo>]</mo>
+              </mrow>
             </mstyle>
           </math>
         MATHML
@@ -1628,7 +1640,8 @@ RSpec.describe Plurimath::Asciimath do
             <mstyle displaystyle="true">
               <munder>
                 <munder>
-                  <mfenced open="(" close=")">
+                  <mrow>
+                    <mo>(</mo>
                     <mtable>
                       <mtr>
                         <mtd>
@@ -1647,7 +1660,8 @@ RSpec.describe Plurimath::Asciimath do
                         </mtd>
                       </mtr>
                     </mtable>
-                  </mfenced>
+                    <mo>)</mo>
+                  </mrow>
                   <mo>&#x23df;</mo>
                 </munder>
                 <mtext>Adjustment to texture space</mtext>
@@ -1972,7 +1986,8 @@ RSpec.describe Plurimath::Asciimath do
                 <mrow>
                   <mo>(</mo>
                   <mfrac>
-                    <mfenced open="(" close=")">
+                    <mrow>
+                      <mo>(</mo>
                       <mtable>
                         <mtr>
                           <mtd>
@@ -1989,7 +2004,8 @@ RSpec.describe Plurimath::Asciimath do
                           </mtd>
                         </mtr>
                       </mtable>
-                    </mfenced>
+                      <mo>)</mo>
+                    </mrow>
                     <mrow>
                       <mrow>
                         <mo>(</mo>
@@ -2210,7 +2226,8 @@ RSpec.describe Plurimath::Asciimath do
                 </mrow>
               </mrow>
               <mo>=</mo>
-              <mfenced open="{" close="">
+              <mrow>
+                <mo>{</mo>
                 <mtable>
                   <mtr>
                     <mtd>
@@ -2223,7 +2240,8 @@ RSpec.describe Plurimath::Asciimath do
                       <mi>r</mi>
                     </mtd>
                     <mtd>
-                      <mfenced open="{" close="">
+                      <mrow>
+                        <mo>{</mo>
                         <mtable>
                           <mtr>
                             <mtd>
@@ -2271,7 +2289,8 @@ RSpec.describe Plurimath::Asciimath do
                             </mtd>
                           </mtr>
                         </mtable>
-                      </mfenced>
+                        <mo></mo>
+                      </mrow>
                     </mtd>
                   </mtr>
                   <mtr>
@@ -2282,7 +2301,8 @@ RSpec.describe Plurimath::Asciimath do
                       <mtext></mtext>
                     </mtd>
                     <mtd>
-                      <mfenced open="{" close="">
+                      <mrow>
+                        <mo>{</mo>
                         <mtable>
                           <mtr>
                             <mtd>
@@ -2380,7 +2400,8 @@ RSpec.describe Plurimath::Asciimath do
                             </mtd>
                           </mtr>
                         </mtable>
-                      </mfenced>
+                        <mo></mo>
+                      </mrow>
                     </mtd>
                   </mtr>
                   <mtr>
@@ -2527,7 +2548,8 @@ RSpec.describe Plurimath::Asciimath do
                     </mtd>
                   </mtr>
                 </mtable>
-              </mfenced>
+                <mo></mo>
+              </mrow>
             </mstyle>
           </math>
         MATHML
@@ -2553,7 +2575,8 @@ RSpec.describe Plurimath::Asciimath do
                 <mo>&#xaf;</mo>
               </munder>
               <mo>=</mo>
-              <mfenced open="[" close="]">
+              <mrow>
+                <mo>[</mo>
                 <mtable>
                   <mtr>
                     <mtd>
@@ -2638,7 +2661,8 @@ RSpec.describe Plurimath::Asciimath do
                     <mtd/>
                   </mtr>
                 </mtable>
-              </mfenced>
+                <mo>]</mo>
+              </mrow>
             </mstyle>
           </math>
         MATHML
@@ -3512,7 +3536,8 @@ RSpec.describe Plurimath::Asciimath do
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
             <mstyle displaystyle="true">
-              <mfenced open="[" close="]">
+              <mrow>
+                <mo>[</mo>
                 <mtable>
                   <mtr>
                     <mtd>
@@ -3531,11 +3556,13 @@ RSpec.describe Plurimath::Asciimath do
                     </mtd>
                   </mtr>
                 </mtable>
-              </mfenced>
+                <mo>]</mo>
+              </mrow>
               <mo>, </mo>
               <mtext> </mtext>
               <mrow>
-                <mfenced open="[" close="]">
+                <mrow>
+                  <mo>[</mo>
                   <mtable>
                     <mtr>
                       <mtd>
@@ -3612,7 +3639,8 @@ RSpec.describe Plurimath::Asciimath do
                       </mtd>
                     </mtr>
                   </mtable>
-                </mfenced>
+                  <mo>]</mo>
+                </mrow>
                 <mo>&#xb7;</mo>
               </mrow>
             </mstyle>

--- a/spec/plurimath/latex/latexmath_aggregator_spec.rb
+++ b/spec/plurimath/latex/latexmath_aggregator_spec.rb
@@ -1,5 +1,4 @@
 require_relative "../../spec_helper"
-require_relative "../../../lib/plurimath/math"
 
 RSpec.describe Plurimath::Latex::Parser do
 
@@ -56,7 +55,6 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Function::Left.new("\\{"),
             Plurimath::Math::Function::Right.new
           ]),
-          Plurimath::Math::Symbol.new(".")
         ])
         expect(formula).to eq(expected_value)
       end
@@ -86,7 +84,8 @@ RSpec.describe Plurimath::Latex::Parser do
               ])
             ],
             nil,
-            []
+            nil,
+            {}
           )
         ])
         expect(formula).to eq(expected_value)
@@ -108,55 +107,62 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("x"),
-                      Plurimath::Math::Symbol.new("-"),
-                      Plurimath::Math::Number.new("5"),
-                      Plurimath::Math::Symbol.new("y"),
-                      Plurimath::Math::Symbol.new("+"),
-                      Plurimath::Math::Number.new("4"),
-                      Plurimath::Math::Symbol.new("z"),
-                      Plurimath::Math::Symbol.new("="),
-                      Plurimath::Math::Number.new("0")
-                    ])
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Number.new("3"),
+                        Plurimath::Math::Symbol.new("x"),
+                        Plurimath::Math::Symbol.new("-"),
+                        Plurimath::Math::Number.new("5"),
+                        Plurimath::Math::Symbol.new("y"),
+                        Plurimath::Math::Symbol.new("+"),
+                        Plurimath::Math::Number.new("4"),
+                        Plurimath::Math::Symbol.new("z"),
+                        Plurimath::Math::Symbol.new("="),
+                        Plurimath::Math::Number.new("0")
+                      ])
+                    ],
+                    { columnalign: "left" },
+                  )
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("x"),
-                      Plurimath::Math::Symbol.new("-"),
-                      Plurimath::Math::Symbol.new("y"),
-                      Plurimath::Math::Symbol.new("+"),
-                      Plurimath::Math::Number.new("8"),
-                      Plurimath::Math::Symbol.new("z"),
-                      Plurimath::Math::Symbol.new("="),
-                      Plurimath::Math::Number.new("0")
-                    ])
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("x"),
+                        Plurimath::Math::Symbol.new("-"),
+                        Plurimath::Math::Symbol.new("y"),
+                        Plurimath::Math::Symbol.new("+"),
+                        Plurimath::Math::Number.new("8"),
+                        Plurimath::Math::Symbol.new("z"),
+                        Plurimath::Math::Symbol.new("="),
+                        Plurimath::Math::Number.new("0")
+                      ])
+                    ],
+                    { columnalign: "left" },
+                  )
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Number.new("2"),
-                      Plurimath::Math::Symbol.new("x"),
-                      Plurimath::Math::Symbol.new("-"),
-                      Plurimath::Math::Number.new("6"),
-                      Plurimath::Math::Symbol.new("y"),
-                      Plurimath::Math::Symbol.new("+"),
-                      Plurimath::Math::Symbol.new("z"),
-                      Plurimath::Math::Symbol.new("="),
-                      Plurimath::Math::Number.new("0")
-                    ])
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Number.new("2"),
+                        Plurimath::Math::Symbol.new("x"),
+                        Plurimath::Math::Symbol.new("-"),
+                        Plurimath::Math::Number.new("6"),
+                        Plurimath::Math::Symbol.new("y"),
+                        Plurimath::Math::Symbol.new("+"),
+                        Plurimath::Math::Symbol.new("z"),
+                        Plurimath::Math::Symbol.new("="),
+                        Plurimath::Math::Number.new("0")
+                      ])
+                    ],
+                    { columnalign: "left" },
+                  )
                 ])
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("l")
-              ]
+              nil,
             ),
             Plurimath::Math::Function::Right.new("\\}")
           ])
@@ -193,7 +199,8 @@ RSpec.describe Plurimath::Latex::Parser do
               ])
             ],
             nil,
-            []
+            nil,
+            { asterisk: true }
           )
         ])
         expect(formula).to eq(expected_value)
@@ -215,13 +222,13 @@ RSpec.describe Plurimath::Latex::Parser do
                   [
                     Plurimath::Math::Symbol.new("a")
                   ],
-                  "right"
+                  { columnalign: "right" },
                 ),
                 Plurimath::Math::Function::Td.new(
                   [
                     Plurimath::Math::Symbol.new("b")
                   ],
-                  "right"
+                  { columnalign: "right" },
                 )
               ]),
               Plurimath::Math::Function::Tr.new([
@@ -229,20 +236,19 @@ RSpec.describe Plurimath::Latex::Parser do
                   [
                     Plurimath::Math::Symbol.new("c")
                   ],
-                  "right"
+                  { columnalign: "right" },
                 ),
                 Plurimath::Math::Function::Td.new(
                   [
                     Plurimath::Math::Symbol.new("d")
                   ],
-                  "right"
+                  { columnalign: "right" },
                 )
               ])
             ],
             nil,
-            [
-              Plurimath::Math::Symbol.new("r")
-            ]
+            nil,
+            { asterisk: true }
           )
         ])
         expect(formula).to eq(expected_value)
@@ -280,7 +286,8 @@ RSpec.describe Plurimath::Latex::Parser do
               ])
             ],
             nil,
-            [],
+            nil,
+            {},
           )
         ])
         expect(formula).to eq(expected_value)
@@ -304,7 +311,7 @@ RSpec.describe Plurimath::Latex::Parser do
               ]),
             ],
             nil,
-            [],
+            nil,
           )
         ])
         expect(formula).to eq(expected_value)
@@ -351,7 +358,8 @@ RSpec.describe Plurimath::Latex::Parser do
               ])
             ],
             nil,
-            []
+            nil,
+            {}
           )
         ])
         expect(formula).to eq(expected_value)
@@ -369,27 +377,37 @@ RSpec.describe Plurimath::Latex::Parser do
           Plurimath::Math::Function::Table::Array.new(
             [
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Number.new("1")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Number.new("2")
-                ])
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Number.new("1")
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Number.new("2")
+                  ],
+                  { columnalign: "center" }
+                )
               ]),
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Number.new("3")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Number.new("4")
-                ])
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Number.new("3")
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Number.new("4")
+                  ],
+                  { columnalign: "center" }
+                )
               ])
             ],
             nil,
-            [
-              Plurimath::Math::Symbol.new("c"),
-              Plurimath::Math::Symbol.new("c")
-            ]
+            nil,
+            {}
           )
         ])
         expect(formula).to eq(expected_value)
@@ -407,6 +425,8 @@ RSpec.describe Plurimath::Latex::Parser do
           \\end{bmatrix}
         LATEX
       end
+
+
       it "returns formula" do
         expected_value = Plurimath::Math::Formula.new([
           Plurimath::Math::Function::Table::Bmatrix.new(
@@ -532,7 +552,8 @@ RSpec.describe Plurimath::Latex::Parser do
               ])
             ],
             "[",
-            []
+            "]",
+            {}
           )
         ])
         expect(formula).to eq(expected_value)
@@ -601,38 +622,53 @@ RSpec.describe Plurimath::Latex::Parser do
           Plurimath::Math::Function::Table::Array.new(
             [
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("A"),
-                  Plurimath::Math::Symbol.new("B"),
-                  Plurimath::Math::Symbol.new("C")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("=")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("a")
-                ])
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Symbol.new("A"),
+                    Plurimath::Math::Symbol.new("B"),
+                    Plurimath::Math::Symbol.new("C")
+                  ],
+                  { columnalign: "right" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Symbol.new("=")
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Symbol.new("a")
+                  ],
+                  { columnalign: "left" }
+                )
               ]),
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("A")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("=")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("a"),
-                  Plurimath::Math::Symbol.new("b"),
-                  Plurimath::Math::Symbol.new("c")
-                ])
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Symbol.new("A")
+                  ],
+                  { columnalign: "right" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Symbol.new("=")
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Symbol.new("a"),
+                    Plurimath::Math::Symbol.new("b"),
+                    Plurimath::Math::Symbol.new("c")
+                  ],
+                  { columnalign: "left" }
+                )
               ])
             ],
             nil,
-            [
-              Plurimath::Math::Symbol.new("r"),
-              Plurimath::Math::Symbol.new("c"),
-              Plurimath::Math::Symbol.new("l")
-            ]
+            nil,
+            {}
           )
         ])
         expect(formula).to eq(expected_value)
@@ -649,41 +685,58 @@ RSpec.describe Plurimath::Latex::Parser do
           \\end{array}
         LATEX
       end
+
       it "returns formula" do
         expected_value = Plurimath::Math::Formula.new([
           Plurimath::Math::Function::Table::Array.new(
             [
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Number.new("1")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Number.new("2")
-                ])
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Number.new("1")
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Number.new("2")
+                  ],
+                  { columnalign: "right" }
+                )
               ]),
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Number.new("3")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Number.new("4")
-                ])
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Number.new("3")
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Number.new("4")
+                  ],
+                  { columnalign: "right" }
+                )
               ]),
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("&#x23af;"),
-                  Plurimath::Math::Number.new("5")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Number.new("6")
-                ])
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Symbol.new("&#x23af;"),
+                    Plurimath::Math::Number.new("5")
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Number.new("6")
+                  ],
+                  { columnalign: "right" }
+                )
               ])
             ],
             nil,
-            [
-              Plurimath::Math::Symbol.new("c"),
-              Plurimath::Math::Symbol.new("r")
-            ]
+            nil,
+            { rowline: "none none solid" }
           )
         ])
         expect(formula).to eq(expected_value)
@@ -705,37 +758,53 @@ RSpec.describe Plurimath::Latex::Parser do
           Plurimath::Math::Function::Table::Array.new(
             [
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Number.new("1")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Number.new("2")
-                ])
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Number.new("1")
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Number.new("2")
+                  ],
+                  { columnalign: "right" }
+                )
               ]),
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("&#x23af;"),
-                  Plurimath::Math::Number.new("3")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Number.new("4")
-                ])
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Symbol.new("&#x23af;"),
+                    Plurimath::Math::Number.new("3")
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Number.new("4")
+                  ],
+                  { columnalign: "right" }
+                )
               ]),
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("&#x23af;"),
-                  Plurimath::Math::Number.new("5")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Number.new("6")
-                ])
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Symbol.new("&#x23af;"),
+                    Plurimath::Math::Number.new("5")
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Number.new("6")
+                  ],
+                  { columnalign: "right" }
+                )
               ])
             ],
             nil,
-            [
-              Plurimath::Math::Symbol.new("c"),
-              Plurimath::Math::Symbol.new("r")
-            ]
+            nil,
+            { rowline: "none solid solid" }
           )
         ])
         expect(formula).to eq(expected_value)
@@ -744,6 +813,7 @@ RSpec.describe Plurimath::Latex::Parser do
 
     context "contains example #18" do
       let(:string) { "\\mathrm{...}" }
+
       it "returns formula" do
         expected_value = Plurimath::Math::Formula.new([
           Plurimath::Math::Function::FontStyle::Normal.new(
@@ -840,7 +910,6 @@ RSpec.describe Plurimath::Latex::Parser do
         ])
         expect(formula).to eq(expected_value)
       end
-
     end
 
     context "contains example #22" do
@@ -881,7 +950,7 @@ RSpec.describe Plurimath::Latex::Parser do
               ])
             ],
             nil,
-            []
+            nil
           )
         ])
         expect(formula).to eq(expected_value)
@@ -899,7 +968,7 @@ RSpec.describe Plurimath::Latex::Parser do
               ])
             ],
             nil,
-            []
+            nil
           )
         ])
         expect(formula).to eq(expected_value)
@@ -983,7 +1052,7 @@ RSpec.describe Plurimath::Latex::Parser do
                 ])
               ],
               nil,
-              []
+              nil
             ),
             Plurimath::Math::Function::Right.new("]")
           ])
@@ -1420,337 +1489,476 @@ RSpec.describe Plurimath::Latex::Parser do
           Plurimath::Math::Function::Table::Array.new(
             [
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Formula.new([
-                    Plurimath::Math::Function::Left.new("("),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Formula.new([
+                      Plurimath::Math::Function::Left.new("("),
+                      Plurimath::Math::Function::Table::Array.new(
+                        [
+                          Plurimath::Math::Function::Tr.new([
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                          ]),
+                          Plurimath::Math::Function::Tr.new([
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new(
+                              [
+                                Plurimath::Math::Symbol.new("+"),
+                                Plurimath::Math::Symbol.new("k"),
+                              ],
+                              { columnalign: "center" }
+                            ),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new(
+                              [
+                                Plurimath::Math::Formula.new([
+                                  Plurimath::Math::Symbol.new("-"),
+                                  Plurimath::Math::Symbol.new("k"),
+                                ]),
+                              ],
+                              { columnalign: "center" }
+                            ),
+                          ]),
+                          Plurimath::Math::Function::Tr.new([
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                          ]),
+                          Plurimath::Math::Function::Tr.new([
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                          ]),
+                          Plurimath::Math::Function::Tr.new([
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                          ]),
+                          Plurimath::Math::Function::Tr.new([
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new(
+                              [
+                                Plurimath::Math::Formula.new([
+                                  Plurimath::Math::Symbol.new("-"),
+                                  Plurimath::Math::Symbol.new("k"),
+                                ]),
+                              ],
+                              { columnalign: "center" }
+                            ),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new(
+                              [
+                                Plurimath::Math::Symbol.new("+"),
+                                Plurimath::Math::Symbol.new("k"),
+                              ],
+                              { columnalign: "center" }
+                            ),
+                          ]),
+                        ],
+                        nil,
+                        nil,
+                        {}
+                      ),
+                      Plurimath::Math::Function::Right.new(")"),
+                    ]),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
                     Plurimath::Math::Function::Table::Array.new(
                       [
                         Plurimath::Math::Function::Tr.new([
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([])
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
                         ]),
                         Plurimath::Math::Function::Tr.new([
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([
-                            Plurimath::Math::Symbol.new("+"),
-                            Plurimath::Math::Symbol.new("k")
-                          ]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([
-                            Plurimath::Math::Formula.new([
-                              Plurimath::Math::Symbol.new("-"),
-                              Plurimath::Math::Symbol.new("k")
-                            ])
-                          ])
+                          Plurimath::Math::Function::Td.new(
+                            [Plurimath::Math::Symbol.new("&#x22ef;")],
+                            { columnalign: "center" }
+                          ),
+                          Plurimath::Math::Function::Td.new(
+                            [
+                              Plurimath::Math::Function::Mbox.new(
+                                Plurimath::Math::Formula.new([
+                                  Plurimath::Math::Symbol.new("d"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("g"),
+                                  Plurimath::Math::Symbol.new("r"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("o"),
+                                  Plurimath::Math::Symbol.new("f"),
+                                  Plurimath::Math::Symbol.new("f"),
+                                  Plurimath::Math::Symbol.new("r"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("d"),
+                                  Plurimath::Math::Symbol.new("o"),
+                                  Plurimath::Math::Symbol.new("m"),
+                                  Plurimath::Math::Number.new("1"),
+                                  Plurimath::Math::Symbol.new(","),
+                                  Plurimath::Math::Symbol.new("n"),
+                                  Plurimath::Math::Symbol.new("o"),
+                                  Plurimath::Math::Symbol.new("d"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Number.new("1"),
+                                ])
+                              ),
+                            ],
+                            { columnalign: "center" }
+                          ),
                         ]),
                         Plurimath::Math::Function::Tr.new([
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([])
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
                         ]),
                         Plurimath::Math::Function::Tr.new([
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([])
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
                         ]),
                         Plurimath::Math::Function::Tr.new([
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([])
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
                         ]),
                         Plurimath::Math::Function::Tr.new([
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([
-                            Plurimath::Math::Formula.new([
-                              Plurimath::Math::Symbol.new("-"),
-                              Plurimath::Math::Symbol.new("k")
-                            ])
-                          ]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([
-                            Plurimath::Math::Symbol.new("+"),
-                            Plurimath::Math::Symbol.new("k")
-                          ])
-                        ])
+                          Plurimath::Math::Function::Td.new(
+                            [Plurimath::Math::Symbol.new("&#x22ef;")],
+                            { columnalign: "center" }
+                          ),
+                          Plurimath::Math::Function::Td.new(
+                            [
+                              Plurimath::Math::Function::Mbox.new(
+                                Plurimath::Math::Formula.new([
+                                  Plurimath::Math::Symbol.new("d"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("g"),
+                                  Plurimath::Math::Symbol.new("r"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("o"),
+                                  Plurimath::Math::Symbol.new("f"),
+                                  Plurimath::Math::Symbol.new("f"),
+                                  Plurimath::Math::Symbol.new("r"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("d"),
+                                  Plurimath::Math::Symbol.new("o"),
+                                  Plurimath::Math::Symbol.new("m"),
+                                  Plurimath::Math::Number.new("2"),
+                                  Plurimath::Math::Symbol.new(","),
+                                  Plurimath::Math::Symbol.new("n"),
+                                  Plurimath::Math::Symbol.new("o"),
+                                  Plurimath::Math::Symbol.new("d"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Number.new("2"),
+                                ])
+                              ),
+                            ],
+                            { columnalign: "center" }
+                          ),
+                        ]),
                       ],
                       nil,
-                      [
-                        Plurimath::Math::Symbol.new("c"),
-                        Plurimath::Math::Symbol.new("c"),
-                        Plurimath::Math::Symbol.new("c"),
-                        Plurimath::Math::Symbol.new("c"),
-                        Plurimath::Math::Symbol.new("c"),
-                        Plurimath::Math::Symbol.new("c"),
-                        Plurimath::Math::Symbol.new("c")
-                      ]
+                      nil,
+                      {}
                     ),
-                    Plurimath::Math::Function::Right.new(")")
-                  ])
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Table::Array.new(
-                    [
-                      Plurimath::Math::Function::Tr.new([
-                        Plurimath::Math::Function::Td.new([]),
-                        Plurimath::Math::Function::Td.new([])
-                      ]),
-                      Plurimath::Math::Function::Tr.new([
-                        Plurimath::Math::Function::Td.new([
-                          Plurimath::Math::Symbol.new("&#x22ef;")
-                        ]),
-                        Plurimath::Math::Function::Td.new([
-                          Plurimath::Math::Function::Mbox.new(
-                            Plurimath::Math::Formula.new([
-                              Plurimath::Math::Symbol.new("d"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("g"),
-                              Plurimath::Math::Symbol.new("r"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("o"),
-                              Plurimath::Math::Symbol.new("f"),
-                              Plurimath::Math::Symbol.new("f"),
-                              Plurimath::Math::Symbol.new("r"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("d"),
-                              Plurimath::Math::Symbol.new("o"),
-                              Plurimath::Math::Symbol.new("m"),
-                              Plurimath::Math::Number.new("1"),
-                              Plurimath::Math::Symbol.new(","),
-                              Plurimath::Math::Symbol.new("n"),
-                              Plurimath::Math::Symbol.new("o"),
-                              Plurimath::Math::Symbol.new("d"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Number.new("1")
-                            ])
-                          )
-                        ])
-                      ]),
-                      Plurimath::Math::Function::Tr.new([
-                        Plurimath::Math::Function::Td.new([]),
-                        Plurimath::Math::Function::Td.new([])
-                      ]),
-                      Plurimath::Math::Function::Tr.new([
-                        Plurimath::Math::Function::Td.new([]),
-                        Plurimath::Math::Function::Td.new([])
-                      ]),
-                      Plurimath::Math::Function::Tr.new([
-                        Plurimath::Math::Function::Td.new([]),
-                        Plurimath::Math::Function::Td.new([])
-                      ]),
-                      Plurimath::Math::Function::Tr.new([
-                        Plurimath::Math::Function::Td.new([
-                          Plurimath::Math::Symbol.new("&#x22ef;")
-                        ]),
-                        Plurimath::Math::Function::Td.new([
-                          Plurimath::Math::Function::Mbox.new(
-                            Plurimath::Math::Formula.new([
-                              Plurimath::Math::Symbol.new("d"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("g"),
-                              Plurimath::Math::Symbol.new("r"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("o"),
-                              Plurimath::Math::Symbol.new("f"),
-                              Plurimath::Math::Symbol.new("f"),
-                              Plurimath::Math::Symbol.new("r"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("d"),
-                              Plurimath::Math::Symbol.new("o"),
-                              Plurimath::Math::Symbol.new("m"),
-                              Plurimath::Math::Number.new("2"),
-                              Plurimath::Math::Symbol.new(","),
-                              Plurimath::Math::Symbol.new("n"),
-                              Plurimath::Math::Symbol.new("o"),
-                              Plurimath::Math::Symbol.new("d"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Number.new("2")
-                            ])
-                          )
-                        ])
-                      ])
-                    ],
-                    nil,
-                    [
-                      Plurimath::Math::Symbol.new("c"),
-                      Plurimath::Math::Symbol.new("c")
-                    ]
-                  )
-                ])
+                  ],
+                  { columnalign: "center" }
+                ),
               ]),
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([]),
-                Plurimath::Math::Function::Td.new([])
+                Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
               ]),
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Table::Array.new(
-                    [
-                      Plurimath::Math::Function::Tr.new([
-                        Plurimath::Math::Function::Td.new([
-                          Plurimath::Math::Symbol.new("&#x22ee;")
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Table::Array.new(
+                      [
+                        Plurimath::Math::Function::Tr.new([
+                          Plurimath::Math::Function::Td.new(
+                            [Plurimath::Math::Symbol.new("&#x22ee;")],
+                            { columnalign: "center" }
+                          ),
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
+                          Plurimath::Math::Function::Td.new(
+                            [Plurimath::Math::Symbol.new("&#x22ee;")],
+                            { columnalign: "center" }
+                          ),
                         ]),
-                        Plurimath::Math::Function::Td.new([]),
-                        Plurimath::Math::Function::Td.new([]),
-                        Plurimath::Math::Function::Td.new([]),
-                        Plurimath::Math::Function::Td.new([]),
-                        Plurimath::Math::Function::Td.new([
-                          Plurimath::Math::Symbol.new("&#x22ee;")
-                        ])
-                      ])
-                    ],
-                    nil,
-                    [
-                      Plurimath::Math::Symbol.new("c"),
-                      Plurimath::Math::Symbol.new("c"),
-                      Plurimath::Math::Symbol.new("c"),
-                      Plurimath::Math::Symbol.new("c"),
-                      Plurimath::Math::Symbol.new("c"),
-                      Plurimath::Math::Symbol.new("c")
-                    ]
-                  )
-                ]),
-                Plurimath::Math::Function::Td.new([])
+                      ],
+                      nil,
+                      nil,
+                      {}
+                    ),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
               ]),
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Table::Array.new(
-                    [
-                      Plurimath::Math::Function::Tr.new([
-                        Plurimath::Math::Function::Td.new([]),
-                        Plurimath::Math::Function::Td.new([
-                          Plurimath::Math::Function::Mbox.new(
-                            Plurimath::Math::Formula.new([
-                              Plurimath::Math::Symbol.new("d"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("g"),
-                              Plurimath::Math::Symbol.new("r"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("o"),
-                              Plurimath::Math::Symbol.new("f")
-                            ])
-                          )
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Table::Array.new(
+                      [
+                        Plurimath::Math::Function::Tr.new([
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
+                          Plurimath::Math::Function::Td.new(
+                            [
+                              Plurimath::Math::Function::Mbox.new(
+                                Plurimath::Math::Formula.new([
+                                  Plurimath::Math::Symbol.new("d"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("g"),
+                                  Plurimath::Math::Symbol.new("r"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("o"),
+                                  Plurimath::Math::Symbol.new("f"),
+                                ])
+                              ),
+                            ],
+                            { columnalign: "center" }
+                          ),
+                          Plurimath::Math::Function::Td.new(
+                            [
+                              Plurimath::Math::Function::Mbox.new(
+                                Plurimath::Math::Formula.new([
+                                  Plurimath::Math::Symbol.new("d"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("g"),
+                                  Plurimath::Math::Symbol.new("r"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("o"),
+                                  Plurimath::Math::Symbol.new("f"),
+                                ])
+                              ),
+                            ],
+                            { columnalign: "center" }
+                          ),
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
                         ]),
-                        Plurimath::Math::Function::Td.new([
-                          Plurimath::Math::Function::Mbox.new(
-                            Plurimath::Math::Formula.new([
-                              Plurimath::Math::Symbol.new("d"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("g"),
-                              Plurimath::Math::Symbol.new("r"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("o"),
-                              Plurimath::Math::Symbol.new("f")
-                            ])
-                          )
+                        Plurimath::Math::Function::Tr.new([
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
+                          Plurimath::Math::Function::Td.new(
+                            [
+                              Plurimath::Math::Function::Mbox.new(
+                                Plurimath::Math::Formula.new([
+                                  Plurimath::Math::Symbol.new("f"),
+                                  Plurimath::Math::Symbol.new("r"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("d"),
+                                  Plurimath::Math::Symbol.new("o"),
+                                  Plurimath::Math::Symbol.new("m"),
+                                  Plurimath::Math::Number.new("1"),
+                                  Plurimath::Math::Symbol.new(","),
+                                ])
+                              ),
+                            ],
+                            { columnalign: "center" }
+                          ),
+                          Plurimath::Math::Function::Td.new(
+                            [
+                              Plurimath::Math::Function::Mbox.new(
+                                Plurimath::Math::Formula.new([
+                                  Plurimath::Math::Symbol.new("f"),
+                                  Plurimath::Math::Symbol.new("r"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("d"),
+                                  Plurimath::Math::Symbol.new("o"),
+                                  Plurimath::Math::Symbol.new("m"),
+                                  Plurimath::Math::Number.new("2"),
+                                  Plurimath::Math::Symbol.new(","),
+                                ])
+                              ),
+                            ],
+                            { columnalign: "center" }
+                          ),
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
                         ]),
-                        Plurimath::Math::Function::Td.new([])
-                      ]),
-                      Plurimath::Math::Function::Tr.new([
-                        Plurimath::Math::Function::Td.new([]),
-                        Plurimath::Math::Function::Td.new([
-                          Plurimath::Math::Function::Mbox.new(
-                            Plurimath::Math::Formula.new([
-                              Plurimath::Math::Symbol.new("f"),
-                              Plurimath::Math::Symbol.new("r"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("d"),
-                              Plurimath::Math::Symbol.new("o"),
-                              Plurimath::Math::Symbol.new("m"),
-                              Plurimath::Math::Number.new("1"),
-                              Plurimath::Math::Symbol.new(",")
-                            ])
-                          )
+                        Plurimath::Math::Function::Tr.new([
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
+                          Plurimath::Math::Function::Td.new(
+                            [
+                              Plurimath::Math::Function::Mbox.new(
+                                Plurimath::Math::Formula.new([
+                                  Plurimath::Math::Symbol.new("n"),
+                                  Plurimath::Math::Symbol.new("o"),
+                                  Plurimath::Math::Symbol.new("d"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Number.new("1"),
+                                ])
+                              ),
+                            ],
+                            { columnalign: "center" }
+                          ),
+                          Plurimath::Math::Function::Td.new(
+                            [
+                              Plurimath::Math::Function::Mbox.new(
+                                Plurimath::Math::Formula.new([
+                                  Plurimath::Math::Symbol.new("n"),
+                                  Plurimath::Math::Symbol.new("o"),
+                                  Plurimath::Math::Symbol.new("d"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Number.new("2"),
+                                ])
+                              ),
+                            ],
+                            { columnalign: "center" }
+                          ),
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
                         ]),
-                        Plurimath::Math::Function::Td.new([
-                          Plurimath::Math::Function::Mbox.new(
-                            Plurimath::Math::Formula.new([
-                              Plurimath::Math::Symbol.new("f"),
-                              Plurimath::Math::Symbol.new("r"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("d"),
-                              Plurimath::Math::Symbol.new("o"),
-                              Plurimath::Math::Symbol.new("m"),
-                              Plurimath::Math::Number.new("2"),
-                              Plurimath::Math::Symbol.new(",")
-                            ])
-                          )
-                        ]),
-                        Plurimath::Math::Function::Td.new([])
-                      ]),
-                      Plurimath::Math::Function::Tr.new([
-                        Plurimath::Math::Function::Td.new([]),
-                        Plurimath::Math::Function::Td.new([
-                          Plurimath::Math::Function::Mbox.new(
-                            Plurimath::Math::Formula.new([
-                              Plurimath::Math::Symbol.new("n"),
-                              Plurimath::Math::Symbol.new("o"),
-                              Plurimath::Math::Symbol.new("d"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Number.new("1")
-                            ])
-                          )
-                        ]),
-                        Plurimath::Math::Function::Td.new([
-                          Plurimath::Math::Function::Mbox.new(
-                            Plurimath::Math::Formula.new([
-                              Plurimath::Math::Symbol.new("n"),
-                              Plurimath::Math::Symbol.new("o"),
-                              Plurimath::Math::Symbol.new("d"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Number.new("2")
-                            ])
-                          )
-                        ]),
-                        Plurimath::Math::Function::Td.new([])
-                      ])
-                    ],
-                    nil,
-                    [
-                      Plurimath::Math::Symbol.new("c"),
-                      Plurimath::Math::Symbol.new("c"),
-                      Plurimath::Math::Symbol.new("c"),
-                      Plurimath::Math::Symbol.new("c")
-                    ]
-                  )
-                ]),
-                Plurimath::Math::Function::Td.new([])
-              ])
+                      ],
+                      nil,
+                      nil,
+                      {}
+                    ),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+              ]),
             ],
             nil,
-            [
-              Plurimath::Math::Symbol.new("c"),
-              Plurimath::Math::Symbol.new("c")
-            ]
-          )
+            nil,
+            {}
+          ),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -1771,191 +1979,206 @@ RSpec.describe Plurimath::Latex::Parser do
           Plurimath::Math::Function::Table::Split.new(
             [
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("C"),
-                    Plurimath::Math::Symbol.new("L")
-                  )
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Over.new(
-                    Plurimath::Math::Formula.new([
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("C"),
                       Plurimath::Math::Symbol.new("L")
-                    ]),
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::Over.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Number.new("1")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Number.new("2")
-                        ])
-                      ),
-                      Plurimath::Math::Function::Base.new(
-                        Plurimath::Math::Symbol.new("&#x3c1;"),
-                        Plurimath::Math::Function::FontStyle.new(
-                          Plurimath::Math::Formula.new([
-                            Plurimath::Math::Symbol.new("r"),
-                            Plurimath::Math::Symbol.new("e"),
-                            Plurimath::Math::Symbol.new("f")
-                          ]),
-                          "textrm"
-                        )
-                      ),
-                      Plurimath::Math::Function::PowerBase.new(
-                        Plurimath::Math::Symbol.new("q"),
-                        Plurimath::Math::Function::FontStyle.new(
-                          Plurimath::Math::Formula.new([
-                            Plurimath::Math::Symbol.new("r"),
-                            Plurimath::Math::Symbol.new("e"),
-                            Plurimath::Math::Symbol.new("f")
-                          ]),
-                          "textrm"
-                        ),
-                        Plurimath::Math::Number.new("2")
-                      ),
-                      Plurimath::Math::Symbol.new("S")
-                    ])
-                  )
-                ])
-              ]),
-              Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([])
-              ]),
-              Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("C"),
-                    Plurimath::Math::Symbol.new("D")
-                  )
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Over.new(
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("D")
-                    ]),
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::Over.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Number.new("1")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Number.new("2")
-                        ])
-                      ),
-                      Plurimath::Math::Function::Base.new(
-                        Plurimath::Math::Symbol.new("&#x3c1;"),
-                        Plurimath::Math::Function::FontStyle.new(
-                          Plurimath::Math::Formula.new([
-                            Plurimath::Math::Symbol.new("r"),
-                            Plurimath::Math::Symbol.new("e"),
-                            Plurimath::Math::Symbol.new("f")
-                          ]),
-                          "textrm"
-                        )
-                      ),
-                      Plurimath::Math::Function::PowerBase.new(
-                        Plurimath::Math::Symbol.new("q"),
-                        Plurimath::Math::Function::FontStyle.new(
-                          Plurimath::Math::Formula.new([
-                            Plurimath::Math::Symbol.new("r"),
-                            Plurimath::Math::Symbol.new("e"),
-                            Plurimath::Math::Symbol.new("f")
-                          ]),
-                          "textrm"
-                        ),
-                        Plurimath::Math::Number.new("2")
-                      ),
-                      Plurimath::Math::Symbol.new("S")
-                    ])
-                  )
-                ])
-              ]),
-              Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([])
-              ]),
-              Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Function::Vec.new(
-                      Plurimath::Math::Symbol.new("C")
                     ),
-                    Plurimath::Math::Symbol.new("M")
-                  )
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Over.new(
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::Vec.new(
-                        Plurimath::Math::Symbol.new("M")
-                      )
-                    ]),
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::Over.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Number.new("1")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Number.new("2")
-                        ])
-                      ),
-                      Plurimath::Math::Function::Base.new(
-                        Plurimath::Math::Symbol.new("&#x3c1;"),
-                        Plurimath::Math::Function::FontStyle.new(
+                  ],
+                  nil
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Over.new(
+                      Plurimath::Math::Formula.new([Plurimath::Math::Symbol.new("L")]),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Function::Over.new(
                           Plurimath::Math::Formula.new([
-                            Plurimath::Math::Symbol.new("r"),
-                            Plurimath::Math::Symbol.new("e"),
-                            Plurimath::Math::Symbol.new("f")
+                            Plurimath::Math::Number.new("1"),
                           ]),
-                          "textrm"
-                        )
-                      ),
-                      Plurimath::Math::Function::PowerBase.new(
-                        Plurimath::Math::Symbol.new("q"),
-                        Plurimath::Math::Function::FontStyle.new(
                           Plurimath::Math::Formula.new([
-                            Plurimath::Math::Symbol.new("r"),
-                            Plurimath::Math::Symbol.new("e"),
-                            Plurimath::Math::Symbol.new("f")
-                          ]),
-                          "textrm"
+                            Plurimath::Math::Number.new("2"),
+                          ])
                         ),
-                        Plurimath::Math::Number.new("2")
-                      ),
-                      Plurimath::Math::Function::Base.new(
-                        Plurimath::Math::Symbol.new("c"),
-                        Plurimath::Math::Function::FontStyle.new(
-                          Plurimath::Math::Formula.new([
-                            Plurimath::Math::Symbol.new("r"),
-                            Plurimath::Math::Symbol.new("e"),
-                            Plurimath::Math::Symbol.new("f")
-                          ]),
-                          "textrm"
-                        )
-                      ),
-                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Function::Base.new(
+                          Plurimath::Math::Symbol.new("&#x3c1;"),
+                          Plurimath::Math::Function::FontStyle::Normal.new(
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("r"),
+                              Plurimath::Math::Symbol.new("e"),
+                              Plurimath::Math::Symbol.new("f"),
+                            ]),
+                            "textrm"
+                          )
+                        ),
+                        Plurimath::Math::Function::PowerBase.new(
+                          Plurimath::Math::Symbol.new("q"),
+                          Plurimath::Math::Function::FontStyle::Normal.new(
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("r"),
+                              Plurimath::Math::Symbol.new("e"),
+                              Plurimath::Math::Symbol.new("f"),
+                            ]),
+                            "textrm"
+                          ),
+                          Plurimath::Math::Number.new("2")
+                        ),
                         Plurimath::Math::Symbol.new("S"),
-                        Plurimath::Math::Function::FontStyle.new(
+                      ])
+                    ),
+                  ],
+                  nil
+                ),
+              ]),
+              Plurimath::Math::Function::Tr.new([
+                Plurimath::Math::Function::Td.new([], nil),
+              ]),
+              Plurimath::Math::Function::Tr.new([
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("C"),
+                      Plurimath::Math::Symbol.new("D")
+                    ),
+                  ],
+                  nil
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Over.new(
+                      Plurimath::Math::Formula.new([Plurimath::Math::Symbol.new("D")]),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Function::Over.new(
                           Plurimath::Math::Formula.new([
-                            Plurimath::Math::Symbol.new("r"),
-                            Plurimath::Math::Symbol.new("e"),
-                            Plurimath::Math::Symbol.new("f")
+                            Plurimath::Math::Number.new("1"),
                           ]),
-                          "textrm"
-                        )
-                      )
-                    ])
-                  ),
-                  Plurimath::Math::Symbol.new(",")
-                ])
-              ])
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Number.new("2"),
+                          ])
+                        ),
+                        Plurimath::Math::Function::Base.new(
+                          Plurimath::Math::Symbol.new("&#x3c1;"),
+                          Plurimath::Math::Function::FontStyle::Normal.new(
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("r"),
+                              Plurimath::Math::Symbol.new("e"),
+                              Plurimath::Math::Symbol.new("f"),
+                            ]),
+                            "textrm"
+                          )
+                        ),
+                        Plurimath::Math::Function::PowerBase.new(
+                          Plurimath::Math::Symbol.new("q"),
+                          Plurimath::Math::Function::FontStyle::Normal.new(
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("r"),
+                              Plurimath::Math::Symbol.new("e"),
+                              Plurimath::Math::Symbol.new("f"),
+                            ]),
+                            "textrm"
+                          ),
+                          Plurimath::Math::Number.new("2")
+                        ),
+                        Plurimath::Math::Symbol.new("S"),
+                      ])
+                    ),
+                  ],
+                  nil
+                ),
+              ]),
+              Plurimath::Math::Function::Tr.new([
+                Plurimath::Math::Function::Td.new([], nil),
+              ]),
+              Plurimath::Math::Function::Tr.new([
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Function::Vec.new(
+                        Plurimath::Math::Symbol.new("C")
+                      ),
+                      Plurimath::Math::Symbol.new("M")
+                    ),
+                  ],
+                  nil
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Over.new(
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Function::Vec.new(
+                          Plurimath::Math::Symbol.new("M")
+                        ),
+                      ]),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Function::Over.new(
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Number.new("1"),
+                          ]),
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Number.new("2"),
+                          ])
+                        ),
+                        Plurimath::Math::Function::Base.new(
+                          Plurimath::Math::Symbol.new("&#x3c1;"),
+                          Plurimath::Math::Function::FontStyle::Normal.new(
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("r"),
+                              Plurimath::Math::Symbol.new("e"),
+                              Plurimath::Math::Symbol.new("f"),
+                            ]),
+                            "textrm"
+                          )
+                        ),
+                        Plurimath::Math::Function::PowerBase.new(
+                          Plurimath::Math::Symbol.new("q"),
+                          Plurimath::Math::Function::FontStyle::Normal.new(
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("r"),
+                              Plurimath::Math::Symbol.new("e"),
+                              Plurimath::Math::Symbol.new("f"),
+                            ]),
+                            "textrm"
+                          ),
+                          Plurimath::Math::Number.new("2")
+                        ),
+                        Plurimath::Math::Function::Base.new(
+                          Plurimath::Math::Symbol.new("c"),
+                          Plurimath::Math::Function::FontStyle::Normal.new(
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("r"),
+                              Plurimath::Math::Symbol.new("e"),
+                              Plurimath::Math::Symbol.new("f"),
+                            ]),
+                            "textrm"
+                          )
+                        ),
+                        Plurimath::Math::Function::Base.new(
+                          Plurimath::Math::Symbol.new("S"),
+                          Plurimath::Math::Function::FontStyle::Normal.new(
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("r"),
+                              Plurimath::Math::Symbol.new("e"),
+                              Plurimath::Math::Symbol.new("f"),
+                            ]),
+                            "textrm"
+                          )
+                        ),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  nil
+                ),
+              ]),
             ],
             nil,
-            []
-          )
+            nil,
+            {}
+          ),
         ])
         expect(formula).to eq(expected_value)
       end

--- a/spec/plurimath/latex/parser_spec.rb
+++ b/spec/plurimath/latex/parser_spec.rb
@@ -298,26 +298,27 @@ RSpec.describe Plurimath::Latex::Parser do
           Plurimath::Math::Function::Table::Array.new(
             [
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Formula.new([
-                    Plurimath::Math::Number.new("3"),
-                    Plurimath::Math::Symbol.new("x"),
-                    Plurimath::Math::Symbol.new("-"),
-                    Plurimath::Math::Number.new("5"),
-                    Plurimath::Math::Symbol.new("y"),
-                    Plurimath::Math::Symbol.new("+"),
-                    Plurimath::Math::Number.new("4"),
-                    Plurimath::Math::Symbol.new("z"),
-                    Plurimath::Math::Symbol.new("="),
-                    Plurimath::Math::Number.new("0"),
-                  ])
-                ])
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Formula.new([
+                      Plurimath::Math::Number.new("3"),
+                      Plurimath::Math::Symbol.new("x"),
+                      Plurimath::Math::Symbol.new("-"),
+                      Plurimath::Math::Number.new("5"),
+                      Plurimath::Math::Symbol.new("y"),
+                      Plurimath::Math::Symbol.new("+"),
+                      Plurimath::Math::Number.new("4"),
+                      Plurimath::Math::Symbol.new("z"),
+                      Plurimath::Math::Symbol.new("="),
+                      Plurimath::Math::Number.new("0"),
+                    ])
+                  ],
+                  { columnalign: "left" },
+                )
               ])
             ],
             nil,
-            [
-              Plurimath::Math::Symbol.new("l"),
-            ]
+            nil,
           )
         ])
         expect(formula).to eq(expected_value)
@@ -336,6 +337,9 @@ RSpec.describe Plurimath::Latex::Parser do
             [
               Plurimath::Math::Function::Tr.new([
                 Plurimath::Math::Function::Td.new([
+                  Plurimath::Math::Symbol.new("|"),
+                ]),
+                Plurimath::Math::Function::Td.new([
                   Plurimath::Math::Formula.new([
                     Plurimath::Math::Number.new("3"),
                     Plurimath::Math::Symbol.new("x"),
@@ -352,9 +356,7 @@ RSpec.describe Plurimath::Latex::Parser do
               ])
             ],
             nil,
-            [
-              Plurimath::Math::Symbol.new("|"),
-            ]
+            nil,
           )
         ])
         expect(formula).to eq(expected_value)
@@ -404,7 +406,7 @@ RSpec.describe Plurimath::Latex::Parser do
               ]),
             ],
             nil,
-            [],
+            nil,
           )
         ])
         expect(formula).to eq(expected_value)
@@ -451,17 +453,20 @@ RSpec.describe Plurimath::Latex::Parser do
           Plurimath::Math::Function::Table::Matrix.new(
             [
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("a"),
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("b"),
-                ]),
-              ])
+                Plurimath::Math::Function::Td.new(
+                  [Plurimath::Math::Symbol.new("a")],
+                  nil
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [Plurimath::Math::Symbol.new("b")],
+                  nil
+                ),
+              ]),
             ],
             nil,
-            [],
-          )
+            nil,
+            {}
+          ),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -495,7 +500,7 @@ RSpec.describe Plurimath::Latex::Parser do
               ]),
             ],
             "{",
-            [],
+            "}",
           )
         ])
         expect(formula).to eq(expected_value)
@@ -522,7 +527,7 @@ RSpec.describe Plurimath::Latex::Parser do
               ])
             ],
             "|",
-            [],
+            "|",
           )
         ])
         expect(formula).to eq(expected_value)
@@ -560,7 +565,7 @@ RSpec.describe Plurimath::Latex::Parser do
               ]),
             ],
             "{",
-            [],
+            "}",
           )
         ])
         expect(formula).to eq(expected_value)
@@ -598,7 +603,7 @@ RSpec.describe Plurimath::Latex::Parser do
               ]),
             ],
             "{",
-            [],
+            "}",
           )
         ])
         expect(formula).to eq(expected_value)
@@ -625,7 +630,7 @@ RSpec.describe Plurimath::Latex::Parser do
               ])
             ],
             "(",
-            [],
+            ")",
           )
         ])
         expect(formula).to eq(expected_value)
@@ -645,29 +650,44 @@ RSpec.describe Plurimath::Latex::Parser do
           Plurimath::Math::Function::Table::Array.new(
             [
               Plurimath::Math::Function::Tr.new([
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Number.new("1"),
+                  ],
+                  { columnalign: "center" },
+                ),
                 Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Number.new("1"),
+                  Plurimath::Math::Symbol.new("|")
                 ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Number.new("2"),
-                  Plurimath::Math::Symbol.new("&#x23af;"),
-                ]),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Number.new("2"),
+                    Plurimath::Math::Symbol.new("&#x23af;"),
+                  ],
+                  { columnalign: "right" },
+                ),
               ]),
               Plurimath::Math::Function::Tr.new([
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Number.new("3"),
+                  ],
+                  { columnalign: "center" }
+                ),
                 Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Number.new("3"),
+                  Plurimath::Math::Symbol.new("|")
                 ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Number.new("4"),
-                ]),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Number.new("4"),
+                  ],
+                  { columnalign: "right" },
+                ),
               ]),
             ],
             nil,
-            [
-              Plurimath::Math::Symbol.new("c"),
-              Plurimath::Math::Symbol.new("|"),
-              Plurimath::Math::Symbol.new("r"),
-            ]
+            nil,
+            {}
           )
         ])
         expect(formula).to eq(expected_value)
@@ -706,7 +726,7 @@ RSpec.describe Plurimath::Latex::Parser do
               ])
             ],
             "norm[",
-            [],
+            "]",
           )
         ])
         expect(formula).to eq(expected_value)
@@ -789,29 +809,34 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("V"),
-                      Plurimath::Math::Symbol.new("x"),
-                    ),
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("V"),
+                        Plurimath::Math::Symbol.new("x")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("V"),
-                      Plurimath::Math::Symbol.new("y"),
-                    ),
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("V"),
+                        Plurimath::Math::Symbol.new("y")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c")
-              ]
+              nil,
+              {}
             ),
             Plurimath::Math::Function::Right.new(")"),
-          ])
+          ]),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -932,15 +957,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Symbol.new("T"),
                 Plurimath::Math::Function::Base.new(
                   Plurimath::Math::Symbol.new("T"),
-                  Plurimath::Math::Function::FontStyle.new(
+                  Plurimath::Math::Function::FontStyle::Normal.new(
                     Plurimath::Math::Formula.new([
                       Plurimath::Math::Symbol.new("r"),
                       Plurimath::Math::Symbol.new("e"),
                       Plurimath::Math::Symbol.new("f"),
                     ]),
                     "textrm"
-                  ),
-                ),
+                  )
+                )
               ),
               Plurimath::Math::Function::Right.new(")"),
             ]),
@@ -948,7 +973,7 @@ RSpec.describe Plurimath::Latex::Parser do
               Plurimath::Math::Number.new("3"),
               Plurimath::Math::Symbol.new("/"),
               Plurimath::Math::Number.new("2"),
-            ]),
+            ])
           ),
         ])
         expect(formula).to eq(expected_value)
@@ -1298,192 +1323,207 @@ RSpec.describe Plurimath::Latex::Parser do
           Plurimath::Math::Function::Table::Split.new(
             [
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("C"),
-                    Plurimath::Math::Symbol.new("L")
-                  )
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Over.new(
-                    Plurimath::Math::Formula.new([
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("C"),
                       Plurimath::Math::Symbol.new("L")
-                    ]),
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::Over.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Number.new("1")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Number.new("2")
-                        ])
-                      ),
-                      Plurimath::Math::Function::Base.new(
-                        Plurimath::Math::Symbol.new("&#x3c1;"),
-                        Plurimath::Math::Function::FontStyle.new(
-                          Plurimath::Math::Formula.new([
-                            Plurimath::Math::Symbol.new("r"),
-                            Plurimath::Math::Symbol.new("e"),
-                            Plurimath::Math::Symbol.new("f"),
-                          ]),
-                          "textrm"
-                        )
-                      ),
-                      Plurimath::Math::Function::PowerBase.new(
-                        Plurimath::Math::Symbol.new("q"),
-                        Plurimath::Math::Function::FontStyle.new(
-                          Plurimath::Math::Formula.new([
-                            Plurimath::Math::Symbol.new("r"),
-                            Plurimath::Math::Symbol.new("e"),
-                            Plurimath::Math::Symbol.new("f"),
-                          ]),
-                          "textrm"
-                        ),
-                        Plurimath::Math::Number.new("2"),
-                      ),
-                      Plurimath::Math::Symbol.new("S")
-                    ])
-                  )
-                ])
-              ]),
-              Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([])
-              ]),
-              Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("C"),
-                    Plurimath::Math::Symbol.new("D")
-                  )
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Over.new(
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("D")
-                    ]),
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::Over.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Number.new("1")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Number.new("2")
-                        ])
-                      ),
-                      Plurimath::Math::Function::Base.new(
-                        Plurimath::Math::Symbol.new("&#x3c1;"),
-                        Plurimath::Math::Function::FontStyle.new(
-                          Plurimath::Math::Formula.new([
-                            Plurimath::Math::Symbol.new("r"),
-                            Plurimath::Math::Symbol.new("e"),
-                            Plurimath::Math::Symbol.new("f"),
-                          ]),
-                          "textrm"
-                        )
-                      ),
-                      Plurimath::Math::Function::PowerBase.new(
-                        Plurimath::Math::Symbol.new("q"),
-                        Plurimath::Math::Function::FontStyle.new(
-                          Plurimath::Math::Formula.new([
-                            Plurimath::Math::Symbol.new("r"),
-                            Plurimath::Math::Symbol.new("e"),
-                            Plurimath::Math::Symbol.new("f"),
-                          ]),
-                          "textrm"
-                        ),
-                        Plurimath::Math::Number.new("2"),
-                      ),
-                      Plurimath::Math::Symbol.new("S")
-                    ])
-                  )
-                ])
-              ]),
-              Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([])
-              ]),
-              Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Function::Vec.new(
-                      Plurimath::Math::Symbol.new("C")
                     ),
-                    Plurimath::Math::Symbol.new("M")
-                  )
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Over.new(
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("&#x3b2;"),
-                      Plurimath::Math::Function::Vec.new(
-                        Plurimath::Math::Symbol.new("M")
-                      )
-                    ]),
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::Over.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Number.new("1")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Number.new("2")
-                        ])
-                      ),
-                      Plurimath::Math::Function::Base.new(
-                        Plurimath::Math::Symbol.new("&#x3c1;"),
-                        Plurimath::Math::Function::FontStyle.new(
+                  ],
+                  nil
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Over.new(
+                      Plurimath::Math::Formula.new([Plurimath::Math::Symbol.new("L")]),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Function::Over.new(
                           Plurimath::Math::Formula.new([
-                            Plurimath::Math::Symbol.new("r"),
-                            Plurimath::Math::Symbol.new("e"),
-                            Plurimath::Math::Symbol.new("f"),
+                            Plurimath::Math::Number.new("1"),
                           ]),
-                          "textrm"
-                        )
-                      ),
-                      Plurimath::Math::Function::PowerBase.new(
-                        Plurimath::Math::Symbol.new("q"),
-                        Plurimath::Math::Function::FontStyle.new(
                           Plurimath::Math::Formula.new([
-                            Plurimath::Math::Symbol.new("r"),
-                            Plurimath::Math::Symbol.new("e"),
-                            Plurimath::Math::Symbol.new("f"),
-                          ]),
-                          "textrm"
+                            Plurimath::Math::Number.new("2"),
+                          ])
                         ),
-                        Plurimath::Math::Number.new("2"),
-                      ),
-                      Plurimath::Math::Function::Base.new(
-                        Plurimath::Math::Symbol.new("c"),
-                        Plurimath::Math::Function::FontStyle.new(
-                          Plurimath::Math::Formula.new([
-                            Plurimath::Math::Symbol.new("r"),
-                            Plurimath::Math::Symbol.new("e"),
-                            Plurimath::Math::Symbol.new("f"),
-                          ]),
-                          "textrm"
-                        )
-                      ),
-                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Function::Base.new(
+                          Plurimath::Math::Symbol.new("&#x3c1;"),
+                          Plurimath::Math::Function::FontStyle::Normal.new(
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("r"),
+                              Plurimath::Math::Symbol.new("e"),
+                              Plurimath::Math::Symbol.new("f"),
+                            ]),
+                            "textrm"
+                          )
+                        ),
+                        Plurimath::Math::Function::PowerBase.new(
+                          Plurimath::Math::Symbol.new("q"),
+                          Plurimath::Math::Function::FontStyle::Normal.new(
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("r"),
+                              Plurimath::Math::Symbol.new("e"),
+                              Plurimath::Math::Symbol.new("f"),
+                            ]),
+                            "textrm"
+                          ),
+                          Plurimath::Math::Number.new("2")
+                        ),
                         Plurimath::Math::Symbol.new("S"),
-                        Plurimath::Math::Function::FontStyle.new(
+                      ])
+                    ),
+                  ],
+                  nil
+                ),
+              ]),
+              Plurimath::Math::Function::Tr.new([
+                Plurimath::Math::Function::Td.new([], nil),
+              ]),
+              Plurimath::Math::Function::Tr.new([
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("C"),
+                      Plurimath::Math::Symbol.new("D")
+                    ),
+                  ],
+                  nil
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Over.new(
+                      Plurimath::Math::Formula.new([Plurimath::Math::Symbol.new("D")]),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Function::Over.new(
                           Plurimath::Math::Formula.new([
-                            Plurimath::Math::Symbol.new("r"),
-                            Plurimath::Math::Symbol.new("e"),
-                            Plurimath::Math::Symbol.new("f"),
+                            Plurimath::Math::Number.new("1"),
                           ]),
-                          "textrm"
-                        )
-                      )
-                    ])
-                  ),
-                  Plurimath::Math::Symbol.new(",")
-                ])
-              ])
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Number.new("2"),
+                          ])
+                        ),
+                        Plurimath::Math::Function::Base.new(
+                          Plurimath::Math::Symbol.new("&#x3c1;"),
+                          Plurimath::Math::Function::FontStyle::Normal.new(
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("r"),
+                              Plurimath::Math::Symbol.new("e"),
+                              Plurimath::Math::Symbol.new("f"),
+                            ]),
+                            "textrm"
+                          )
+                        ),
+                        Plurimath::Math::Function::PowerBase.new(
+                          Plurimath::Math::Symbol.new("q"),
+                          Plurimath::Math::Function::FontStyle::Normal.new(
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("r"),
+                              Plurimath::Math::Symbol.new("e"),
+                              Plurimath::Math::Symbol.new("f"),
+                            ]),
+                            "textrm"
+                          ),
+                          Plurimath::Math::Number.new("2")
+                        ),
+                        Plurimath::Math::Symbol.new("S"),
+                      ])
+                    ),
+                  ],
+                  nil
+                ),
+              ]),
+              Plurimath::Math::Function::Tr.new([
+                Plurimath::Math::Function::Td.new([], nil),
+              ]),
+              Plurimath::Math::Function::Tr.new([
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Function::Vec.new(
+                        Plurimath::Math::Symbol.new("C")
+                      ),
+                      Plurimath::Math::Symbol.new("M")
+                    ),
+                  ],
+                  nil
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Over.new(
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("&#x3b2;"),
+                        Plurimath::Math::Function::Vec.new(
+                          Plurimath::Math::Symbol.new("M")
+                        ),
+                      ]),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Function::Over.new(
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Number.new("1"),
+                          ]),
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Number.new("2"),
+                          ])
+                        ),
+                        Plurimath::Math::Function::Base.new(
+                          Plurimath::Math::Symbol.new("&#x3c1;"),
+                          Plurimath::Math::Function::FontStyle::Normal.new(
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("r"),
+                              Plurimath::Math::Symbol.new("e"),
+                              Plurimath::Math::Symbol.new("f"),
+                            ]),
+                            "textrm"
+                          )
+                        ),
+                        Plurimath::Math::Function::PowerBase.new(
+                          Plurimath::Math::Symbol.new("q"),
+                          Plurimath::Math::Function::FontStyle::Normal.new(
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("r"),
+                              Plurimath::Math::Symbol.new("e"),
+                              Plurimath::Math::Symbol.new("f"),
+                            ]),
+                            "textrm"
+                          ),
+                          Plurimath::Math::Number.new("2")
+                        ),
+                        Plurimath::Math::Function::Base.new(
+                          Plurimath::Math::Symbol.new("c"),
+                          Plurimath::Math::Function::FontStyle::Normal.new(
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("r"),
+                              Plurimath::Math::Symbol.new("e"),
+                              Plurimath::Math::Symbol.new("f"),
+                            ]),
+                            "textrm"
+                          )
+                        ),
+                        Plurimath::Math::Function::Base.new(
+                          Plurimath::Math::Symbol.new("S"),
+                          Plurimath::Math::Function::FontStyle::Normal.new(
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("r"),
+                              Plurimath::Math::Symbol.new("e"),
+                              Plurimath::Math::Symbol.new("f"),
+                            ]),
+                            "textrm"
+                          )
+                        ),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  nil
+                ),
+              ]),
             ],
             nil,
-            [],
-          )
+            nil,
+            {}
+          ),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -1501,7 +1541,7 @@ RSpec.describe Plurimath::Latex::Parser do
         expected_value = Plurimath::Math::Formula.new([
           Plurimath::Math::Function::Base.new(
             Plurimath::Math::Symbol.new("c"),
-            Plurimath::Math::Symbol.new("l"),
+            Plurimath::Math::Symbol.new("l")
           ),
           Plurimath::Math::Symbol.new("="),
           Plurimath::Math::Function::Over.new(
@@ -1511,16 +1551,12 @@ RSpec.describe Plurimath::Latex::Parser do
             ]),
             Plurimath::Math::Formula.new([
               Plurimath::Math::Function::Over.new(
-                Plurimath::Math::Formula.new([
-                  Plurimath::Math::Number.new("1")
-                ]),
-                Plurimath::Math::Formula.new([
-                  Plurimath::Math::Number.new("2")
-                ]),
+                Plurimath::Math::Formula.new([Plurimath::Math::Number.new("1")]),
+                Plurimath::Math::Formula.new([Plurimath::Math::Number.new("2")])
               ),
               Plurimath::Math::Function::Base.new(
                 Plurimath::Math::Symbol.new("&#x3c1;"),
-                Plurimath::Math::Function::FontStyle.new(
+                Plurimath::Math::Function::FontStyle::Normal.new(
                   Plurimath::Math::Formula.new([
                     Plurimath::Math::Symbol.new("r"),
                     Plurimath::Math::Symbol.new("e"),
@@ -1531,7 +1567,7 @@ RSpec.describe Plurimath::Latex::Parser do
               ),
               Plurimath::Math::Function::PowerBase.new(
                 Plurimath::Math::Symbol.new("q"),
-                Plurimath::Math::Function::FontStyle.new(
+                Plurimath::Math::Function::FontStyle::Normal.new(
                   Plurimath::Math::Formula.new([
                     Plurimath::Math::Symbol.new("r"),
                     Plurimath::Math::Symbol.new("e"),
@@ -1539,11 +1575,11 @@ RSpec.describe Plurimath::Latex::Parser do
                   ]),
                   "textrm"
                 ),
-                Plurimath::Math::Number.new("2"),
+                Plurimath::Math::Number.new("2")
               ),
               Plurimath::Math::Function::Base.new(
                 Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Function::FontStyle.new(
+                Plurimath::Math::Function::FontStyle::Normal.new(
                   Plurimath::Math::Formula.new([
                     Plurimath::Math::Symbol.new("r"),
                     Plurimath::Math::Symbol.new("e"),
@@ -1557,26 +1593,22 @@ RSpec.describe Plurimath::Latex::Parser do
           Plurimath::Math::Symbol.new("&#xa0;&#xa0;&#xa0;&#xa0;"),
           Plurimath::Math::Function::Base.new(
             Plurimath::Math::Symbol.new("c"),
-            Plurimath::Math::Symbol.new("d"),
+            Plurimath::Math::Symbol.new("d")
           ),
           Plurimath::Math::Symbol.new("="),
           Plurimath::Math::Function::Over.new(
             Plurimath::Math::Formula.new([
               Plurimath::Math::Symbol.new("D"),
-              Plurimath::Math::Unicode.new("&#x27;")
+              Plurimath::Math::Unicode.new("&#x27;"),
             ]),
             Plurimath::Math::Formula.new([
               Plurimath::Math::Function::Over.new(
-                Plurimath::Math::Formula.new([
-                  Plurimath::Math::Number.new("1")
-                ]),
-                Plurimath::Math::Formula.new([
-                  Plurimath::Math::Number.new("2")
-                ]),
+                Plurimath::Math::Formula.new([Plurimath::Math::Number.new("1")]),
+                Plurimath::Math::Formula.new([Plurimath::Math::Number.new("2")])
               ),
               Plurimath::Math::Function::Base.new(
                 Plurimath::Math::Symbol.new("&#x3c1;"),
-                Plurimath::Math::Function::FontStyle.new(
+                Plurimath::Math::Function::FontStyle::Normal.new(
                   Plurimath::Math::Formula.new([
                     Plurimath::Math::Symbol.new("r"),
                     Plurimath::Math::Symbol.new("e"),
@@ -1587,7 +1619,7 @@ RSpec.describe Plurimath::Latex::Parser do
               ),
               Plurimath::Math::Function::PowerBase.new(
                 Plurimath::Math::Symbol.new("q"),
-                Plurimath::Math::Function::FontStyle.new(
+                Plurimath::Math::Function::FontStyle::Normal.new(
                   Plurimath::Math::Formula.new([
                     Plurimath::Math::Symbol.new("r"),
                     Plurimath::Math::Symbol.new("e"),
@@ -1595,11 +1627,11 @@ RSpec.describe Plurimath::Latex::Parser do
                   ]),
                   "textrm"
                 ),
-                Plurimath::Math::Number.new("2"),
+                Plurimath::Math::Number.new("2")
               ),
               Plurimath::Math::Function::Base.new(
                 Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Function::FontStyle.new(
+                Plurimath::Math::Function::FontStyle::Normal.new(
                   Plurimath::Math::Formula.new([
                     Plurimath::Math::Symbol.new("r"),
                     Plurimath::Math::Symbol.new("e"),
@@ -1612,42 +1644,34 @@ RSpec.describe Plurimath::Latex::Parser do
           ),
           Plurimath::Math::Symbol.new("&#xa0;&#xa0;&#xa0;&#xa0;"),
           Plurimath::Math::Function::Base.new(
-            Plurimath::Math::Function::Vec.new(
-              Plurimath::Math::Symbol.new("c")
-            ),
+            Plurimath::Math::Function::Vec.new(Plurimath::Math::Symbol.new("c")),
             Plurimath::Math::Symbol.new("m")
           ),
           Plurimath::Math::Symbol.new("="),
           Plurimath::Math::Function::Over.new(
             Plurimath::Math::Formula.new([
-              Plurimath::Math::Function::Vec.new(
-                Plurimath::Math::Symbol.new("M")
-              ),
-              Plurimath::Math::Unicode.new("&#x27;")
+              Plurimath::Math::Function::Vec.new(Plurimath::Math::Symbol.new("M")),
+              Plurimath::Math::Unicode.new("&#x27;"),
             ]),
             Plurimath::Math::Formula.new([
               Plurimath::Math::Function::Over.new(
-                Plurimath::Math::Formula.new([
-                  Plurimath::Math::Number.new("1")
-                ]),
-                Plurimath::Math::Formula.new([
-                  Plurimath::Math::Number.new("2")
-                ]),
+                Plurimath::Math::Formula.new([Plurimath::Math::Number.new("1")]),
+                Plurimath::Math::Formula.new([Plurimath::Math::Number.new("2")])
               ),
               Plurimath::Math::Function::Base.new(
                 Plurimath::Math::Symbol.new("&#x3c1;"),
-                Plurimath::Math::Function::FontStyle.new(
+                Plurimath::Math::Function::FontStyle::Normal.new(
                   Plurimath::Math::Formula.new([
                     Plurimath::Math::Symbol.new("r"),
                     Plurimath::Math::Symbol.new("e"),
                     Plurimath::Math::Symbol.new("f"),
                   ]),
                   "textrm"
-                ),
+                )
               ),
               Plurimath::Math::Function::PowerBase.new(
                 Plurimath::Math::Symbol.new("q"),
-                Plurimath::Math::Function::FontStyle.new(
+                Plurimath::Math::Function::FontStyle::Normal.new(
                   Plurimath::Math::Formula.new([
                     Plurimath::Math::Symbol.new("r"),
                     Plurimath::Math::Symbol.new("e"),
@@ -1659,7 +1683,7 @@ RSpec.describe Plurimath::Latex::Parser do
               ),
               Plurimath::Math::Function::PowerBase.new(
                 Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Function::FontStyle.new(
+                Plurimath::Math::Function::FontStyle::Normal.new(
                   Plurimath::Math::Formula.new([
                     Plurimath::Math::Symbol.new("r"),
                     Plurimath::Math::Symbol.new("e"),
@@ -1669,9 +1693,9 @@ RSpec.describe Plurimath::Latex::Parser do
                 ),
                 Plurimath::Math::Number.new("2")
               ),
-            ]),
+            ])
           ),
-          Plurimath::Math::Symbol.new(",")
+          Plurimath::Math::Symbol.new(","),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -1689,14 +1713,14 @@ RSpec.describe Plurimath::Latex::Parser do
           Plurimath::Math::Symbol.new("="),
           Plurimath::Math::Function::Base.new(
             Plurimath::Math::Symbol.new("k"),
-            Plurimath::Math::Function::FontStyle.new(
+            Plurimath::Math::Function::FontStyle::Normal.new(
               Plurimath::Math::Formula.new([
                 Plurimath::Math::Symbol.new("r"),
                 Plurimath::Math::Symbol.new("e"),
                 Plurimath::Math::Symbol.new("f"),
               ]),
               "textrm"
-            ),
+            )
           ),
           Plurimath::Math::Function::Power.new(
             Plurimath::Math::Formula.new([
@@ -1705,15 +1729,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Symbol.new("T"),
                 Plurimath::Math::Function::Base.new(
                   Plurimath::Math::Symbol.new("T"),
-                  Plurimath::Math::Function::FontStyle.new(
+                  Plurimath::Math::Function::FontStyle::Normal.new(
                     Plurimath::Math::Formula.new([
                       Plurimath::Math::Symbol.new("r"),
                       Plurimath::Math::Symbol.new("e"),
                       Plurimath::Math::Symbol.new("f"),
                     ]),
                     "textrm"
-                  ),
-                ),
+                  )
+                )
               ),
               Plurimath::Math::Function::Right.new(")"),
             ]),
@@ -1721,25 +1745,25 @@ RSpec.describe Plurimath::Latex::Parser do
               Plurimath::Math::Number.new("3"),
               Plurimath::Math::Symbol.new("/"),
               Plurimath::Math::Number.new("2"),
-            ]),
+            ])
           ),
           Plurimath::Math::Function::Frac.new(
             Plurimath::Math::Formula.new([
               Plurimath::Math::Function::Base.new(
                 Plurimath::Math::Symbol.new("T"),
-                Plurimath::Math::Function::FontStyle.new(
+                Plurimath::Math::Function::FontStyle::Normal.new(
                   Plurimath::Math::Formula.new([
                     Plurimath::Math::Symbol.new("r"),
                     Plurimath::Math::Symbol.new("e"),
                     Plurimath::Math::Symbol.new("f"),
                   ]),
                   "textrm"
-                ),
+                )
               ),
               Plurimath::Math::Symbol.new("+"),
               Plurimath::Math::Function::Base.new(
                 Plurimath::Math::Symbol.new("T"),
-                Plurimath::Math::Symbol.new("s"),
+                Plurimath::Math::Symbol.new("s")
               ),
             ]),
             Plurimath::Math::Formula.new([
@@ -1747,9 +1771,9 @@ RSpec.describe Plurimath::Latex::Parser do
               Plurimath::Math::Symbol.new("+"),
               Plurimath::Math::Function::Base.new(
                 Plurimath::Math::Symbol.new("T"),
-                Plurimath::Math::Symbol.new("s"),
-              )
-            ]),
+                Plurimath::Math::Symbol.new("s")
+              ),
+            ])
           ),
           Plurimath::Math::Symbol.new(","),
         ])
@@ -1844,14 +1868,14 @@ RSpec.describe Plurimath::Latex::Parser do
           Plurimath::Math::Symbol.new("="),
           Plurimath::Math::Function::Base.new(
             Plurimath::Math::Symbol.new("&#x3bc;"),
-            Plurimath::Math::Function::FontStyle.new(
+            Plurimath::Math::Function::FontStyle::Normal.new(
               Plurimath::Math::Formula.new([
                 Plurimath::Math::Symbol.new("r"),
                 Plurimath::Math::Symbol.new("e"),
                 Plurimath::Math::Symbol.new("f"),
               ]),
-              "textrm",
-            ),
+              "textrm"
+            )
           ),
           Plurimath::Math::Function::Power.new(
             Plurimath::Math::Formula.new([
@@ -1860,19 +1884,19 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Symbol.new("T"),
                 Plurimath::Math::Function::Base.new(
                   Plurimath::Math::Symbol.new("T"),
-                  Plurimath::Math::Function::FontStyle.new(
+                  Plurimath::Math::Function::FontStyle::Normal.new(
                     Plurimath::Math::Formula.new([
                       Plurimath::Math::Symbol.new("r"),
                       Plurimath::Math::Symbol.new("e"),
                       Plurimath::Math::Symbol.new("f"),
                     ]),
-                    "textrm",
-                  ),
-                ),
+                    "textrm"
+                  )
+                )
               ),
               Plurimath::Math::Function::Right.new(")"),
             ]),
-            Plurimath::Math::Symbol.new("n"),
+            Plurimath::Math::Symbol.new("n")
           ),
           Plurimath::Math::Symbol.new("."),
         ])
@@ -1893,14 +1917,14 @@ RSpec.describe Plurimath::Latex::Parser do
           Plurimath::Math::Symbol.new("="),
           Plurimath::Math::Function::Base.new(
             Plurimath::Math::Symbol.new("&#x3bc;"),
-            Plurimath::Math::Function::FontStyle.new(
+            Plurimath::Math::Function::FontStyle::Normal.new(
               Plurimath::Math::Formula.new([
                 Plurimath::Math::Symbol.new("r"),
                 Plurimath::Math::Symbol.new("e"),
                 Plurimath::Math::Symbol.new("f"),
               ]),
-              "textrm",
-            ),
+              "textrm"
+            )
           ),
           Plurimath::Math::Function::Power.new(
             Plurimath::Math::Formula.new([
@@ -1909,15 +1933,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Symbol.new("T"),
                 Plurimath::Math::Function::Base.new(
                   Plurimath::Math::Symbol.new("T"),
-                  Plurimath::Math::Function::FontStyle.new(
+                  Plurimath::Math::Function::FontStyle::Normal.new(
                     Plurimath::Math::Formula.new([
                       Plurimath::Math::Symbol.new("r"),
                       Plurimath::Math::Symbol.new("e"),
                       Plurimath::Math::Symbol.new("f"),
                     ]),
-                    "textrm",
-                  ),
-                ),
+                    "textrm"
+                  )
+                )
               ),
               Plurimath::Math::Function::Right.new(")"),
             ]),
@@ -1925,25 +1949,25 @@ RSpec.describe Plurimath::Latex::Parser do
               Plurimath::Math::Number.new("3"),
               Plurimath::Math::Symbol.new("/"),
               Plurimath::Math::Number.new("2"),
-            ]),
+            ])
           ),
           Plurimath::Math::Function::Frac.new(
             Plurimath::Math::Formula.new([
               Plurimath::Math::Function::Base.new(
                 Plurimath::Math::Symbol.new("T"),
-                Plurimath::Math::Function::FontStyle.new(
+                Plurimath::Math::Function::FontStyle::Normal.new(
                   Plurimath::Math::Formula.new([
                     Plurimath::Math::Symbol.new("r"),
                     Plurimath::Math::Symbol.new("e"),
                     Plurimath::Math::Symbol.new("f"),
                   ]),
-                  "textrm",
-                ),
+                  "textrm"
+                )
               ),
               Plurimath::Math::Symbol.new("+"),
               Plurimath::Math::Function::Base.new(
                 Plurimath::Math::Symbol.new("T"),
-                Plurimath::Math::Symbol.new("s"),
+                Plurimath::Math::Symbol.new("s")
               ),
             ]),
             Plurimath::Math::Formula.new([
@@ -1951,9 +1975,9 @@ RSpec.describe Plurimath::Latex::Parser do
               Plurimath::Math::Symbol.new("+"),
               Plurimath::Math::Function::Base.new(
                 Plurimath::Math::Symbol.new("T"),
-                Plurimath::Math::Symbol.new("s"),
+                Plurimath::Math::Symbol.new("s")
               ),
-            ]),
+            ])
           ),
           Plurimath::Math::Symbol.new(","),
         ])
@@ -2087,49 +2111,55 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Function::Left.new("("),
             Plurimath::Math::Function::Table::Array.new(
               [
-              Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("s"),
+                Plurimath::Math::Function::Tr.new([
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Symbol.new("s")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Number.new("0"),
+                Plurimath::Math::Function::Tr.new([
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Symbol.new("s")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Number.new("0"),
+                Plurimath::Math::Function::Tr.new([
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Symbol.new("s")],
+                    { columnalign: "center" }
+                  ),
                 ]),
-              ]),
-              Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Number.new("0"),
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("s"),
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Number.new("0"),
-                ]),
-              ]),
-              Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Number.new("0"),
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Number.new("0"),
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("s"),
-                ]),
-              ]),
-            ],
+              ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-              ]
+              nil,
+              {}
             ),
             Plurimath::Math::Function::Right.new(")"),
-          ])
+          ]),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -2153,58 +2183,70 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Function::Left.new("("),
             Plurimath::Math::Function::Table::Array.new(
               [
-              Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("s"),
-                    Plurimath::Math::Number.new("11"),
+                Plurimath::Math::Function::Tr.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("s"),
+                        Plurimath::Math::Number.new("11")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
                   ),
                 ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Number.new("0"),
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Number.new("0"),
-                ]),
-              ]),
-              Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Number.new("0"),
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("s"),
-                    Plurimath::Math::Number.new("22"),
+                Plurimath::Math::Function::Tr.new([
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("s"),
+                        Plurimath::Math::Number.new("22")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
                   ),
                 ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Number.new("0"),
-                ]),
-              ]),
-              Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Number.new("0"),
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Number.new("0"),
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("s"),
-                    Plurimath::Math::Number.new("33"),
+                Plurimath::Math::Function::Tr.new([
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("s"),
+                        Plurimath::Math::Number.new("33")
+                      ),
+                    ],
+                    { columnalign: "center" }
                   ),
                 ]),
-              ]),
-            ],
+              ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-              ]
+              nil,
+              {}
             ),
             Plurimath::Math::Function::Right.new(")"),
-          ])
+          ]),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -2316,58 +2358,75 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("s"),
-                      Plurimath::Math::Number.new("11"),
-                    ),
-                  ]),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("s"),
+                        Plurimath::Math::Number.new("11")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("s"),
-                      Plurimath::Math::Number.new("22"),
-                    ),
-                  ]),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("s"),
+                        Plurimath::Math::Number.new("22")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("s"),
-                      Plurimath::Math::Number.new("33"),
-                    ),
-                  ]),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("s"),
+                        Plurimath::Math::Number.new("33")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("s"),
-                      Plurimath::Math::Number.new("12"),
-                    ),
-                  ]),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("s"),
+                        Plurimath::Math::Number.new("12")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("s"),
-                      Plurimath::Math::Number.new("23"),
-                    ),
-                  ]),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("s"),
+                        Plurimath::Math::Number.new("23")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("s"),
-                      Plurimath::Math::Number.new("31"),
-                    ),
-                  ]),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("s"),
+                        Plurimath::Math::Number.new("31")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c")
-              ]
+              nil,
+              {}
             ),
             Plurimath::Math::Function::Right.new(")"),
           ]),
@@ -2414,185 +2473,245 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("1111")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("1122")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("1133")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("1112")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("1123")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("1131")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("1111")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("1122")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("1133")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("1112")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("1123")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("1131")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("2222")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("2233")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("2212")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("2223")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("2231")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("2222")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("2233")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("2212")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("2223")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("2231")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("3333")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("3312")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("3323")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("3331")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("3333")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("3312")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("3323")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("3331")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("1212")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("1223")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("1231")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("1212")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("1223")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("1231")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Mbox.new(
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("s"),
-                        Plurimath::Math::Symbol.new("y"),
-                        Plurimath::Math::Symbol.new("m"),
-                        Plurimath::Math::Symbol.new("m"),
-                        Plurimath::Math::Symbol.new("e"),
-                        Plurimath::Math::Symbol.new("t"),
-                        Plurimath::Math::Symbol.new("r"),
-                        Plurimath::Math::Symbol.new("i"),
-                        Plurimath::Math::Symbol.new("c"),
-                      ])
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("2323")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("2331")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Mbox.new(
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("s"),
+                          Plurimath::Math::Symbol.new("y"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("e"),
+                          Plurimath::Math::Symbol.new("t"),
+                          Plurimath::Math::Symbol.new("r"),
+                          Plurimath::Math::Symbol.new("i"),
+                          Plurimath::Math::Symbol.new("c"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("2323")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("2331")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("3131")
-                    )
-                  ])
-                ])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("3131")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -2775,315 +2894,374 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Number.new("1"),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("E"),
-                          Plurimath::Math::Number.new("11")
-                        )
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Number.new("1"),
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("E"),
+                            Plurimath::Math::Number.new("11")
+                          )
+                        ),
+                        "displaystyle"
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("-"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("-"),
+                        Plurimath::Math::Function::FontStyle.new(
+                          Plurimath::Math::Function::Frac.new(
+                            Plurimath::Math::Function::Base.new(
+                              Plurimath::Math::Symbol.new("&#x3bd;"),
+                              Plurimath::Math::Number.new("12")
+                            ),
+                            Plurimath::Math::Function::Base.new(
+                              Plurimath::Math::Symbol.new("E"),
+                              Plurimath::Math::Number.new("22")
+                            )
+                          ),
+                          "displaystyle"
+                        ),
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("-"),
+                        Plurimath::Math::Function::FontStyle.new(
+                          Plurimath::Math::Function::Frac.new(
+                            Plurimath::Math::Function::Base.new(
+                              Plurimath::Math::Symbol.new("&#x3bd;"),
+                              Plurimath::Math::Number.new("13")
+                            ),
+                            Plurimath::Math::Function::Base.new(
+                              Plurimath::Math::Symbol.new("E"),
+                              Plurimath::Math::Number.new("33")
+                            )
+                          ),
+                          "displaystyle"
+                        ),
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::FontStyle.new(
                         Plurimath::Math::Function::Frac.new(
                           Plurimath::Math::Function::Base.new(
                             Plurimath::Math::Symbol.new("&#x3bd;"),
-                            Plurimath::Math::Number.new("12")
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Number.new("1"),
+                              Plurimath::Math::Symbol.new(","),
+                              Plurimath::Math::Number.new("12"),
+                            ])
                           ),
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("G"),
+                            Plurimath::Math::Number.new("12")
+                          )
+                        ),
+                        "displaystyle"
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                ]),
+                Plurimath::Math::Function::Tr.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("["),
+                      Plurimath::Math::Number.new("3"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("]"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Number.new("1"),
                           Plurimath::Math::Function::Base.new(
                             Plurimath::Math::Symbol.new("E"),
                             Plurimath::Math::Number.new("22")
                           )
                         ),
                         "displaystyle"
-                      )
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("-"),
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("-"),
+                        Plurimath::Math::Function::FontStyle.new(
+                          Plurimath::Math::Function::Frac.new(
+                            Plurimath::Math::Function::Base.new(
+                              Plurimath::Math::Symbol.new("&#x3bd;"),
+                              Plurimath::Math::Number.new("23")
+                            ),
+                            Plurimath::Math::Function::Base.new(
+                              Plurimath::Math::Symbol.new("E"),
+                              Plurimath::Math::Number.new("22")
+                            )
+                          ),
+                          "displaystyle"
+                        ),
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::FontStyle.new(
                         Plurimath::Math::Function::Frac.new(
                           Plurimath::Math::Function::Base.new(
                             Plurimath::Math::Symbol.new("&#x3bd;"),
-                            Plurimath::Math::Number.new("13")
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Number.new("2"),
+                              Plurimath::Math::Symbol.new(","),
+                              Plurimath::Math::Number.new("12"),
+                            ])
                           ),
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("G"),
+                            Plurimath::Math::Number.new("12")
+                          )
+                        ),
+                        "displaystyle"
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                ]),
+                Plurimath::Math::Function::Tr.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("["),
+                      Plurimath::Math::Number.new("3"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("]"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Number.new("1"),
                           Plurimath::Math::Function::Base.new(
                             Plurimath::Math::Symbol.new("E"),
                             Plurimath::Math::Number.new("33")
                           )
                         ),
                         "displaystyle"
-                      )
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("&#x3bd;"),
-                          Plurimath::Math::Formula.new([
-                            Plurimath::Math::Number.new("1"),
-                            Plurimath::Math::Symbol.new(","),
-                            Plurimath::Math::Number.new("12")
-                          ])
-                        ),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("G"),
-                          Plurimath::Math::Number.new("12")
-                        )
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
-                ]),
-                Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("["),
-                    Plurimath::Math::Number.new("3"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("]")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Number.new("1"),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("E"),
-                          Plurimath::Math::Number.new("22")
-                        )
-                      ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("-"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::FontStyle.new(
                         Plurimath::Math::Function::Frac.new(
                           Plurimath::Math::Function::Base.new(
                             Plurimath::Math::Symbol.new("&#x3bd;"),
-                            Plurimath::Math::Number.new("23")
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Number.new("3"),
+                              Plurimath::Math::Symbol.new(","),
+                              Plurimath::Math::Number.new("12"),
+                            ])
                           ),
                           Plurimath::Math::Function::Base.new(
-                            Plurimath::Math::Symbol.new("E"),
-                            Plurimath::Math::Number.new("22")
+                            Plurimath::Math::Symbol.new("G"),
+                            Plurimath::Math::Number.new("12")
                           )
                         ),
                         "displaystyle"
-                      )
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("&#x3bd;"),
-                          Plurimath::Math::Formula.new([
-                            Plurimath::Math::Number.new("2"),
-                            Plurimath::Math::Symbol.new(","),
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                ]),
+                Plurimath::Math::Function::Tr.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("["),
+                      Plurimath::Math::Number.new("3"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("]"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Number.new("1"),
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("G"),
                             Plurimath::Math::Number.new("12")
-                          ])
+                          )
                         ),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("G"),
-                          Plurimath::Math::Number.new("12")
-                        )
+                        "displaystyle"
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("["),
-                    Plurimath::Math::Number.new("3"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("]")
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Number.new("1"),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("E"),
-                          Plurimath::Math::Number.new("33")
-                        )
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("["),
+                      Plurimath::Math::Number.new("3"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("]"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Mbox.new(
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("s"),
+                          Plurimath::Math::Symbol.new("y"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("e"),
+                          Plurimath::Math::Symbol.new("t"),
+                          Plurimath::Math::Symbol.new("r"),
+                          Plurimath::Math::Symbol.new("i"),
+                          Plurimath::Math::Symbol.new("c"),
+                        ])
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("&#x3bd;"),
-                          Plurimath::Math::Formula.new([
-                            Plurimath::Math::Number.new("3"),
-                            Plurimath::Math::Symbol.new(","),
-                            Plurimath::Math::Number.new("12")
-                          ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Number.new("1"),
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("G"),
+                            Plurimath::Math::Number.new("23")
+                          )
                         ),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("G"),
-                          Plurimath::Math::Number.new("12")
-                        )
+                        "displaystyle"
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
-                ]),
-                Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("["),
-                    Plurimath::Math::Number.new("3"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("]")
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Number.new("1"),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("G"),
-                          Plurimath::Math::Number.new("12")
-                        )
-                      ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
-                ]),
-                Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("["),
-                    Plurimath::Math::Number.new("3"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("]")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Mbox.new(
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("s"),
-                        Plurimath::Math::Symbol.new("y"),
-                        Plurimath::Math::Symbol.new("m"),
-                        Plurimath::Math::Symbol.new("m"),
-                        Plurimath::Math::Symbol.new("e"),
-                        Plurimath::Math::Symbol.new("t"),
-                        Plurimath::Math::Symbol.new("r"),
-                        Plurimath::Math::Symbol.new("i"),
-                        Plurimath::Math::Symbol.new("c")
-                      ])
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Number.new("1"),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("G"),
-                          Plurimath::Math::Number.new("23")
-                        )
-                      ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("&#x3bd;"),
-                          Plurimath::Math::Formula.new([
-                            Plurimath::Math::Number.new("23"),
-                            Plurimath::Math::Symbol.new(","),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("&#x3bd;"),
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Number.new("23"),
+                              Plurimath::Math::Symbol.new(","),
+                              Plurimath::Math::Number.new("31"),
+                            ])
+                          ),
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("G"),
                             Plurimath::Math::Number.new("31")
-                          ])
+                          )
                         ),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("G"),
-                          Plurimath::Math::Number.new("31")
-                        )
+                        "displaystyle"
                       ),
-                      "displaystyle"
-                    )
-                  ])
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("["),
-                    Plurimath::Math::Number.new("3"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("]")
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Number.new("1"),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("G"),
-                          Plurimath::Math::Number.new("31")
-                        )
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("["),
+                      Plurimath::Math::Number.new("3"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("]"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Number.new("1"),
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("G"),
+                            Plurimath::Math::Number.new("31")
+                          )
+                        ),
+                        "displaystyle"
                       ),
-                      "displaystyle"
-                    )
-                  ])
-                ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c")
-              ]
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -3132,251 +3310,302 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Number.new("1"),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("E"),
-                          Plurimath::Math::Number.new("11")
-                        )
-                      ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("-"),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::FontStyle.new(
                         Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Number.new("1"),
                           Plurimath::Math::Function::Base.new(
-                            Plurimath::Math::Symbol.new("&#x3bd;"),
-                            Plurimath::Math::Number.new("12")
+                            Plurimath::Math::Symbol.new("E"),
+                            Plurimath::Math::Number.new("11")
+                          )
+                        ),
+                        "displaystyle"
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("-"),
+                        Plurimath::Math::Function::FontStyle.new(
+                          Plurimath::Math::Function::Frac.new(
+                            Plurimath::Math::Function::Base.new(
+                              Plurimath::Math::Symbol.new("&#x3bd;"),
+                              Plurimath::Math::Number.new("12")
+                            ),
+                            Plurimath::Math::Function::Base.new(
+                              Plurimath::Math::Symbol.new("E"),
+                              Plurimath::Math::Number.new("22")
+                            )
                           ),
+                          "displaystyle"
+                        ),
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("-"),
+                        Plurimath::Math::Function::FontStyle.new(
+                          Plurimath::Math::Function::Frac.new(
+                            Plurimath::Math::Function::Base.new(
+                              Plurimath::Math::Symbol.new("&#x3bd;"),
+                              Plurimath::Math::Number.new("13")
+                            ),
+                            Plurimath::Math::Function::Base.new(
+                              Plurimath::Math::Symbol.new("E"),
+                              Plurimath::Math::Number.new("33")
+                            )
+                          ),
+                          "displaystyle"
+                        ),
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                ]),
+                Plurimath::Math::Function::Tr.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("["),
+                      Plurimath::Math::Number.new("3"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("]"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Number.new("1"),
                           Plurimath::Math::Function::Base.new(
                             Plurimath::Math::Symbol.new("E"),
                             Plurimath::Math::Number.new("22")
                           )
                         ),
                         "displaystyle"
-                      )
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("-"),
-                      Plurimath::Math::Function::FontStyle.new(
-                        Plurimath::Math::Function::Frac.new(
-                          Plurimath::Math::Function::Base.new(
-                            Plurimath::Math::Symbol.new("&#x3bd;"),
-                            Plurimath::Math::Number.new("13")
-                          ),
-                          Plurimath::Math::Function::Base.new(
-                            Plurimath::Math::Symbol.new("E"),
-                            Plurimath::Math::Number.new("33")
-                          )
-                        ),
-                        "displaystyle"
-                      )
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
-                ]),
-                Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("["),
-                    Plurimath::Math::Number.new("3"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("]")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Number.new("1"),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("E"),
-                          Plurimath::Math::Number.new("22")
-                        )
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("-"),
-                      Plurimath::Math::Function::FontStyle.new(
-                        Plurimath::Math::Function::Frac.new(
-                          Plurimath::Math::Function::Base.new(
-                            Plurimath::Math::Symbol.new("&#x3bd;"),
-                            Plurimath::Math::Number.new("23")
-                          ),
-                          Plurimath::Math::Function::Base.new(
-                            Plurimath::Math::Symbol.new("E"),
-                            Plurimath::Math::Number.new("33")
-                          )
-                        ),
-                        "displaystyle"
-                      )
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
-                ]),
-                Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("["),
-                    Plurimath::Math::Number.new("3"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("]")
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Number.new("1"),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("E"),
-                          Plurimath::Math::Number.new("33")
-                        )
-                      ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
-                ]),
-                Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("["),
-                    Plurimath::Math::Number.new("3"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("]")
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Number.new("1"),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("G"),
-                          Plurimath::Math::Number.new("12")
-                        )
-                      ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
-                ]),
-                Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("["),
-                    Plurimath::Math::Number.new("3"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("]")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Mbox.new(
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("s"),
-                        Plurimath::Math::Symbol.new("y"),
-                        Plurimath::Math::Symbol.new("m"),
-                        Plurimath::Math::Symbol.new("m"),
-                        Plurimath::Math::Symbol.new("e"),
-                        Plurimath::Math::Symbol.new("t"),
-                        Plurimath::Math::Symbol.new("r"),
-                        Plurimath::Math::Symbol.new("i"),
-                        Plurimath::Math::Symbol.new("c")
-                      ])
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Number.new("1"),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("G"),
-                          Plurimath::Math::Number.new("23")
-                        )
-                      ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
+                        Plurimath::Math::Symbol.new("-"),
+                        Plurimath::Math::Function::FontStyle.new(
+                          Plurimath::Math::Function::Frac.new(
+                            Plurimath::Math::Function::Base.new(
+                              Plurimath::Math::Symbol.new("&#x3bd;"),
+                              Plurimath::Math::Number.new("23")
+                            ),
+                            Plurimath::Math::Function::Base.new(
+                              Plurimath::Math::Symbol.new("E"),
+                              Plurimath::Math::Number.new("33")
+                            )
+                          ),
+                          "displaystyle"
+                        ),
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("["),
-                    Plurimath::Math::Number.new("3"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("]")
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Number.new("1"),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("G"),
-                          Plurimath::Math::Number.new("31")
-                        )
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("["),
+                      Plurimath::Math::Number.new("3"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("]"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Number.new("1"),
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("E"),
+                            Plurimath::Math::Number.new("33")
+                          )
+                        ),
+                        "displaystyle"
                       ),
-                      "displaystyle"
-                    )
-                  ])
-                ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                ]),
+                Plurimath::Math::Function::Tr.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("["),
+                      Plurimath::Math::Number.new("3"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("]"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Number.new("1"),
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("G"),
+                            Plurimath::Math::Number.new("12")
+                          )
+                        ),
+                        "displaystyle"
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                ]),
+                Plurimath::Math::Function::Tr.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("["),
+                      Plurimath::Math::Number.new("3"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("]"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Mbox.new(
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("s"),
+                          Plurimath::Math::Symbol.new("y"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("e"),
+                          Plurimath::Math::Symbol.new("t"),
+                          Plurimath::Math::Symbol.new("r"),
+                          Plurimath::Math::Symbol.new("i"),
+                          Plurimath::Math::Symbol.new("c"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Number.new("1"),
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("G"),
+                            Plurimath::Math::Number.new("23")
+                          )
+                        ),
+                        "displaystyle"
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                ]),
+                Plurimath::Math::Function::Tr.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("["),
+                      Plurimath::Math::Number.new("3"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("]"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Number.new("1"),
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("G"),
+                            Plurimath::Math::Number.new("31")
+                          )
+                        ),
+                        "displaystyle"
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c")
-              ]
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -3472,287 +3701,338 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Number.new("1"),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("E"),
-                          Plurimath::Math::Formula.new([
-                            Plurimath::Math::Symbol.new("l"),
-                            Plurimath::Math::Symbol.new("l")
-                          ])
-                        )
-                      ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("-"),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::FontStyle.new(
                         Plurimath::Math::Function::Frac.new(
-                          Plurimath::Math::Function::Base.new(
-                            Plurimath::Math::Symbol.new("&#x3bd;"),
-                            Plurimath::Math::Formula.new([
-                              Plurimath::Math::Symbol.new("t"),
-                              Plurimath::Math::Symbol.new("l")
-                            ])
-                          ),
+                          Plurimath::Math::Number.new("1"),
                           Plurimath::Math::Function::Base.new(
                             Plurimath::Math::Symbol.new("E"),
                             Plurimath::Math::Formula.new([
-                              Plurimath::Math::Symbol.new("t"),
-                              Plurimath::Math::Symbol.new("t")
+                              Plurimath::Math::Symbol.new("l"),
+                              Plurimath::Math::Symbol.new("l"),
                             ])
                           )
                         ),
                         "displaystyle"
-                      )
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("-"),
-                      Plurimath::Math::Function::FontStyle.new(
-                        Plurimath::Math::Function::Frac.new(
-                          Plurimath::Math::Function::Base.new(
-                            Plurimath::Math::Symbol.new("&#x3bd;"),
-                            Plurimath::Math::Formula.new([
-                              Plurimath::Math::Symbol.new("t"),
-                              Plurimath::Math::Symbol.new("l")
-                            ])
-                          ),
-                          Plurimath::Math::Function::Base.new(
-                            Plurimath::Math::Symbol.new("E"),
-                            Plurimath::Math::Formula.new([
-                              Plurimath::Math::Symbol.new("t"),
-                              Plurimath::Math::Symbol.new("t")
-                            ])
-                          )
-                        ),
-                        "displaystyle"
-                      )
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
-                ]),
-                Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("["),
-                    Plurimath::Math::Number.new("3"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("]")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Number.new("1"),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("E"),
-                          Plurimath::Math::Formula.new([
-                            Plurimath::Math::Symbol.new("t"),
-                            Plurimath::Math::Symbol.new("t")
-                          ])
-                        )
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("-"),
-                      Plurimath::Math::Function::FontStyle.new(
-                        Plurimath::Math::Function::Frac.new(
-                          Plurimath::Math::Function::Base.new(
-                            Plurimath::Math::Symbol.new("&#x3bd;"),
-                            Plurimath::Math::Formula.new([
-                              Plurimath::Math::Symbol.new("t"),
-                              Plurimath::Math::Symbol.new("t")
-                            ])
-                          ),
-                          Plurimath::Math::Function::Base.new(
-                            Plurimath::Math::Symbol.new("E"),
-                            Plurimath::Math::Formula.new([
-                              Plurimath::Math::Symbol.new("t"),
-                              Plurimath::Math::Symbol.new("t")
-                            ])
-                          )
-                        ),
-                        "displaystyle"
-                      )
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
-                ]),
-                Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("["),
-                    Plurimath::Math::Number.new("3"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("]")
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Number.new("1"),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("E"),
-                          Plurimath::Math::Formula.new([
-                            Plurimath::Math::Symbol.new("t"),
-                            Plurimath::Math::Symbol.new("t")
-                          ])
-                        )
-                      ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
-                ]),
-                Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("["),
-                    Plurimath::Math::Number.new("3"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("]")
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Number.new("1"),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("G"),
-                          Plurimath::Math::Formula.new([
-                            Plurimath::Math::Symbol.new("l"),
-                            Plurimath::Math::Symbol.new("t")
-                          ])
-                        )
-                      ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
-                ]),
-                Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("["),
-                    Plurimath::Math::Number.new("3"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("]")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Mbox.new(
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("s"),
-                        Plurimath::Math::Symbol.new("y"),
-                        Plurimath::Math::Symbol.new("m"),
-                        Plurimath::Math::Symbol.new("m"),
-                        Plurimath::Math::Symbol.new("e"),
-                        Plurimath::Math::Symbol.new("t"),
-                        Plurimath::Math::Symbol.new("r"),
-                        Plurimath::Math::Symbol.new("i"),
-                        Plurimath::Math::Symbol.new("c")
-                      ])
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Number.new("1"),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("G"),
-                          Plurimath::Math::Formula.new([
-                            Plurimath::Math::Symbol.new("t"),
-                            Plurimath::Math::Symbol.new("t")
-                          ])
-                        )
-                      ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
+                        Plurimath::Math::Symbol.new("-"),
+                        Plurimath::Math::Function::FontStyle.new(
+                          Plurimath::Math::Function::Frac.new(
+                            Plurimath::Math::Function::Base.new(
+                              Plurimath::Math::Symbol.new("&#x3bd;"),
+                              Plurimath::Math::Formula.new([
+                                Plurimath::Math::Symbol.new("t"),
+                                Plurimath::Math::Symbol.new("l"),
+                              ])
+                            ),
+                            Plurimath::Math::Function::Base.new(
+                              Plurimath::Math::Symbol.new("E"),
+                              Plurimath::Math::Formula.new([
+                                Plurimath::Math::Symbol.new("t"),
+                                Plurimath::Math::Symbol.new("t"),
+                              ])
+                            )
+                          ),
+                          "displaystyle"
+                        ),
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("-"),
+                        Plurimath::Math::Function::FontStyle.new(
+                          Plurimath::Math::Function::Frac.new(
+                            Plurimath::Math::Function::Base.new(
+                              Plurimath::Math::Symbol.new("&#x3bd;"),
+                              Plurimath::Math::Formula.new([
+                                Plurimath::Math::Symbol.new("t"),
+                                Plurimath::Math::Symbol.new("l"),
+                              ])
+                            ),
+                            Plurimath::Math::Function::Base.new(
+                              Plurimath::Math::Symbol.new("E"),
+                              Plurimath::Math::Formula.new([
+                                Plurimath::Math::Symbol.new("t"),
+                                Plurimath::Math::Symbol.new("t"),
+                              ])
+                            )
+                          ),
+                          "displaystyle"
+                        ),
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("["),
-                    Plurimath::Math::Number.new("3"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("]")
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Number.new("1"),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("G"),
-                          Plurimath::Math::Formula.new([
-                            Plurimath::Math::Symbol.new("l"),
-                            Plurimath::Math::Symbol.new("t")
-                          ])
-                        )
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("["),
+                      Plurimath::Math::Number.new("3"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("]"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Number.new("1"),
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("E"),
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("t"),
+                              Plurimath::Math::Symbol.new("t"),
+                            ])
+                          )
+                        ),
+                        "displaystyle"
                       ),
-                      "displaystyle"
-                    )
-                  ])
-                ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("-"),
+                        Plurimath::Math::Function::FontStyle.new(
+                          Plurimath::Math::Function::Frac.new(
+                            Plurimath::Math::Function::Base.new(
+                              Plurimath::Math::Symbol.new("&#x3bd;"),
+                              Plurimath::Math::Formula.new([
+                                Plurimath::Math::Symbol.new("t"),
+                                Plurimath::Math::Symbol.new("t"),
+                              ])
+                            ),
+                            Plurimath::Math::Function::Base.new(
+                              Plurimath::Math::Symbol.new("E"),
+                              Plurimath::Math::Formula.new([
+                                Plurimath::Math::Symbol.new("t"),
+                                Plurimath::Math::Symbol.new("t"),
+                              ])
+                            )
+                          ),
+                          "displaystyle"
+                        ),
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                ]),
+                Plurimath::Math::Function::Tr.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("["),
+                      Plurimath::Math::Number.new("3"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("]"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Number.new("1"),
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("E"),
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("t"),
+                              Plurimath::Math::Symbol.new("t"),
+                            ])
+                          )
+                        ),
+                        "displaystyle"
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                ]),
+                Plurimath::Math::Function::Tr.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("["),
+                      Plurimath::Math::Number.new("3"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("]"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Number.new("1"),
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("G"),
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("l"),
+                              Plurimath::Math::Symbol.new("t"),
+                            ])
+                          )
+                        ),
+                        "displaystyle"
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                ]),
+                Plurimath::Math::Function::Tr.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("["),
+                      Plurimath::Math::Number.new("3"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("]"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Mbox.new(
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("s"),
+                          Plurimath::Math::Symbol.new("y"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("e"),
+                          Plurimath::Math::Symbol.new("t"),
+                          Plurimath::Math::Symbol.new("r"),
+                          Plurimath::Math::Symbol.new("i"),
+                          Plurimath::Math::Symbol.new("c"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Number.new("1"),
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("G"),
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("t"),
+                              Plurimath::Math::Symbol.new("t"),
+                            ])
+                          )
+                        ),
+                        "displaystyle"
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                ]),
+                Plurimath::Math::Function::Tr.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("["),
+                      Plurimath::Math::Number.new("3"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("]"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Number.new("1"),
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("G"),
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("l"),
+                              Plurimath::Math::Symbol.new("t"),
+                            ])
+                          )
+                        ),
+                        "displaystyle"
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c")
-              ]
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -3801,287 +4081,338 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Number.new("1"),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("E"),
-                          Plurimath::Math::Formula.new([
-                            Plurimath::Math::Symbol.new("l"),
-                            Plurimath::Math::Symbol.new("l")
-                          ])
-                        )
-                      ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("-"),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::FontStyle.new(
                         Plurimath::Math::Function::Frac.new(
-                          Plurimath::Math::Function::Base.new(
-                            Plurimath::Math::Symbol.new("&#x3bd;"),
-                            Plurimath::Math::Formula.new([
-                              Plurimath::Math::Symbol.new("t"),
-                              Plurimath::Math::Symbol.new("l")
-                            ])
-                          ),
+                          Plurimath::Math::Number.new("1"),
                           Plurimath::Math::Function::Base.new(
                             Plurimath::Math::Symbol.new("E"),
                             Plurimath::Math::Formula.new([
-                              Plurimath::Math::Symbol.new("t"),
-                              Plurimath::Math::Symbol.new("t")
+                              Plurimath::Math::Symbol.new("l"),
+                              Plurimath::Math::Symbol.new("l"),
                             ])
                           )
                         ),
                         "displaystyle"
-                      )
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("-"),
-                      Plurimath::Math::Function::FontStyle.new(
-                        Plurimath::Math::Function::Frac.new(
-                          Plurimath::Math::Function::Base.new(
-                            Plurimath::Math::Symbol.new("&#x3bd;"),
-                            Plurimath::Math::Formula.new([
-                              Plurimath::Math::Symbol.new("t"),
-                              Plurimath::Math::Symbol.new("l")
-                            ])
-                          ),
-                          Plurimath::Math::Function::Base.new(
-                            Plurimath::Math::Symbol.new("E"),
-                            Plurimath::Math::Formula.new([
-                              Plurimath::Math::Symbol.new("t"),
-                              Plurimath::Math::Symbol.new("t")
-                            ])
-                          )
-                        ),
-                        "displaystyle"
-                      )
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
-                ]),
-                Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("["),
-                    Plurimath::Math::Number.new("3"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("]")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Number.new("1"),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("E"),
-                          Plurimath::Math::Formula.new([
-                            Plurimath::Math::Symbol.new("t"),
-                            Plurimath::Math::Symbol.new("t")
-                          ])
-                        )
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("-"),
-                      Plurimath::Math::Function::FontStyle.new(
-                        Plurimath::Math::Function::Frac.new(
-                          Plurimath::Math::Function::Base.new(
-                            Plurimath::Math::Symbol.new("&#x3bd;"),
-                            Plurimath::Math::Formula.new([
-                              Plurimath::Math::Symbol.new("t"),
-                              Plurimath::Math::Symbol.new("t")
-                            ])
-                          ),
-                          Plurimath::Math::Function::Base.new(
-                            Plurimath::Math::Symbol.new("E"),
-                            Plurimath::Math::Formula.new([
-                              Plurimath::Math::Symbol.new("t"),
-                              Plurimath::Math::Symbol.new("t")
-                            ])
-                          )
-                        ),
-                        "displaystyle"
-                      )
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
-                ]),
-                Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("["),
-                    Plurimath::Math::Number.new("3"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("]")
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Number.new("1"),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("E"),
-                          Plurimath::Math::Formula.new([
-                            Plurimath::Math::Symbol.new("t"),
-                            Plurimath::Math::Symbol.new("t")
-                          ])
-                        )
-                      ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
-                ]),
-                Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("["),
-                    Plurimath::Math::Number.new("3"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("]")
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Number.new("1"),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("G"),
-                          Plurimath::Math::Formula.new([
-                            Plurimath::Math::Symbol.new("l"),
-                            Plurimath::Math::Symbol.new("t")
-                          ])
-                        )
-                      ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
-                ]),
-                Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("["),
-                    Plurimath::Math::Number.new("3"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("]")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Mbox.new(
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("s"),
-                        Plurimath::Math::Symbol.new("y"),
-                        Plurimath::Math::Symbol.new("m"),
-                        Plurimath::Math::Symbol.new("m"),
-                        Plurimath::Math::Symbol.new("e"),
-                        Plurimath::Math::Symbol.new("t"),
-                        Plurimath::Math::Symbol.new("r"),
-                        Plurimath::Math::Symbol.new("i"),
-                        Plurimath::Math::Symbol.new("c")
-                      ])
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Number.new("1"),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("G"),
-                          Plurimath::Math::Formula.new([
-                            Plurimath::Math::Symbol.new("t"),
-                            Plurimath::Math::Symbol.new("t")
-                          ])
-                        )
-                      ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
+                        Plurimath::Math::Symbol.new("-"),
+                        Plurimath::Math::Function::FontStyle.new(
+                          Plurimath::Math::Function::Frac.new(
+                            Plurimath::Math::Function::Base.new(
+                              Plurimath::Math::Symbol.new("&#x3bd;"),
+                              Plurimath::Math::Formula.new([
+                                Plurimath::Math::Symbol.new("t"),
+                                Plurimath::Math::Symbol.new("l"),
+                              ])
+                            ),
+                            Plurimath::Math::Function::Base.new(
+                              Plurimath::Math::Symbol.new("E"),
+                              Plurimath::Math::Formula.new([
+                                Plurimath::Math::Symbol.new("t"),
+                                Plurimath::Math::Symbol.new("t"),
+                              ])
+                            )
+                          ),
+                          "displaystyle"
+                        ),
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("-"),
+                        Plurimath::Math::Function::FontStyle.new(
+                          Plurimath::Math::Function::Frac.new(
+                            Plurimath::Math::Function::Base.new(
+                              Plurimath::Math::Symbol.new("&#x3bd;"),
+                              Plurimath::Math::Formula.new([
+                                Plurimath::Math::Symbol.new("t"),
+                                Plurimath::Math::Symbol.new("l"),
+                              ])
+                            ),
+                            Plurimath::Math::Function::Base.new(
+                              Plurimath::Math::Symbol.new("E"),
+                              Plurimath::Math::Formula.new([
+                                Plurimath::Math::Symbol.new("t"),
+                                Plurimath::Math::Symbol.new("t"),
+                              ])
+                            )
+                          ),
+                          "displaystyle"
+                        ),
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("["),
-                    Plurimath::Math::Number.new("3"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("]")
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Number.new("1"),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("G"),
-                          Plurimath::Math::Formula.new([
-                            Plurimath::Math::Symbol.new("l"),
-                            Plurimath::Math::Symbol.new("t")
-                          ])
-                        )
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("["),
+                      Plurimath::Math::Number.new("3"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("]"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Number.new("1"),
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("E"),
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("t"),
+                              Plurimath::Math::Symbol.new("t"),
+                            ])
+                          )
+                        ),
+                        "displaystyle"
                       ),
-                      "displaystyle"
-                    )
-                  ])
-                ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("-"),
+                        Plurimath::Math::Function::FontStyle.new(
+                          Plurimath::Math::Function::Frac.new(
+                            Plurimath::Math::Function::Base.new(
+                              Plurimath::Math::Symbol.new("&#x3bd;"),
+                              Plurimath::Math::Formula.new([
+                                Plurimath::Math::Symbol.new("t"),
+                                Plurimath::Math::Symbol.new("t"),
+                              ])
+                            ),
+                            Plurimath::Math::Function::Base.new(
+                              Plurimath::Math::Symbol.new("E"),
+                              Plurimath::Math::Formula.new([
+                                Plurimath::Math::Symbol.new("t"),
+                                Plurimath::Math::Symbol.new("t"),
+                              ])
+                            )
+                          ),
+                          "displaystyle"
+                        ),
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                ]),
+                Plurimath::Math::Function::Tr.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("["),
+                      Plurimath::Math::Number.new("3"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("]"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Number.new("1"),
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("E"),
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("t"),
+                              Plurimath::Math::Symbol.new("t"),
+                            ])
+                          )
+                        ),
+                        "displaystyle"
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                ]),
+                Plurimath::Math::Function::Tr.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("["),
+                      Plurimath::Math::Number.new("3"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("]"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Number.new("1"),
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("G"),
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("l"),
+                              Plurimath::Math::Symbol.new("t"),
+                            ])
+                          )
+                        ),
+                        "displaystyle"
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                ]),
+                Plurimath::Math::Function::Tr.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("["),
+                      Plurimath::Math::Number.new("3"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("]"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Mbox.new(
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("s"),
+                          Plurimath::Math::Symbol.new("y"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("e"),
+                          Plurimath::Math::Symbol.new("t"),
+                          Plurimath::Math::Symbol.new("r"),
+                          Plurimath::Math::Symbol.new("i"),
+                          Plurimath::Math::Symbol.new("c"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Number.new("1"),
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("G"),
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("t"),
+                              Plurimath::Math::Symbol.new("t"),
+                            ])
+                          )
+                        ),
+                        "displaystyle"
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                ]),
+                Plurimath::Math::Function::Tr.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("["),
+                      Plurimath::Math::Number.new("3"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("]"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Number.new("1"),
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("G"),
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("l"),
+                              Plurimath::Math::Symbol.new("t"),
+                            ])
+                          )
+                        ),
+                        "displaystyle"
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c")
-              ]
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -4129,215 +4460,266 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Number.new("1"),
-                        Plurimath::Math::Symbol.new("E")
-                      ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("-"),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::FontStyle.new(
                         Plurimath::Math::Function::Frac.new(
-                          Plurimath::Math::Symbol.new("&#x3bd;"),
+                          Plurimath::Math::Number.new("1"),
                           Plurimath::Math::Symbol.new("E")
                         ),
                         "displaystyle"
-                      )
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("-"),
-                      Plurimath::Math::Function::FontStyle.new(
-                        Plurimath::Math::Function::Frac.new(
-                          Plurimath::Math::Symbol.new("&#x3bd;"),
-                          Plurimath::Math::Symbol.new("E")
-                        ),
-                        "displaystyle"
-                      )
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
-                ]),
-                Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("["),
-                    Plurimath::Math::Number.new("3"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("]")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Number.new("1"),
-                        Plurimath::Math::Symbol.new("E")
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("-"),
-                      Plurimath::Math::Function::FontStyle.new(
-                        Plurimath::Math::Function::Frac.new(
-                          Plurimath::Math::Symbol.new("&#x3bd;"),
-                          Plurimath::Math::Symbol.new("E")
-                        ),
-                        "displaystyle"
-                      )
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
-                ]),
-                Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("["),
-                    Plurimath::Math::Number.new("3"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("]")
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Number.new("1"),
-                        Plurimath::Math::Symbol.new("E")
-                      ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
-                ]),
-                Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("["),
-                    Plurimath::Math::Number.new("3"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("]")
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Number.new("1"),
-                        Plurimath::Math::Symbol.new("G")
-                      ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
-                ]),
-                Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("["),
-                    Plurimath::Math::Number.new("3"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("]")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Mbox.new(
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("s"),
-                        Plurimath::Math::Symbol.new("y"),
-                        Plurimath::Math::Symbol.new("m"),
-                        Plurimath::Math::Symbol.new("m"),
-                        Plurimath::Math::Symbol.new("e"),
-                        Plurimath::Math::Symbol.new("t"),
-                        Plurimath::Math::Symbol.new("r"),
-                        Plurimath::Math::Symbol.new("i"),
-                        Plurimath::Math::Symbol.new("c")
-                      ])
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Number.new("1"),
-                        Plurimath::Math::Symbol.new("G")
-                      ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
+                        Plurimath::Math::Symbol.new("-"),
+                        Plurimath::Math::Function::FontStyle.new(
+                          Plurimath::Math::Function::Frac.new(
+                            Plurimath::Math::Symbol.new("&#x3bd;"),
+                            Plurimath::Math::Symbol.new("E")
+                          ),
+                          "displaystyle"
+                        ),
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("-"),
+                        Plurimath::Math::Function::FontStyle.new(
+                          Plurimath::Math::Function::Frac.new(
+                            Plurimath::Math::Symbol.new("&#x3bd;"),
+                            Plurimath::Math::Symbol.new("E")
+                          ),
+                          "displaystyle"
+                        ),
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("["),
-                    Plurimath::Math::Number.new("3"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("]")
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Number.new("1"),
-                        Plurimath::Math::Symbol.new("G")
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("["),
+                      Plurimath::Math::Number.new("3"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("]"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Number.new("1"),
+                          Plurimath::Math::Symbol.new("E")
+                        ),
+                        "displaystyle"
                       ),
-                      "displaystyle"
-                    )
-                  ])
-                ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("-"),
+                        Plurimath::Math::Function::FontStyle.new(
+                          Plurimath::Math::Function::Frac.new(
+                            Plurimath::Math::Symbol.new("&#x3bd;"),
+                            Plurimath::Math::Symbol.new("E")
+                          ),
+                          "displaystyle"
+                        ),
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                ]),
+                Plurimath::Math::Function::Tr.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("["),
+                      Plurimath::Math::Number.new("3"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("]"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Number.new("1"),
+                          Plurimath::Math::Symbol.new("E")
+                        ),
+                        "displaystyle"
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                ]),
+                Plurimath::Math::Function::Tr.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("["),
+                      Plurimath::Math::Number.new("3"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("]"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Number.new("1"),
+                          Plurimath::Math::Symbol.new("G")
+                        ),
+                        "displaystyle"
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                ]),
+                Plurimath::Math::Function::Tr.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("["),
+                      Plurimath::Math::Number.new("3"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("]"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Mbox.new(
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("s"),
+                          Plurimath::Math::Symbol.new("y"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("e"),
+                          Plurimath::Math::Symbol.new("t"),
+                          Plurimath::Math::Symbol.new("r"),
+                          Plurimath::Math::Symbol.new("i"),
+                          Plurimath::Math::Symbol.new("c"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Number.new("1"),
+                          Plurimath::Math::Symbol.new("G")
+                        ),
+                        "displaystyle"
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                ]),
+                Plurimath::Math::Function::Tr.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("["),
+                      Plurimath::Math::Number.new("3"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("]"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Number.new("1"),
+                          Plurimath::Math::Symbol.new("G")
+                        ),
+                        "displaystyle"
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c")
-              ]
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -4365,64 +4747,81 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("&#x03b5;"),
-                      Plurimath::Math::Number.new("11")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("&#x03b5;"),
+                        Plurimath::Math::Number.new("11")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("&#x03b5;"),
-                      Plurimath::Math::Number.new("22")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("&#x03b5;"),
+                        Plurimath::Math::Number.new("22")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("&#x03b5;"),
-                      Plurimath::Math::Number.new("33")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("&#x03b5;"),
+                        Plurimath::Math::Number.new("33")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("2"),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("&#x03b5;"),
-                      Plurimath::Math::Number.new("12")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Number.new("2"),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("&#x03b5;"),
+                        Plurimath::Math::Number.new("12")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("2"),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("&#x03b5;"),
-                      Plurimath::Math::Number.new("23")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Number.new("2"),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("&#x03b5;"),
+                        Plurimath::Math::Number.new("23")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("2"),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Number.new("2"),
                       Plurimath::Math::Function::Base.new(
                         Plurimath::Math::Symbol.new("&#x03b5;"),
                         Plurimath::Math::Number.new("31")
-                      )
-                    ])
-                ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c")
-              ],
+              nil,
+              {}
             ),
             Plurimath::Math::Function::Right.new(")"),
-          ])
+          ]),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -4534,185 +4933,245 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("1111")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("1122")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("1133")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("1112")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("1123")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("1131")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("1111")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("1122")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("1133")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("1112")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("1123")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("1131")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("2222")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("2233")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("2212")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("2223")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("2231")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("2222")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("2233")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("2212")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("2223")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("2231")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("3333")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("3312")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("3323")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("3331")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("3333")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("3312")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("3323")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("3331")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("1212")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("1223")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("1231")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("1212")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("1223")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("1231")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Mbox.new(
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("s"),
-                        Plurimath::Math::Symbol.new("y"),
-                        Plurimath::Math::Symbol.new("m"),
-                        Plurimath::Math::Symbol.new("m"),
-                        Plurimath::Math::Symbol.new("e"),
-                        Plurimath::Math::Symbol.new("t"),
-                        Plurimath::Math::Symbol.new("r"),
-                        Plurimath::Math::Symbol.new("i"),
-                        Plurimath::Math::Symbol.new("c"),
-                      ])
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("2323")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("2331")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Mbox.new(
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("s"),
+                          Plurimath::Math::Symbol.new("y"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("e"),
+                          Plurimath::Math::Symbol.new("t"),
+                          Plurimath::Math::Symbol.new("r"),
+                          Plurimath::Math::Symbol.new("i"),
+                          Plurimath::Math::Symbol.new("c"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("2323")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("2331")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("3131")
-                    )
-                  ])
-                ])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("3131")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -4740,61 +5199,78 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("s"),
-                      Plurimath::Math::Number.new("11")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("s"),
+                        Plurimath::Math::Number.new("11")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("s"),
-                      Plurimath::Math::Number.new("22")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("s"),
+                        Plurimath::Math::Number.new("22")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("s"),
-                      Plurimath::Math::Number.new("33")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("s"),
+                        Plurimath::Math::Number.new("33")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("s"),
-                      Plurimath::Math::Number.new("12")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("s"),
+                        Plurimath::Math::Number.new("12")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("s"),
-                      Plurimath::Math::Number.new("23")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("s"),
+                        Plurimath::Math::Number.new("23")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("s"),
-                      Plurimath::Math::Number.new("31")
-                    )
-                  ])
-                ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("s"),
+                        Plurimath::Math::Number.new("31")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c")
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -4993,57 +5469,69 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("s"),
-                      Plurimath::Math::Number.new("11")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("s"),
+                        Plurimath::Math::Number.new("11")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("s"),
-                      Plurimath::Math::Number.new("22")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("s"),
+                        Plurimath::Math::Number.new("22")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("s"),
-                      Plurimath::Math::Number.new("33")
-                    )
-                  ])
-                ])
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("s"),
+                        Plurimath::Math::Number.new("33")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -5113,136 +5601,160 @@ RSpec.describe Plurimath::Latex::Parser do
           Plurimath::Math::Function::Table::Array.new(
             [
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Tilde.new(
-                    Plurimath::Math::Symbol.new("x")
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Symbol.new("x"),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("L"),
-                  Plurimath::Math::Symbol.new(",")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Tilde.new(
-                    Plurimath::Math::Symbol.new("u")
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Symbol.new("u"),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("c"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new(",")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Tilde.new(
-                    Plurimath::Math::Symbol.new("&#x3c1;")
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Symbol.new("&#x3c1;"),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Function::Base.new(
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Tilde.new(
+                      Plurimath::Math::Symbol.new("x")
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Symbol.new("x"),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Symbol.new("L"),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Tilde.new(
+                      Plurimath::Math::Symbol.new("u")
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Symbol.new("u"),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("c"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Tilde.new(
+                      Plurimath::Math::Symbol.new("&#x3c1;")
+                    ),
+                    Plurimath::Math::Symbol.new("="),
                     Plurimath::Math::Symbol.new("&#x3c1;"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new(",")
-                ])
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("&#x3c1;"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
               ]),
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Tilde.new(
-                    Plurimath::Math::Symbol.new("y")
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Symbol.new("y"),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("L"),
-                  Plurimath::Math::Symbol.new(",")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Tilde.new(
-                    Plurimath::Math::Symbol.new("v")
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Symbol.new("v"),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("c"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new(",")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Tilde.new(
-                    Plurimath::Math::Symbol.new("p")
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Symbol.new("p"),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("("),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("&#x3c1;"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Function::PowerBase.new(
-                    Plurimath::Math::Symbol.new("c"),
-                    Plurimath::Math::Symbol.new("&#x221e;"),
-                    Plurimath::Math::Number.new("2")
-                  ),
-                  Plurimath::Math::Symbol.new(")"),
-                  Plurimath::Math::Symbol.new(",")
-                ])
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Tilde.new(
+                      Plurimath::Math::Symbol.new("y")
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Symbol.new("y"),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Symbol.new("L"),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Tilde.new(
+                      Plurimath::Math::Symbol.new("v")
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Symbol.new("v"),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("c"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Tilde.new(
+                      Plurimath::Math::Symbol.new("p")
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Symbol.new("p"),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Symbol.new("("),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("&#x3c1;"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Function::PowerBase.new(
+                      Plurimath::Math::Symbol.new("c"),
+                      Plurimath::Math::Symbol.new("&#x221e;"),
+                      Plurimath::Math::Number.new("2")
+                    ),
+                    Plurimath::Math::Symbol.new(")"),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
               ]),
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Tilde.new(
-                    Plurimath::Math::Symbol.new("z")
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Symbol.new("z"),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("L"),
-                  Plurimath::Math::Symbol.new(","),
-                  Plurimath::Math::Symbol.new("&#x2001;")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Tilde.new(
-                    Plurimath::Math::Symbol.new("w")
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Symbol.new("w"),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("c"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new(","),
-                  Plurimath::Math::Symbol.new("&#x2001;")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Tilde.new(
-                    Plurimath::Math::Symbol.new("&#x3bc;")
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Symbol.new("&#x3bc;"),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Function::Base.new(
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Tilde.new(
+                      Plurimath::Math::Symbol.new("z")
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Symbol.new("z"),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Symbol.new("L"),
+                    Plurimath::Math::Symbol.new(","),
+                    Plurimath::Math::Symbol.new("&#x2001;"),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Tilde.new(
+                      Plurimath::Math::Symbol.new("w")
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Symbol.new("w"),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("c"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new(","),
+                    Plurimath::Math::Symbol.new("&#x2001;"),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Tilde.new(
+                      Plurimath::Math::Symbol.new("&#x3bc;")
+                    ),
+                    Plurimath::Math::Symbol.new("="),
                     Plurimath::Math::Symbol.new("&#x3bc;"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new(",")
-                ])
-              ])
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("&#x3bc;"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+              ]),
             ],
             nil,
-            [
-              Plurimath::Math::Symbol.new("c"),
-              Plurimath::Math::Symbol.new("c"),
-              Plurimath::Math::Symbol.new("c")
-            ]
-          )
+            nil,
+            {}
+          ),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -5387,317 +5899,341 @@ RSpec.describe Plurimath::Latex::Parser do
           Plurimath::Math::Function::Table::Array.new(
             [
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("x"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Unicode.new("&#x27;"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("r"),
-                        Plurimath::Math::Symbol.new("e"),
-                        Plurimath::Math::Symbol.new("f")
-                      ]),
-                      "textrm"
-                    )
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
+                Plurimath::Math::Function::Td.new(
+                  [
                     Plurimath::Math::Symbol.new("x"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("r"),
-                        Plurimath::Math::Symbol.new("e"),
-                        Plurimath::Math::Symbol.new("f")
-                      ]),
-                      "textrm"
-                    )
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("L"),
-                  Plurimath::Math::Symbol.new(",")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("u"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Unicode.new("&#x27;"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("r"),
-                        Plurimath::Math::Symbol.new("e"),
-                        Plurimath::Math::Symbol.new("f")
-                      ]),
-                      "textrm"
-                    )
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("u"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("r"),
-                        Plurimath::Math::Symbol.new("e"),
-                        Plurimath::Math::Symbol.new("f")
-                      ]),
-                      "textrm"
-                    )
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("("),
-                  Plurimath::Math::Symbol.new("L"),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("T"),
-                  Plurimath::Math::Symbol.new(")"),
-                  Plurimath::Math::Symbol.new(",")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("&#x3c1;"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Unicode.new("&#x27;"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("r"),
-                        Plurimath::Math::Symbol.new("e"),
-                        Plurimath::Math::Symbol.new("f")
-                      ]),
-                      "textrm"
-                    )
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("&#x3c1;"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("r"),
-                        Plurimath::Math::Symbol.new("e"),
-                        Plurimath::Math::Symbol.new("f")
-                      ]),
-                      "textrm"
-                    )
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("("),
-                  Plurimath::Math::Symbol.new("M"),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Function::Power.new(
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Unicode.new("&#x27;"),
+                      Plurimath::Math::Function::FontStyle::Normal.new(
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("r"),
+                          Plurimath::Math::Symbol.new("e"),
+                          Plurimath::Math::Symbol.new("f"),
+                        ]),
+                        "textrm"
+                      )
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("x"),
+                      Plurimath::Math::Function::FontStyle::Normal.new(
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("r"),
+                          Plurimath::Math::Symbol.new("e"),
+                          Plurimath::Math::Symbol.new("f"),
+                        ]),
+                        "textrm"
+                      )
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
                     Plurimath::Math::Symbol.new("L"),
-                    Plurimath::Math::Number.new("3")
-                  ),
-                  Plurimath::Math::Symbol.new(")"),
-                  Plurimath::Math::Symbol.new(",")
-                ])
-              ]),
-              Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("y"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Unicode.new("&#x27;"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("r"),
-                        Plurimath::Math::Symbol.new("e"),
-                        Plurimath::Math::Symbol.new("f")
-                      ]),
-                      "textrm"
-                    )
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("y"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("r"),
-                        Plurimath::Math::Symbol.new("e"),
-                        Plurimath::Math::Symbol.new("f")
-                      ]),
-                      "textrm"
-                    )
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("L"),
-                  Plurimath::Math::Symbol.new(",")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("v"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Unicode.new("&#x27;"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("r"),
-                        Plurimath::Math::Symbol.new("e"),
-                        Plurimath::Math::Symbol.new("f")
-                      ]),
-                      "textrm"
-                    )
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("v"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("r"),
-                        Plurimath::Math::Symbol.new("e"),
-                        Plurimath::Math::Symbol.new("f")
-                      ]),
-                      "textrm"
-                    )
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("("),
-                  Plurimath::Math::Symbol.new("L"),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("T"),
-                  Plurimath::Math::Symbol.new(")"),
-                  Plurimath::Math::Symbol.new(",")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("p"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Unicode.new("&#x27;"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("r"),
-                        Plurimath::Math::Symbol.new("e"),
-                        Plurimath::Math::Symbol.new("f")
-                      ]),
-                      "textrm"
-                    )
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("p"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("r"),
-                        Plurimath::Math::Symbol.new("e"),
-                        Plurimath::Math::Symbol.new("f")
-                      ]),
-                      "textrm"
-                    )
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("("),
-                  Plurimath::Math::Symbol.new("M"),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("("),
-                  Plurimath::Math::Symbol.new("L"),
-                  Plurimath::Math::Function::Power.new(
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Symbol.new("u"),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Unicode.new("&#x27;"),
+                      Plurimath::Math::Function::FontStyle::Normal.new(
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("r"),
+                          Plurimath::Math::Symbol.new("e"),
+                          Plurimath::Math::Symbol.new("f"),
+                        ]),
+                        "textrm"
+                      )
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("u"),
+                      Plurimath::Math::Function::FontStyle::Normal.new(
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("r"),
+                          Plurimath::Math::Symbol.new("e"),
+                          Plurimath::Math::Symbol.new("f"),
+                        ]),
+                        "textrm"
+                      )
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Symbol.new("("),
+                    Plurimath::Math::Symbol.new("L"),
+                    Plurimath::Math::Symbol.new("/"),
                     Plurimath::Math::Symbol.new("T"),
-                    Plurimath::Math::Number.new("2")
-                  ),
-                  Plurimath::Math::Symbol.new(")"),
-                  Plurimath::Math::Symbol.new(")")
-                ])
+                    Plurimath::Math::Symbol.new(")"),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Symbol.new("&#x3c1;"),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Unicode.new("&#x27;"),
+                      Plurimath::Math::Function::FontStyle::Normal.new(
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("r"),
+                          Plurimath::Math::Symbol.new("e"),
+                          Plurimath::Math::Symbol.new("f"),
+                        ]),
+                        "textrm"
+                      )
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("&#x3c1;"),
+                      Plurimath::Math::Function::FontStyle::Normal.new(
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("r"),
+                          Plurimath::Math::Symbol.new("e"),
+                          Plurimath::Math::Symbol.new("f"),
+                        ]),
+                        "textrm"
+                      )
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Symbol.new("("),
+                    Plurimath::Math::Symbol.new("M"),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Function::Power.new(
+                      Plurimath::Math::Symbol.new("L"),
+                      Plurimath::Math::Number.new("3")
+                    ),
+                    Plurimath::Math::Symbol.new(")"),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
               ]),
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("z"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Unicode.new("&#x27;"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("r"),
-                        Plurimath::Math::Symbol.new("e"),
-                        Plurimath::Math::Symbol.new("f")
-                      ]),
-                      "textrm"
-                    )
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Symbol.new("y"),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Unicode.new("&#x27;"),
+                      Plurimath::Math::Function::FontStyle::Normal.new(
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("r"),
+                          Plurimath::Math::Symbol.new("e"),
+                          Plurimath::Math::Symbol.new("f"),
+                        ]),
+                        "textrm"
+                      )
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("y"),
+                      Plurimath::Math::Function::FontStyle::Normal.new(
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("r"),
+                          Plurimath::Math::Symbol.new("e"),
+                          Plurimath::Math::Symbol.new("f"),
+                        ]),
+                        "textrm"
+                      )
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Symbol.new("L"),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Symbol.new("v"),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Unicode.new("&#x27;"),
+                      Plurimath::Math::Function::FontStyle::Normal.new(
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("r"),
+                          Plurimath::Math::Symbol.new("e"),
+                          Plurimath::Math::Symbol.new("f"),
+                        ]),
+                        "textrm"
+                      )
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("v"),
+                      Plurimath::Math::Function::FontStyle::Normal.new(
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("r"),
+                          Plurimath::Math::Symbol.new("e"),
+                          Plurimath::Math::Symbol.new("f"),
+                        ]),
+                        "textrm"
+                      )
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Symbol.new("("),
+                    Plurimath::Math::Symbol.new("L"),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Symbol.new("T"),
+                    Plurimath::Math::Symbol.new(")"),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Symbol.new("p"),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Unicode.new("&#x27;"),
+                      Plurimath::Math::Function::FontStyle::Normal.new(
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("r"),
+                          Plurimath::Math::Symbol.new("e"),
+                          Plurimath::Math::Symbol.new("f"),
+                        ]),
+                        "textrm"
+                      )
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("p"),
+                      Plurimath::Math::Function::FontStyle::Normal.new(
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("r"),
+                          Plurimath::Math::Symbol.new("e"),
+                          Plurimath::Math::Symbol.new("f"),
+                        ]),
+                        "textrm"
+                      )
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Symbol.new("("),
+                    Plurimath::Math::Symbol.new("M"),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Symbol.new("("),
+                    Plurimath::Math::Symbol.new("L"),
+                    Plurimath::Math::Function::Power.new(
+                      Plurimath::Math::Symbol.new("T"),
+                      Plurimath::Math::Number.new("2")
+                    ),
+                    Plurimath::Math::Symbol.new(")"),
+                    Plurimath::Math::Symbol.new(")"),
+                  ],
+                  { columnalign: "center" }
+                ),
+              ]),
+              Plurimath::Math::Function::Tr.new([
+                Plurimath::Math::Function::Td.new(
+                  [
                     Plurimath::Math::Symbol.new("z"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("r"),
-                        Plurimath::Math::Symbol.new("e"),
-                        Plurimath::Math::Symbol.new("f")
-                      ]),
-                      "textrm"
-                    )
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("L"),
-                  Plurimath::Math::Symbol.new(","),
-                  Plurimath::Math::Symbol.new("&#x2001;")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("w"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Unicode.new("&#x27;"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("r"),
-                        Plurimath::Math::Symbol.new("e"),
-                        Plurimath::Math::Symbol.new("f")
-                      ]),
-                      "textrm"
-                    )
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Unicode.new("&#x27;"),
+                      Plurimath::Math::Function::FontStyle::Normal.new(
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("r"),
+                          Plurimath::Math::Symbol.new("e"),
+                          Plurimath::Math::Symbol.new("f"),
+                        ]),
+                        "textrm"
+                      )
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("z"),
+                      Plurimath::Math::Function::FontStyle::Normal.new(
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("r"),
+                          Plurimath::Math::Symbol.new("e"),
+                          Plurimath::Math::Symbol.new("f"),
+                        ]),
+                        "textrm"
+                      )
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Symbol.new("L"),
+                    Plurimath::Math::Symbol.new(","),
+                    Plurimath::Math::Symbol.new("&#x2001;"),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
                     Plurimath::Math::Symbol.new("w"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("r"),
-                        Plurimath::Math::Symbol.new("e"),
-                        Plurimath::Math::Symbol.new("f")
-                      ]),
-                      "textrm"
-                    )
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("("),
-                  Plurimath::Math::Symbol.new("L"),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("T"),
-                  Plurimath::Math::Symbol.new(")"),
-                  Plurimath::Math::Symbol.new(","),
-                  Plurimath::Math::Symbol.new("&#x2001;")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("&#x3bc;"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Unicode.new("&#x27;"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("r"),
-                        Plurimath::Math::Symbol.new("e"),
-                        Plurimath::Math::Symbol.new("f")
-                      ]),
-                      "textrm"
-                    )
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Unicode.new("&#x27;"),
+                      Plurimath::Math::Function::FontStyle::Normal.new(
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("r"),
+                          Plurimath::Math::Symbol.new("e"),
+                          Plurimath::Math::Symbol.new("f"),
+                        ]),
+                        "textrm"
+                      )
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("w"),
+                      Plurimath::Math::Function::FontStyle::Normal.new(
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("r"),
+                          Plurimath::Math::Symbol.new("e"),
+                          Plurimath::Math::Symbol.new("f"),
+                        ]),
+                        "textrm"
+                      )
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Symbol.new("("),
+                    Plurimath::Math::Symbol.new("L"),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Symbol.new("T"),
+                    Plurimath::Math::Symbol.new(")"),
+                    Plurimath::Math::Symbol.new(","),
+                    Plurimath::Math::Symbol.new("&#x2001;"),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
                     Plurimath::Math::Symbol.new("&#x3bc;"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("r"),
-                        Plurimath::Math::Symbol.new("e"),
-                        Plurimath::Math::Symbol.new("f")
-                      ]),
-                      "textrm"
-                    )
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("("),
-                  Plurimath::Math::Symbol.new("M"),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("("),
-                  Plurimath::Math::Symbol.new("L"),
-                  Plurimath::Math::Symbol.new("T"),
-                  Plurimath::Math::Symbol.new(")"),
-                  Plurimath::Math::Symbol.new(")"),
-                  Plurimath::Math::Symbol.new(".")
-                ])
-              ])
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Unicode.new("&#x27;"),
+                      Plurimath::Math::Function::FontStyle::Normal.new(
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("r"),
+                          Plurimath::Math::Symbol.new("e"),
+                          Plurimath::Math::Symbol.new("f"),
+                        ]),
+                        "textrm"
+                      )
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("&#x3bc;"),
+                      Plurimath::Math::Function::FontStyle::Normal.new(
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("r"),
+                          Plurimath::Math::Symbol.new("e"),
+                          Plurimath::Math::Symbol.new("f"),
+                        ]),
+                        "textrm"
+                      )
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Symbol.new("("),
+                    Plurimath::Math::Symbol.new("M"),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Symbol.new("("),
+                    Plurimath::Math::Symbol.new("L"),
+                    Plurimath::Math::Symbol.new("T"),
+                    Plurimath::Math::Symbol.new(")"),
+                    Plurimath::Math::Symbol.new(")"),
+                    Plurimath::Math::Symbol.new("."),
+                  ],
+                  { columnalign: "center" }
+                ),
+              ]),
             ],
             nil,
-            [
-              Plurimath::Math::Symbol.new("c"),
-              Plurimath::Math::Symbol.new("c"),
-              Plurimath::Math::Symbol.new("c")
-            ]
-          )
+            nil,
+            {}
+          ),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -5718,204 +6254,217 @@ RSpec.describe Plurimath::Latex::Parser do
           Plurimath::Math::Function::Table::Split.new(
             [
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("p"),
-                  Plurimath::Math::Unicode.new("&#x27;"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Unicode.new("&#x27;"),
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("i"),
-                      Plurimath::Math::Symbol.new("j"),
-                      Plurimath::Math::Symbol.new("k")
-                    ])
-                  )
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("&#x2261;"),
-                  Plurimath::Math::Function::Base.new(
+                Plurimath::Math::Function::Td.new(
+                  [
                     Plurimath::Math::Symbol.new("p"),
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("i"),
-                      Plurimath::Math::Symbol.new("j"),
-                      Plurimath::Math::Symbol.new("k")
-                    ])
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("("),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("&#x3c1;"),
-                    Plurimath::Math::Function::FontStyle.new(
+                    Plurimath::Math::Unicode.new("&#x27;"),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Unicode.new("&#x27;"),
                       Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("r"),
-                        Plurimath::Math::Symbol.new("e"),
-                        Plurimath::Math::Symbol.new("f")
-                      ]),
-                      "textrm"
-                    )
-                  ),
-                  Plurimath::Math::Function::PowerBase.new(
-                    Plurimath::Math::Symbol.new("c"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("r"),
-                        Plurimath::Math::Symbol.new("e"),
-                        Plurimath::Math::Symbol.new("f")
-                      ]),
-                      "textrm"
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("j"),
+                        Plurimath::Math::Symbol.new("k"),
+                      ])
                     ),
-                    Plurimath::Math::Number.new("2")
-                  ),
-                  Plurimath::Math::Symbol.new(")"),
-                  Plurimath::Math::Symbol.new("["),
-                  Plurimath::Math::Symbol.new("."),
-                  Plurimath::Math::Number.new("02"),
-                  Plurimath::Math::Symbol.new("i"),
-                  Plurimath::Math::Symbol.new("n"),
-                  Plurimath::Math::Symbol.new("]")
-                ])
-              ]),
-              Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([])
-              ]),
-              Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::FontStyle.new(
-                    Plurimath::Math::Symbol.new("&"),
-                    "displaystyle"
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Over.new(
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::Base.new(
-                        Plurimath::Math::Symbol.new("p"),
+                  ],
+                  nil
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Symbol.new("&#x2261;"),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("p"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("j"),
+                        Plurimath::Math::Symbol.new("k"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Symbol.new("("),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("&#x3c1;"),
+                      Plurimath::Math::Function::FontStyle::Normal.new(
                         Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("i"),
-                          Plurimath::Math::Symbol.new("j"),
-                          Plurimath::Math::Symbol.new("k")
-                        ])
-                      )
-                    ]),
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("M"),
-                      Plurimath::Math::Symbol.new("/"),
-                      Plurimath::Math::Symbol.new("("),
-                      Plurimath::Math::Symbol.new("L"),
-                      Plurimath::Math::Function::Power.new(
-                        Plurimath::Math::Symbol.new("T"),
-                        Plurimath::Math::Number.new("2")
-                      ),
-                      Plurimath::Math::Symbol.new(")")
-                    ])
-                  ),
-                  Plurimath::Math::Function::Over.new(
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("M"),
-                      Plurimath::Math::Symbol.new("/"),
-                      Plurimath::Math::Function::Power.new(
-                        Plurimath::Math::Symbol.new("L"),
-                        Plurimath::Math::Number.new("3")
-                      )
-                    ]),
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::Base.new(
-                        Plurimath::Math::Symbol.new("&#x3c1;"),
-                        Plurimath::Math::Function::FontStyle.new(
-                          Plurimath::Math::Formula.new([
-                            Plurimath::Math::Symbol.new("r"),
-                            Plurimath::Math::Symbol.new("e"),
-                            Plurimath::Math::Symbol.new("f")
-                          ]),
-                          "textrm"
-                        )
-                      )
-                    ])
-                  ),
-                  Plurimath::Math::Function::Power.new(
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::Left.new("["),
-                      Plurimath::Math::Function::Over.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("L"),
-                          Plurimath::Math::Symbol.new("/"),
-                          Plurimath::Math::Symbol.new("T")
+                          Plurimath::Math::Symbol.new("r"),
+                          Plurimath::Math::Symbol.new("e"),
+                          Plurimath::Math::Symbol.new("f"),
                         ]),
+                        "textrm"
+                      )
+                    ),
+                    Plurimath::Math::Function::PowerBase.new(
+                      Plurimath::Math::Symbol.new("c"),
+                      Plurimath::Math::Function::FontStyle::Normal.new(
                         Plurimath::Math::Formula.new([
-                          Plurimath::Math::Function::Base.new(
-                            Plurimath::Math::Symbol.new("c"),
-                            Plurimath::Math::Function::FontStyle.new(
-                              Plurimath::Math::Formula.new([
-                                Plurimath::Math::Symbol.new("r"),
-                                Plurimath::Math::Symbol.new("e"),
-                                Plurimath::Math::Symbol.new("f")
-                              ]),
-                              "textrm"
-                            )
-                          )
-                        ])
+                          Plurimath::Math::Symbol.new("r"),
+                          Plurimath::Math::Symbol.new("e"),
+                          Plurimath::Math::Symbol.new("f"),
+                        ]),
+                        "textrm"
                       ),
-                      Plurimath::Math::Function::Right.new("]")
-                    ]),
-                    Plurimath::Math::Number.new("2")
-                  )
-                ])
-              ]),
-              Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([])
-              ]),
-              Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::FontStyle.new(
-                    Plurimath::Math::Symbol.new("&"),
-                    "displaystyle"
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Symbol.new("p"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Unicode.new("&#x27;"),
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("i"),
-                      Plurimath::Math::Symbol.new("j"),
-                      Plurimath::Math::Symbol.new("k")
-                    ])
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("("),
-                  Plurimath::Math::Symbol.new("&#x3c1;"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Unicode.new("&#x27;"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("r"),
-                        Plurimath::Math::Symbol.new("e"),
-                        Plurimath::Math::Symbol.new("f")
-                      ]),
-                      "textrm"
-                    )
-                  ),
-                  Plurimath::Math::Symbol.new("("),
-                  Plurimath::Math::Symbol.new("c"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Unicode.new("&#x27;"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("r"),
-                        Plurimath::Math::Symbol.new("e"),
-                        Plurimath::Math::Symbol.new("f")
-                      ]),
-                      "textrm"
-                    )
-                  ),
-                  Plurimath::Math::Function::Power.new(
+                      Plurimath::Math::Number.new("2")
+                    ),
                     Plurimath::Math::Symbol.new(")"),
-                    Plurimath::Math::Number.new("2")
-                  ),
-                  Plurimath::Math::Symbol.new(")")
-                ])
-              ])
+                    Plurimath::Math::Symbol.new("["),
+                    Plurimath::Math::Symbol.new("."),
+                    Plurimath::Math::Number.new("02"),
+                    Plurimath::Math::Symbol.new("i"),
+                    Plurimath::Math::Symbol.new("n"),
+                    Plurimath::Math::Symbol.new("]"),
+                  ],
+                  nil
+                ),
+              ]),
+              Plurimath::Math::Function::Tr.new([
+                Plurimath::Math::Function::Td.new([], nil),
+              ]),
+              Plurimath::Math::Function::Tr.new([
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::FontStyle.new(
+                      Plurimath::Math::Symbol.new("&"),
+                      "displaystyle"
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Over.new(
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Function::Base.new(
+                          Plurimath::Math::Symbol.new("p"),
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("i"),
+                            Plurimath::Math::Symbol.new("j"),
+                            Plurimath::Math::Symbol.new("k"),
+                          ])
+                        ),
+                      ]),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("M"),
+                        Plurimath::Math::Symbol.new("/"),
+                        Plurimath::Math::Symbol.new("("),
+                        Plurimath::Math::Symbol.new("L"),
+                        Plurimath::Math::Function::Power.new(
+                          Plurimath::Math::Symbol.new("T"),
+                          Plurimath::Math::Number.new("2")
+                        ),
+                        Plurimath::Math::Symbol.new(")"),
+                      ])
+                    ),
+                    Plurimath::Math::Function::Over.new(
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("M"),
+                        Plurimath::Math::Symbol.new("/"),
+                        Plurimath::Math::Function::Power.new(
+                          Plurimath::Math::Symbol.new("L"),
+                          Plurimath::Math::Number.new("3")
+                        ),
+                      ]),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Function::Base.new(
+                          Plurimath::Math::Symbol.new("&#x3c1;"),
+                          Plurimath::Math::Function::FontStyle::Normal.new(
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("r"),
+                              Plurimath::Math::Symbol.new("e"),
+                              Plurimath::Math::Symbol.new("f"),
+                            ]),
+                            "textrm"
+                          )
+                        ),
+                      ])
+                    ),
+                    Plurimath::Math::Function::Power.new(
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Function::Left.new("["),
+                        Plurimath::Math::Function::Over.new(
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("L"),
+                            Plurimath::Math::Symbol.new("/"),
+                            Plurimath::Math::Symbol.new("T"),
+                          ]),
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Function::Base.new(
+                              Plurimath::Math::Symbol.new("c"),
+                              Plurimath::Math::Function::FontStyle::Normal.new(
+                                Plurimath::Math::Formula.new([
+                                  Plurimath::Math::Symbol.new("r"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("f"),
+                                ]),
+                                "textrm"
+                              )
+                            ),
+                          ])
+                        ),
+                        Plurimath::Math::Function::Right.new("]"),
+                      ]),
+                      Plurimath::Math::Number.new("2")
+                    ),
+                  ],
+                  nil
+                ),
+              ]),
+              Plurimath::Math::Function::Tr.new([
+                Plurimath::Math::Function::Td.new([], nil),
+              ]),
+              Plurimath::Math::Function::Tr.new([
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::FontStyle.new(
+                      Plurimath::Math::Symbol.new("&"),
+                      "displaystyle"
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Symbol.new("p"),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Unicode.new("&#x27;"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("j"),
+                        Plurimath::Math::Symbol.new("k"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Symbol.new("("),
+                    Plurimath::Math::Symbol.new("&#x3c1;"),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Unicode.new("&#x27;"),
+                      Plurimath::Math::Function::FontStyle::Normal.new(
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("r"),
+                          Plurimath::Math::Symbol.new("e"),
+                          Plurimath::Math::Symbol.new("f"),
+                        ]),
+                        "textrm"
+                      )
+                    ),
+                    Plurimath::Math::Symbol.new("("),
+                    Plurimath::Math::Symbol.new("c"),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Unicode.new("&#x27;"),
+                      Plurimath::Math::Function::FontStyle::Normal.new(
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("r"),
+                          Plurimath::Math::Symbol.new("e"),
+                          Plurimath::Math::Symbol.new("f"),
+                        ]),
+                        "textrm"
+                      )
+                    ),
+                    Plurimath::Math::Function::Power.new(
+                      Plurimath::Math::Symbol.new(")"),
+                      Plurimath::Math::Number.new("2")
+                    ),
+                    Plurimath::Math::Symbol.new(")"),
+                  ],
+                  nil
+                ),
+              ]),
             ],
             nil,
-            []
-          )
+            nil,
+            {}
+          ),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -5936,275 +6485,299 @@ RSpec.describe Plurimath::Latex::Parser do
           Plurimath::Math::Function::Table::Array.new(
             [
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Function::Tilde.new(
-                      Plurimath::Math::Symbol.new("x")
-                    ),
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("i"),
-                      Plurimath::Math::Symbol.new("j"),
-                      Plurimath::Math::Symbol.new("k")
-                    ])
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("x"),
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("i"),
-                      Plurimath::Math::Symbol.new("j"),
-                      Plurimath::Math::Symbol.new("k")
-                    ])
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("L"),
-                  Plurimath::Math::Symbol.new(",")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Function::Tilde.new(
-                      Plurimath::Math::Symbol.new("u")
-                    ),
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("i"),
-                      Plurimath::Math::Symbol.new("j"),
-                      Plurimath::Math::Symbol.new("k")
-                    ])
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("u"),
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("i"),
-                      Plurimath::Math::Symbol.new("j"),
-                      Plurimath::Math::Symbol.new("k")
-                    ])
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("c"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new(",")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Function::Tilde.new(
-                      Plurimath::Math::Symbol.new("&#x3c1;")
-                    ),
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("i"),
-                      Plurimath::Math::Symbol.new("j"),
-                      Plurimath::Math::Symbol.new("k")
-                    ])
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("&#x3c1;"),
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("i"),
-                      Plurimath::Math::Symbol.new("j"),
-                      Plurimath::Math::Symbol.new("k")
-                    ])
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("&#x3c1;"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new(",")
-                ])
-              ]),
-              Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Function::Tilde.new(
-                      Plurimath::Math::Symbol.new("y")
-                    ),
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("i"),
-                      Plurimath::Math::Symbol.new("j"),
-                      Plurimath::Math::Symbol.new("k")
-                    ])
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("y"),
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("i"),
-                      Plurimath::Math::Symbol.new("j"),
-                      Plurimath::Math::Symbol.new("k")
-                    ])
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("L"),
-                  Plurimath::Math::Symbol.new(",")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Function::Tilde.new(
-                      Plurimath::Math::Symbol.new("v")
-                    ),
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("i"),
-                      Plurimath::Math::Symbol.new("j"),
-                      Plurimath::Math::Symbol.new("k")
-                    ])
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("v"),
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("i"),
-                      Plurimath::Math::Symbol.new("j"),
-                      Plurimath::Math::Symbol.new("k")
-                    ])
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("c"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new(",")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Function::Tilde.new(
-                      Plurimath::Math::Symbol.new("p")
-                    ),
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("i"),
-                      Plurimath::Math::Symbol.new("j"),
-                      Plurimath::Math::Symbol.new("k")
-                    ])
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("p"),
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("i"),
-                      Plurimath::Math::Symbol.new("j"),
-                      Plurimath::Math::Symbol.new("k")
-                    ])
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("("),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("&#x3c1;"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Function::PowerBase.new(
-                    Plurimath::Math::Symbol.new("c"),
-                    Plurimath::Math::Symbol.new("&#x221e;"),
-                    Plurimath::Math::Number.new("2")
-                  ),
-                  Plurimath::Math::Symbol.new(")"),
-                  Plurimath::Math::Symbol.new(","),
-                  Plurimath::Math::Symbol.new("["),
-                  Plurimath::Math::Symbol.new("."),
-                  Plurimath::Math::Number.new("02"),
-                  Plurimath::Math::Symbol.new("i"),
-                  Plurimath::Math::Symbol.new("n"),
-                  Plurimath::Math::Symbol.new("]")
-                ])
-              ]),
-              Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Function::Tilde.new(
-                      Plurimath::Math::Symbol.new("z")
-                    ),
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("i"),
-                      Plurimath::Math::Symbol.new("j"),
-                      Plurimath::Math::Symbol.new("k")
-                    ])
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("z"),
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("i"),
-                      Plurimath::Math::Symbol.new("j"),
-                      Plurimath::Math::Symbol.new("k")
-                    ])
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("L"),
-                  Plurimath::Math::Symbol.new(",")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Function::Tilde.new(
-                      Plurimath::Math::Symbol.new("w")
-                    ),
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("i"),
-                      Plurimath::Math::Symbol.new("j"),
-                      Plurimath::Math::Symbol.new("k")
-                    ])
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("w"),
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("i"),
-                      Plurimath::Math::Symbol.new("j"),
-                      Plurimath::Math::Symbol.new("k")
-                    ])
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("c"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new(",")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Function::Tilde.new(
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
                       Plurimath::Math::Function::Tilde.new(
-                        Plurimath::Math::Symbol.new("&#x3bc;")
-                      )
+                        Plurimath::Math::Symbol.new("x")
+                      ),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("j"),
+                        Plurimath::Math::Symbol.new("k"),
+                      ])
                     ),
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("i"),
-                      Plurimath::Math::Symbol.new("j"),
-                      Plurimath::Math::Symbol.new("k")
-                    ])
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("&#x3bc;"),
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("i"),
-                      Plurimath::Math::Symbol.new("j"),
-                      Plurimath::Math::Symbol.new("k")
-                    ])
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("("),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("&#x3c1;"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("c"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new("L"),
-                  Plurimath::Math::Symbol.new(")"),
-                  Plurimath::Math::Symbol.new(",")
-                ])
-              ])
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("x"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("j"),
+                        Plurimath::Math::Symbol.new("k"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Symbol.new("L"),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Function::Tilde.new(
+                        Plurimath::Math::Symbol.new("u")
+                      ),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("j"),
+                        Plurimath::Math::Symbol.new("k"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("u"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("j"),
+                        Plurimath::Math::Symbol.new("k"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("c"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Function::Tilde.new(
+                        Plurimath::Math::Symbol.new("&#x3c1;")
+                      ),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("j"),
+                        Plurimath::Math::Symbol.new("k"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("&#x3c1;"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("j"),
+                        Plurimath::Math::Symbol.new("k"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("&#x3c1;"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+              ]),
+              Plurimath::Math::Function::Tr.new([
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Function::Tilde.new(
+                        Plurimath::Math::Symbol.new("y")
+                      ),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("j"),
+                        Plurimath::Math::Symbol.new("k"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("y"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("j"),
+                        Plurimath::Math::Symbol.new("k"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Symbol.new("L"),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Function::Tilde.new(
+                        Plurimath::Math::Symbol.new("v")
+                      ),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("j"),
+                        Plurimath::Math::Symbol.new("k"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("v"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("j"),
+                        Plurimath::Math::Symbol.new("k"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("c"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Function::Tilde.new(
+                        Plurimath::Math::Symbol.new("p")
+                      ),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("j"),
+                        Plurimath::Math::Symbol.new("k"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("p"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("j"),
+                        Plurimath::Math::Symbol.new("k"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Symbol.new("("),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("&#x3c1;"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Function::PowerBase.new(
+                      Plurimath::Math::Symbol.new("c"),
+                      Plurimath::Math::Symbol.new("&#x221e;"),
+                      Plurimath::Math::Number.new("2")
+                    ),
+                    Plurimath::Math::Symbol.new(")"),
+                    Plurimath::Math::Symbol.new(","),
+                    Plurimath::Math::Symbol.new("["),
+                    Plurimath::Math::Symbol.new("."),
+                    Plurimath::Math::Number.new("02"),
+                    Plurimath::Math::Symbol.new("i"),
+                    Plurimath::Math::Symbol.new("n"),
+                    Plurimath::Math::Symbol.new("]"),
+                  ],
+                  { columnalign: "center" }
+                ),
+              ]),
+              Plurimath::Math::Function::Tr.new([
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Function::Tilde.new(
+                        Plurimath::Math::Symbol.new("z")
+                      ),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("j"),
+                        Plurimath::Math::Symbol.new("k"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("z"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("j"),
+                        Plurimath::Math::Symbol.new("k"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Symbol.new("L"),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Function::Tilde.new(
+                        Plurimath::Math::Symbol.new("w")
+                      ),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("j"),
+                        Plurimath::Math::Symbol.new("k"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("w"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("j"),
+                        Plurimath::Math::Symbol.new("k"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("c"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Function::Tilde.new(
+                        Plurimath::Math::Function::Tilde.new(
+                          Plurimath::Math::Symbol.new("&#x3bc;")
+                        )
+                      ),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("j"),
+                        Plurimath::Math::Symbol.new("k"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("&#x3bc;"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("j"),
+                        Plurimath::Math::Symbol.new("k"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Symbol.new("("),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("&#x3c1;"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("c"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new("L"),
+                    Plurimath::Math::Symbol.new(")"),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+              ]),
             ],
             nil,
-            [
-              Plurimath::Math::Symbol.new("c"),
-              Plurimath::Math::Symbol.new("c"),
-              Plurimath::Math::Symbol.new("c")
-            ]
-          )
+            nil,
+            {}
+          ),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -6225,169 +6798,185 @@ RSpec.describe Plurimath::Latex::Parser do
           Plurimath::Math::Function::Table::Array.new(
             [
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Function::Tilde.new(
-                      Plurimath::Math::Symbol.new("u")
-                    ),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("u"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("c"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new(","),
-                  Plurimath::Math::Symbol.new("&#x2001;")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Function::Tilde.new(
-                      Plurimath::Math::Symbol.new("&#x3c1;")
-                    ),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("&#x3c1;"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("&#x3c1;"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Number.new("1"),
-                  Plurimath::Math::Symbol.new(",")
-                ])
-              ]),
-              Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Function::Tilde.new(
-                      Plurimath::Math::Symbol.new("v")
-                    ),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("v"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("c"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new(",")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Function::Tilde.new(
-                      Plurimath::Math::Symbol.new("p")
-                    ),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("p"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("("),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("&#x3c1;"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Function::PowerBase.new(
-                    Plurimath::Math::Symbol.new("c"),
-                    Plurimath::Math::Symbol.new("&#x221e;"),
-                    Plurimath::Math::Number.new("2")
-                  ),
-                  Plurimath::Math::Symbol.new(")"),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Number.new("1"),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("&#x3b3;"),
-                  Plurimath::Math::Symbol.new(","),
-                  Plurimath::Math::Symbol.new("["),
-                  Plurimath::Math::Symbol.new("."),
-                  Plurimath::Math::Number.new("02"),
-                  Plurimath::Math::Symbol.new("i"),
-                  Plurimath::Math::Symbol.new("n"),
-                  Plurimath::Math::Symbol.new("]")
-                ])
-              ]),
-              Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Function::Tilde.new(
-                      Plurimath::Math::Symbol.new("w")
-                    ),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("w"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("c"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new(",")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Function::Tilde.new(
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
                       Plurimath::Math::Function::Tilde.new(
-                        Plurimath::Math::Symbol.new("&#x3bc;")
-                      )
+                        Plurimath::Math::Symbol.new("u")
+                      ),
+                      Plurimath::Math::Symbol.new("&#x221e;")
                     ),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("&#x3bc;"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("("),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("&#x3c1;"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("c"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new("L"),
-                  Plurimath::Math::Symbol.new(")"),
-                  Plurimath::Math::Symbol.new("&#x223c;"),
-                  Plurimath::Math::Symbol.new("O"),
-                  Plurimath::Math::Symbol.new("("),
-                  Plurimath::Math::Number.new("1"),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("R"),
-                  Plurimath::Math::Symbol.new("e"),
-                  Plurimath::Math::Symbol.new(")"),
-                  Plurimath::Math::Symbol.new(",")
-                ])
-              ])
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("u"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("c"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new(","),
+                    Plurimath::Math::Symbol.new("&#x2001;"),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Function::Tilde.new(
+                        Plurimath::Math::Symbol.new("&#x3c1;")
+                      ),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("&#x3c1;"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("&#x3c1;"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Number.new("1"),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+              ]),
+              Plurimath::Math::Function::Tr.new([
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Function::Tilde.new(
+                        Plurimath::Math::Symbol.new("v")
+                      ),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("v"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("c"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Function::Tilde.new(
+                        Plurimath::Math::Symbol.new("p")
+                      ),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("p"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Symbol.new("("),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("&#x3c1;"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Function::PowerBase.new(
+                      Plurimath::Math::Symbol.new("c"),
+                      Plurimath::Math::Symbol.new("&#x221e;"),
+                      Plurimath::Math::Number.new("2")
+                    ),
+                    Plurimath::Math::Symbol.new(")"),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Number.new("1"),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Symbol.new("&#x3b3;"),
+                    Plurimath::Math::Symbol.new(","),
+                    Plurimath::Math::Symbol.new("["),
+                    Plurimath::Math::Symbol.new("."),
+                    Plurimath::Math::Number.new("02"),
+                    Plurimath::Math::Symbol.new("i"),
+                    Plurimath::Math::Symbol.new("n"),
+                    Plurimath::Math::Symbol.new("]"),
+                  ],
+                  { columnalign: "center" }
+                ),
+              ]),
+              Plurimath::Math::Function::Tr.new([
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Function::Tilde.new(
+                        Plurimath::Math::Symbol.new("w")
+                      ),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("w"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("c"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Function::Tilde.new(
+                        Plurimath::Math::Function::Tilde.new(
+                          Plurimath::Math::Symbol.new("&#x3bc;")
+                        )
+                      ),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("&#x3bc;"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Symbol.new("("),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("&#x3c1;"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("c"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new("L"),
+                    Plurimath::Math::Symbol.new(")"),
+                    Plurimath::Math::Symbol.new("&#x223c;"),
+                    Plurimath::Math::Symbol.new("O"),
+                    Plurimath::Math::Symbol.new("("),
+                    Plurimath::Math::Number.new("1"),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Symbol.new("R"),
+                    Plurimath::Math::Symbol.new("e"),
+                    Plurimath::Math::Symbol.new(")"),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+              ]),
             ],
             nil,
-            [
-              Plurimath::Math::Symbol.new("c"),
-              Plurimath::Math::Symbol.new("c")
-            ]
-          )
+            nil,
+            {}
+          ),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -6412,7 +7001,7 @@ RSpec.describe Plurimath::Latex::Parser do
               Plurimath::Math::Symbol.new("-"),
               Plurimath::Math::Function::Base.new(
                 Plurimath::Math::Symbol.new("p"),
-                Plurimath::Math::Function::FontStyle.new(
+                Plurimath::Math::Function::FontStyle::Normal.new(
                   Plurimath::Math::Formula.new([
                     Plurimath::Math::Symbol.new("r"),
                     Plurimath::Math::Symbol.new("e"),
@@ -6420,20 +7009,16 @@ RSpec.describe Plurimath::Latex::Parser do
                   ]),
                   "textrm"
                 )
-              )
+              ),
             ]),
             Plurimath::Math::Formula.new([
               Plurimath::Math::Function::Over.new(
-                Plurimath::Math::Formula.new([
-                  Plurimath::Math::Number.new("1")
-                ]),
-                Plurimath::Math::Formula.new([
-                  Plurimath::Math::Number.new("2")
-                ])
+                Plurimath::Math::Formula.new([Plurimath::Math::Number.new("1")]),
+                Plurimath::Math::Formula.new([Plurimath::Math::Number.new("2")])
               ),
               Plurimath::Math::Function::Base.new(
                 Plurimath::Math::Symbol.new("&#x3c1;"),
-                Plurimath::Math::Function::FontStyle.new(
+                Plurimath::Math::Function::FontStyle::Normal.new(
                   Plurimath::Math::Formula.new([
                     Plurimath::Math::Symbol.new("r"),
                     Plurimath::Math::Symbol.new("e"),
@@ -6444,7 +7029,7 @@ RSpec.describe Plurimath::Latex::Parser do
               ),
               Plurimath::Math::Function::PowerBase.new(
                 Plurimath::Math::Symbol.new("q"),
-                Plurimath::Math::Function::FontStyle.new(
+                Plurimath::Math::Function::FontStyle::Normal.new(
                   Plurimath::Math::Formula.new([
                     Plurimath::Math::Symbol.new("r"),
                     Plurimath::Math::Symbol.new("e"),
@@ -6453,10 +7038,10 @@ RSpec.describe Plurimath::Latex::Parser do
                   "textrm"
                 ),
                 Plurimath::Math::Number.new("2")
-              )
+              ),
             ])
           ),
-          Plurimath::Math::Symbol.new(",")
+          Plurimath::Math::Symbol.new(","),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -6471,9 +7056,7 @@ RSpec.describe Plurimath::Latex::Parser do
       it "returns formula" do
         expected_value = Plurimath::Math::Formula.new([
           Plurimath::Math::Function::Base.new(
-            Plurimath::Math::Function::Vec.new(
-              Plurimath::Math::Symbol.new("c")
-            ),
+            Plurimath::Math::Function::Vec.new(Plurimath::Math::Symbol.new("c")),
             Plurimath::Math::Symbol.new("f")
           ),
           Plurimath::Math::Symbol.new("="),
@@ -6481,20 +7064,16 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Formula.new([
               Plurimath::Math::Function::Vec.new(
                 Plurimath::Math::Symbol.new("&#x3c4;")
-              )
+              ),
             ]),
             Plurimath::Math::Formula.new([
               Plurimath::Math::Function::Over.new(
-                Plurimath::Math::Formula.new([
-                  Plurimath::Math::Number.new("1")
-                ]),
-                Plurimath::Math::Formula.new([
-                  Plurimath::Math::Number.new("2")
-                ])
+                Plurimath::Math::Formula.new([Plurimath::Math::Number.new("1")]),
+                Plurimath::Math::Formula.new([Plurimath::Math::Number.new("2")])
               ),
               Plurimath::Math::Function::Base.new(
                 Plurimath::Math::Symbol.new("&#x3c1;"),
-                Plurimath::Math::Function::FontStyle.new(
+                Plurimath::Math::Function::FontStyle::Normal.new(
                   Plurimath::Math::Formula.new([
                     Plurimath::Math::Symbol.new("r"),
                     Plurimath::Math::Symbol.new("e"),
@@ -6505,7 +7084,7 @@ RSpec.describe Plurimath::Latex::Parser do
               ),
               Plurimath::Math::Function::PowerBase.new(
                 Plurimath::Math::Symbol.new("q"),
-                Plurimath::Math::Function::FontStyle.new(
+                Plurimath::Math::Function::FontStyle::Normal.new(
                   Plurimath::Math::Formula.new([
                     Plurimath::Math::Symbol.new("r"),
                     Plurimath::Math::Symbol.new("e"),
@@ -6514,10 +7093,10 @@ RSpec.describe Plurimath::Latex::Parser do
                   "textrm"
                 ),
                 Plurimath::Math::Number.new("2")
-              )
+              ),
             ])
           ),
-          Plurimath::Math::Symbol.new(",")
+          Plurimath::Math::Symbol.new(","),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -6721,30 +7300,32 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("1")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("1")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("1")
-                  ])
-                ])
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("1")],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -6773,28 +7354,33 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("V"),
-                      Plurimath::Math::Symbol.new("x")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("V"),
+                        Plurimath::Math::Symbol.new("x")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("V"),
-                      Plurimath::Math::Symbol.new("y")
-                    )
-                  ])
-                ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("V"),
+                        Plurimath::Math::Symbol.new("y")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c")
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
+            Plurimath::Math::Function::Right.new(")"),
           ]),
           Plurimath::Math::Symbol.new("="),
           Plurimath::Math::Function::Base.new(
@@ -6812,35 +7398,40 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("&#x03b5;"),
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("x"),
-                        Plurimath::Math::Symbol.new("z"),
-                      ])
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("&#x03b5;"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("x"),
+                          Plurimath::Math::Symbol.new("z"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("&#x03b5;"),
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("y"),
-                        Plurimath::Math::Symbol.new("z"),
-                      ])
-                    )
-                  ])
-                ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("&#x03b5;"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("y"),
+                          Plurimath::Math::Symbol.new("z"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c")
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -6869,105 +7460,115 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("h"),
-                      Plurimath::Math::Symbol.new("m")
-                    ),
-                    Plurimath::Math::Symbol.new("&#x2c;"),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("D"),
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("m"),
-                        Plurimath::Math::Symbol.new("m")
-                      ])
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("h"),
-                      Plurimath::Math::Symbol.new("b")
-                    ),
-                    Plurimath::Math::Symbol.new("&#x2c;"),
-                    Plurimath::Math::Symbol.new("p"),
-                    Plurimath::Math::Symbol.new("&#x2c;"),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("D"),
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("m"),
-                        Plurimath::Math::Symbol.new("c")
-                      ])
-                    )
-                  ])
-                ]),
-                Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("["),
-                    Plurimath::Math::Number.new("2"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("]"),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("h"),
-                      Plurimath::Math::Symbol.new("b")
-                    ),
-                    Plurimath::Math::Symbol.new("&#x2c;"),
-                    Plurimath::Math::Symbol.new("p"),
-                    Plurimath::Math::Symbol.new("&#x2c;"),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("D"),
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("m"),
-                        Plurimath::Math::Symbol.new("c")
-                      ])
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::FontStyle.new(
-                        Plurimath::Math::Symbol.new("("),
-                        "displaystyle"
-                      ),
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Number.new("1"),
-                        Plurimath::Math::Number.new("12")
-                      ),
-                      Plurimath::Math::Function::PowerBase.new(
-                        Plurimath::Math::Symbol.new("h"),
-                        Plurimath::Math::Symbol.new("b"),
-                        Plurimath::Math::Number.new("3")
-                      ),
-                      Plurimath::Math::Symbol.new("+"),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Base.new(
                         Plurimath::Math::Symbol.new("h"),
-                        Plurimath::Math::Symbol.new("b")
+                        Plurimath::Math::Symbol.new("m")
                       ),
-                      Plurimath::Math::Symbol.new("&#x2c;"),
-                      Plurimath::Math::Function::Power.new(
-                        Plurimath::Math::Symbol.new("p"),
-                        Plurimath::Math::Number.new("2")
-                      ),
-                      Plurimath::Math::Symbol.new(")"),
                       Plurimath::Math::Symbol.new("&#x2c;"),
                       Plurimath::Math::Function::Base.new(
                         Plurimath::Math::Symbol.new("D"),
                         Plurimath::Math::Formula.new([
                           Plurimath::Math::Symbol.new("m"),
-                          Plurimath::Math::Symbol.new("b")
+                          Plurimath::Math::Symbol.new("m"),
                         ])
-                      )
-                    ])
-                  ])
-                ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("h"),
+                        Plurimath::Math::Symbol.new("b")
+                      ),
+                      Plurimath::Math::Symbol.new("&#x2c;"),
+                      Plurimath::Math::Symbol.new("p"),
+                      Plurimath::Math::Symbol.new("&#x2c;"),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("D"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("c"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
+                Plurimath::Math::Function::Tr.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("["),
+                      Plurimath::Math::Number.new("2"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("h"),
+                        Plurimath::Math::Symbol.new("b")
+                      ),
+                      Plurimath::Math::Symbol.new("&#x2c;"),
+                      Plurimath::Math::Symbol.new("p"),
+                      Plurimath::Math::Symbol.new("&#x2c;"),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("D"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("c"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Function::FontStyle.new(
+                          Plurimath::Math::Symbol.new("("),
+                          "displaystyle"
+                        ),
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Number.new("1"),
+                          Plurimath::Math::Number.new("12")
+                        ),
+                        Plurimath::Math::Function::PowerBase.new(
+                          Plurimath::Math::Symbol.new("h"),
+                          Plurimath::Math::Symbol.new("b"),
+                          Plurimath::Math::Number.new("3")
+                        ),
+                        Plurimath::Math::Symbol.new("+"),
+                        Plurimath::Math::Function::Base.new(
+                          Plurimath::Math::Symbol.new("h"),
+                          Plurimath::Math::Symbol.new("b")
+                        ),
+                        Plurimath::Math::Symbol.new("&#x2c;"),
+                        Plurimath::Math::Function::Power.new(
+                          Plurimath::Math::Symbol.new("p"),
+                          Plurimath::Math::Number.new("2")
+                        ),
+                        Plurimath::Math::Symbol.new(")"),
+                        Plurimath::Math::Symbol.new("&#x2c;"),
+                        Plurimath::Math::Function::Base.new(
+                          Plurimath::Math::Symbol.new("D"),
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("m"),
+                            Plurimath::Math::Symbol.new("b"),
+                          ])
+                        ),
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c")
-              ]
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -6993,70 +7594,83 @@ RSpec.describe Plurimath::Latex::Parser do
         LATEX
       }
       it "returns formula" do
-          expected_value = Plurimath::Math::Formula.new([
-            Plurimath::Math::Function::Base.new(
-              Plurimath::Math::Symbol.new("D"),
-              Plurimath::Math::Symbol.new("m")
-            ),
-            Plurimath::Math::Symbol.new("="),
-            Plurimath::Math::Function::Frac.new(
-              Plurimath::Math::Symbol.new("E"),
-              Plurimath::Math::Formula.new([
-                Plurimath::Math::Symbol.new("("),
-                Plurimath::Math::Number.new("1"),
-                Plurimath::Math::Symbol.new("-"),
-                Plurimath::Math::Function::Power.new(
-                  Plurimath::Math::Symbol.new("&#x3bd;"),
-                  Plurimath::Math::Number.new("2")
-                ),
-                Plurimath::Math::Symbol.new(")")
-              ])
-            ),
-            Plurimath::Math::Symbol.new("&#x3a;"),
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Base.new(
+            Plurimath::Math::Symbol.new("D"),
+            Plurimath::Math::Symbol.new("m")
+          ),
+          Plurimath::Math::Symbol.new("="),
+          Plurimath::Math::Function::Frac.new(
+            Plurimath::Math::Symbol.new("E"),
             Plurimath::Math::Formula.new([
-              Plurimath::Math::Function::Left.new("("),
-              Plurimath::Math::Function::Table::Array.new(
-                [
-                  Plurimath::Math::Function::Tr.new([
-                    Plurimath::Math::Function::Td.new([
-                      Plurimath::Math::Number.new("1")
-                    ]),
-                    Plurimath::Math::Function::Td.new([
-                      Plurimath::Math::Symbol.new("&#x3bd;")
-                    ]),
-                    Plurimath::Math::Function::Td.new([
-                      Plurimath::Math::Number.new("0")
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Tr.new([
-                    Plurimath::Math::Function::Td.new([
+              Plurimath::Math::Symbol.new("("),
+              Plurimath::Math::Number.new("1"),
+              Plurimath::Math::Symbol.new("-"),
+              Plurimath::Math::Function::Power.new(
+                Plurimath::Math::Symbol.new("&#x3bd;"),
+                Plurimath::Math::Number.new("2")
+              ),
+              Plurimath::Math::Symbol.new(")"),
+            ])
+          ),
+          Plurimath::Math::Symbol.new("&#x3a;"),
+          Plurimath::Math::Formula.new([
+            Plurimath::Math::Function::Left.new("("),
+            Plurimath::Math::Function::Table::Array.new(
+              [
+                Plurimath::Math::Function::Tr.new([
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("1")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Symbol.new("&#x3bd;")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                ]),
+                Plurimath::Math::Function::Tr.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Symbol.new("["),
                       Plurimath::Math::Number.new("2"),
                       Plurimath::Math::Symbol.new("m"),
                       Plurimath::Math::Symbol.new("m"),
                       Plurimath::Math::Symbol.new("]"),
-                      Plurimath::Math::Symbol.new("&#x3bd;")
-                    ]),
-                    Plurimath::Math::Function::Td.new([
-                      Plurimath::Math::Number.new("1")
-                    ]),
-                    Plurimath::Math::Function::Td.new([
-                      Plurimath::Math::Number.new("0")
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Tr.new([
-                    Plurimath::Math::Function::Td.new([
+                      Plurimath::Math::Symbol.new("&#x3bd;"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("1")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                ]),
+                Plurimath::Math::Function::Tr.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Symbol.new("["),
                       Plurimath::Math::Number.new("2"),
                       Plurimath::Math::Symbol.new("m"),
                       Plurimath::Math::Symbol.new("m"),
                       Plurimath::Math::Symbol.new("]"),
-                      Plurimath::Math::Number.new("0")
-                    ]),
-                    Plurimath::Math::Function::Td.new([
-                      Plurimath::Math::Number.new("0")
-                    ]),
-                    Plurimath::Math::Function::Td.new([
+                      Plurimath::Math::Number.new("0"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::FontStyle.new(
                         Plurimath::Math::Function::Frac.new(
                           Plurimath::Math::Formula.new([
@@ -7064,25 +7678,24 @@ RSpec.describe Plurimath::Latex::Parser do
                             Plurimath::Math::Number.new("1"),
                             Plurimath::Math::Symbol.new("-"),
                             Plurimath::Math::Symbol.new("&#x3bd;"),
-                            Plurimath::Math::Symbol.new(")")
+                            Plurimath::Math::Symbol.new(")"),
                           ]),
                           Plurimath::Math::Number.new("2")
                         ),
                         "displaystyle"
-                      )
-                    ])
-                  ])
-                ],
-                nil,
-                [
-                  Plurimath::Math::Symbol.new("c"),
-                  Plurimath::Math::Symbol.new("c"),
-                  Plurimath::Math::Symbol.new("c")
-                ]
-              ),
-              Plurimath::Math::Function::Right.new(")")
-            ])
-          ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
+              ],
+              nil,
+              nil,
+              {}
+            ),
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
+        ])
         expect(formula).to eq(expected_value)
       end
     end
@@ -7110,80 +7723,90 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("h"),
-                    Plurimath::Math::Symbol.new("&#x2c;"),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("D"),
-                      Plurimath::Math::Symbol.new("m")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("h"),
-                    Plurimath::Math::Symbol.new("&#x2c;"),
-                    Plurimath::Math::Symbol.new("p"),
-                    Plurimath::Math::Symbol.new("&#x2c;"),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("D"),
-                      Plurimath::Math::Symbol.new("m")
-                    )
-                  ])
-                ]),
-                Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("["),
-                    Plurimath::Math::Number.new("2"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("]"),
-                    Plurimath::Math::Symbol.new("h"),
-                    Plurimath::Math::Symbol.new("&#x2c;"),
-                    Plurimath::Math::Symbol.new("p"),
-                    Plurimath::Math::Symbol.new("&#x2c;"),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("D"),
-                      Plurimath::Math::Symbol.new("m")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::FontStyle.new(
-                        Plurimath::Math::Symbol.new("("),
-                        "displaystyle"
-                      ),
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Number.new("1"),
-                        Plurimath::Math::Number.new("12")
-                      ),
-                      Plurimath::Math::Function::Power.new(
-                        Plurimath::Math::Symbol.new("h"),
-                        Plurimath::Math::Number.new("3")
-                      ),
-                      Plurimath::Math::Symbol.new("+"),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Symbol.new("h"),
-                      Plurimath::Math::Symbol.new("&#x2c;"),
-                      Plurimath::Math::Function::Power.new(
-                        Plurimath::Math::Symbol.new("p"),
-                        Plurimath::Math::Number.new("2")
-                      ),
-                      Plurimath::Math::Symbol.new(")"),
                       Plurimath::Math::Symbol.new("&#x2c;"),
                       Plurimath::Math::Function::Base.new(
                         Plurimath::Math::Symbol.new("D"),
                         Plurimath::Math::Symbol.new("m")
-                      )
-                    ])
-                  ])
-                ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("h"),
+                      Plurimath::Math::Symbol.new("&#x2c;"),
+                      Plurimath::Math::Symbol.new("p"),
+                      Plurimath::Math::Symbol.new("&#x2c;"),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("D"),
+                        Plurimath::Math::Symbol.new("m")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
+                Plurimath::Math::Function::Tr.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("["),
+                      Plurimath::Math::Number.new("2"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Symbol.new("h"),
+                      Plurimath::Math::Symbol.new("&#x2c;"),
+                      Plurimath::Math::Symbol.new("p"),
+                      Plurimath::Math::Symbol.new("&#x2c;"),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("D"),
+                        Plurimath::Math::Symbol.new("m")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Function::FontStyle.new(
+                          Plurimath::Math::Symbol.new("("),
+                          "displaystyle"
+                        ),
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Number.new("1"),
+                          Plurimath::Math::Number.new("12")
+                        ),
+                        Plurimath::Math::Function::Power.new(
+                          Plurimath::Math::Symbol.new("h"),
+                          Plurimath::Math::Number.new("3")
+                        ),
+                        Plurimath::Math::Symbol.new("+"),
+                        Plurimath::Math::Symbol.new("h"),
+                        Plurimath::Math::Symbol.new("&#x2c;"),
+                        Plurimath::Math::Function::Power.new(
+                          Plurimath::Math::Symbol.new("p"),
+                          Plurimath::Math::Number.new("2")
+                        ),
+                        Plurimath::Math::Symbol.new(")"),
+                        Plurimath::Math::Symbol.new("&#x2c;"),
+                        Plurimath::Math::Function::Base.new(
+                          Plurimath::Math::Symbol.new("D"),
+                          Plurimath::Math::Symbol.new("m")
+                        ),
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c")
-              ]
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -7211,79 +7834,96 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("&#x03b5;"),
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("x"),
-                        Plurimath::Math::Symbol.new("x"),
-                      ])
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("&#x03b5;"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("x"),
+                          Plurimath::Math::Symbol.new("x"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("&#x03b5;"),
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("y"),
-                        Plurimath::Math::Symbol.new("y"),
-                      ])
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("&#x03b5;"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("y"),
+                          Plurimath::Math::Symbol.new("y"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("&#x3b3;"),
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("x"),
-                        Plurimath::Math::Symbol.new("y"),
-                      ])
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("&#x3b3;"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("x"),
+                          Plurimath::Math::Symbol.new("y"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("&#x3c7;"),
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("x"),
-                        Plurimath::Math::Symbol.new("x"),
-                      ])
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("&#x3c7;"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("x"),
+                          Plurimath::Math::Symbol.new("x"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("&#x3c7;"),
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("y"),
-                        Plurimath::Math::Symbol.new("y"),
-                      ])
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("&#x3c7;"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("y"),
+                          Plurimath::Math::Symbol.new("y"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("&#x3c4;"),
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("x"),
-                        Plurimath::Math::Symbol.new("y"),
-                      ])
-                    )
-                  ])
-                ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("&#x3c4;"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("x"),
+                          Plurimath::Math::Symbol.new("y"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c")
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -7311,79 +7951,96 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("N"),
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("y"),
-                        Plurimath::Math::Symbol.new("y"),
-                      ])
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("N"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("y"),
+                          Plurimath::Math::Symbol.new("y"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("N"),
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("x"),
-                        Plurimath::Math::Symbol.new("x"),
-                      ])
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("N"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("x"),
+                          Plurimath::Math::Symbol.new("x"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("N"),
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("x"),
-                        Plurimath::Math::Symbol.new("y"),
-                      ])
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("N"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("x"),
+                          Plurimath::Math::Symbol.new("y"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("M"),
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("x"),
-                        Plurimath::Math::Symbol.new("x"),
-                      ])
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("M"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("x"),
+                          Plurimath::Math::Symbol.new("x"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("M"),
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("y"),
-                        Plurimath::Math::Symbol.new("y"),
-                      ])
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("M"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("y"),
+                          Plurimath::Math::Symbol.new("y"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("M"),
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("x"),
-                        Plurimath::Math::Symbol.new("y"),
-                      ])
-                    )
-                  ])
-                ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("M"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("x"),
+                          Plurimath::Math::Symbol.new("y"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c")
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -7633,78 +8290,83 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::FontStyle.new(
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Function::FontStyle.new(
+                          Plurimath::Math::Function::Frac.new(
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("&#x2202;"),
+                              Plurimath::Math::Symbol.new("w"),
+                            ]),
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("&#x2202;"),
+                              Plurimath::Math::Symbol.new("x"),
+                            ])
+                          ),
+                          "displaystyle"
+                        ),
+                        Plurimath::Math::Symbol.new("+"),
                         Plurimath::Math::Function::Frac.new(
                           Plurimath::Math::Formula.new([
                             Plurimath::Math::Symbol.new("&#x2202;"),
-                            Plurimath::Math::Symbol.new("w")
+                            Plurimath::Math::Symbol.new("u"),
                           ]),
                           Plurimath::Math::Formula.new([
                             Plurimath::Math::Symbol.new("&#x2202;"),
-                            Plurimath::Math::Symbol.new("x")
+                            Plurimath::Math::Symbol.new("z"),
                           ])
                         ),
-                        "displaystyle"
-                      ),
-                      Plurimath::Math::Symbol.new("+"),
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("u")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("z")
-                        ])
-                      )
-                    ])
-                  ])
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("["),
-                    Plurimath::Math::Number.new("3"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("]"),
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::FontStyle.new(
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("["),
+                      Plurimath::Math::Number.new("3"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Function::FontStyle.new(
+                          Plurimath::Math::Function::Frac.new(
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("&#x2202;"),
+                              Plurimath::Math::Symbol.new("w"),
+                            ]),
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("&#x2202;"),
+                              Plurimath::Math::Symbol.new("y"),
+                            ])
+                          ),
+                          "displaystyle"
+                        ),
+                        Plurimath::Math::Symbol.new("+"),
                         Plurimath::Math::Function::Frac.new(
                           Plurimath::Math::Formula.new([
                             Plurimath::Math::Symbol.new("&#x2202;"),
-                            Plurimath::Math::Symbol.new("w")
+                            Plurimath::Math::Symbol.new("v"),
                           ]),
                           Plurimath::Math::Formula.new([
                             Plurimath::Math::Symbol.new("&#x2202;"),
-                            Plurimath::Math::Symbol.new("y")
+                            Plurimath::Math::Symbol.new("z"),
                           ])
                         ),
-                        "displaystyle"
-                      ),
-                      Plurimath::Math::Symbol.new("+"),
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("v")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("z")
-                        ])
-                      )
-                    ])
-                  ])
-                ])
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c")
-              ]
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -7826,117 +8488,127 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::FontStyle.new(
-                        Plurimath::Math::Symbol.new("-"),
-                        "displaystyle"
-                      ),
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Function::Power.new(
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Function::FontStyle.new(
+                          Plurimath::Math::Symbol.new("-"),
+                          "displaystyle"
+                        ),
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Function::Power.new(
+                              Plurimath::Math::Symbol.new("&#x2202;"),
+                              Plurimath::Math::Number.new("2")
+                            ),
+                            Plurimath::Math::Symbol.new("w"),
+                          ]),
+                          Plurimath::Math::Formula.new([
                             Plurimath::Math::Symbol.new("&#x2202;"),
-                            Plurimath::Math::Number.new("2")
-                          ),
-                          Plurimath::Math::Symbol.new("w")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Function::Power.new(
+                            Plurimath::Math::Function::Power.new(
+                              Plurimath::Math::Symbol.new("x"),
+                              Plurimath::Math::Number.new("2")
+                            ),
+                          ])
+                        ),
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Function::FontStyle.new(
+                          Plurimath::Math::Symbol.new("-"),
+                          "displaystyle"
+                        ),
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Function::Power.new(
+                              Plurimath::Math::Symbol.new("&#x2202;"),
+                              Plurimath::Math::Number.new("2")
+                            ),
+                            Plurimath::Math::Symbol.new("w"),
+                          ]),
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("&#x2202;"),
                             Plurimath::Math::Symbol.new("x"),
-                            Plurimath::Math::Number.new("2")
-                          )
-                        ])
-                      )
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::FontStyle.new(
-                        Plurimath::Math::Symbol.new("-"),
-                        "displaystyle"
-                      ),
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Function::Power.new(
                             Plurimath::Math::Symbol.new("&#x2202;"),
-                            Plurimath::Math::Number.new("2")
-                          ),
-                          Plurimath::Math::Symbol.new("w")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("x"),
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("y")
-                        ])
-                      )
-                    ])
-                  ])
+                            Plurimath::Math::Symbol.new("y"),
+                          ])
+                        ),
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("["),
-                    Plurimath::Math::Number.new("3"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("]"),
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::FontStyle.new(
-                        Plurimath::Math::Symbol.new("-"),
-                        "displaystyle"
-                      ),
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Function::Power.new(
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("["),
+                      Plurimath::Math::Number.new("3"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Function::FontStyle.new(
+                          Plurimath::Math::Symbol.new("-"),
+                          "displaystyle"
+                        ),
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Function::Power.new(
+                              Plurimath::Math::Symbol.new("&#x2202;"),
+                              Plurimath::Math::Number.new("2")
+                            ),
+                            Plurimath::Math::Symbol.new("w"),
+                          ]),
+                          Plurimath::Math::Formula.new([
                             Plurimath::Math::Symbol.new("&#x2202;"),
-                            Plurimath::Math::Number.new("2")
-                          ),
-                          Plurimath::Math::Symbol.new("w")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("x"),
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("y")
-                        ])
-                      )
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::FontStyle.new(
-                        Plurimath::Math::Symbol.new("-"),
-                        "displaystyle"
-                      ),
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Function::Power.new(
+                            Plurimath::Math::Symbol.new("x"),
                             Plurimath::Math::Symbol.new("&#x2202;"),
-                            Plurimath::Math::Number.new("2")
-                          ),
-                          Plurimath::Math::Symbol.new("w")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Function::Power.new(
                             Plurimath::Math::Symbol.new("y"),
-                            Plurimath::Math::Number.new("2")
-                          )
-                        ])
-                      )
-                    ])
-                  ])
-                ])
+                          ])
+                        ),
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Function::FontStyle.new(
+                          Plurimath::Math::Symbol.new("-"),
+                          "displaystyle"
+                        ),
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Function::Power.new(
+                              Plurimath::Math::Symbol.new("&#x2202;"),
+                              Plurimath::Math::Number.new("2")
+                            ),
+                            Plurimath::Math::Symbol.new("w"),
+                          ]),
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("&#x2202;"),
+                            Plurimath::Math::Function::Power.new(
+                              Plurimath::Math::Symbol.new("y"),
+                              Plurimath::Math::Number.new("2")
+                            ),
+                          ])
+                        ),
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c")
-              ]
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -8020,83 +8692,93 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("u")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("x")
-                        ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("&#x2202;"),
+                            Plurimath::Math::Symbol.new("u"),
+                          ]),
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("&#x2202;"),
+                            Plurimath::Math::Symbol.new("x"),
+                          ])
+                        ),
+                        "displaystyle"
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("v")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("x")
-                        ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("&#x2202;"),
+                            Plurimath::Math::Symbol.new("v"),
+                          ]),
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("&#x2202;"),
+                            Plurimath::Math::Symbol.new("x"),
+                          ])
+                        ),
+                        "displaystyle"
                       ),
-                      "displaystyle"
-                    )
-                  ])
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("["),
-                    Plurimath::Math::Number.new("3"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("]"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("u")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("y")
-                        ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("["),
+                      Plurimath::Math::Number.new("3"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("&#x2202;"),
+                            Plurimath::Math::Symbol.new("u"),
+                          ]),
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("&#x2202;"),
+                            Plurimath::Math::Symbol.new("y"),
+                          ])
+                        ),
+                        "displaystyle"
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("v")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("y")
-                        ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("&#x2202;"),
+                            Plurimath::Math::Symbol.new("v"),
+                          ]),
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("&#x2202;"),
+                            Plurimath::Math::Symbol.new("y"),
+                          ])
+                        ),
+                        "displaystyle"
                       ),
-                      "displaystyle"
-                    )
-                  ])
-                ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c")
-              ]
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -9130,337 +9812,476 @@ RSpec.describe Plurimath::Latex::Parser do
           Plurimath::Math::Function::Table::Array.new(
             [
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Formula.new([
-                    Plurimath::Math::Function::Left.new("("),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Formula.new([
+                      Plurimath::Math::Function::Left.new("("),
+                      Plurimath::Math::Function::Table::Array.new(
+                        [
+                          Plurimath::Math::Function::Tr.new([
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                          ]),
+                          Plurimath::Math::Function::Tr.new([
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new(
+                              [
+                                Plurimath::Math::Symbol.new("+"),
+                                Plurimath::Math::Symbol.new("k"),
+                              ],
+                              { columnalign: "center" }
+                            ),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new(
+                              [
+                                Plurimath::Math::Formula.new([
+                                  Plurimath::Math::Symbol.new("-"),
+                                  Plurimath::Math::Symbol.new("k"),
+                                ]),
+                              ],
+                              { columnalign: "center" }
+                            ),
+                          ]),
+                          Plurimath::Math::Function::Tr.new([
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                          ]),
+                          Plurimath::Math::Function::Tr.new([
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                          ]),
+                          Plurimath::Math::Function::Tr.new([
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                          ]),
+                          Plurimath::Math::Function::Tr.new([
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new(
+                              [
+                                Plurimath::Math::Formula.new([
+                                  Plurimath::Math::Symbol.new("-"),
+                                  Plurimath::Math::Symbol.new("k"),
+                                ]),
+                              ],
+                              { columnalign: "center" }
+                            ),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new(
+                              [
+                                Plurimath::Math::Symbol.new("+"),
+                                Plurimath::Math::Symbol.new("k"),
+                              ],
+                              { columnalign: "center" }
+                            ),
+                          ]),
+                        ],
+                        nil,
+                        nil,
+                        {}
+                      ),
+                      Plurimath::Math::Function::Right.new(")"),
+                    ]),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
                     Plurimath::Math::Function::Table::Array.new(
                       [
                         Plurimath::Math::Function::Tr.new([
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([])
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
                         ]),
                         Plurimath::Math::Function::Tr.new([
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([
-                            Plurimath::Math::Symbol.new("+"),
-                            Plurimath::Math::Symbol.new("k")
-                          ]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([
-                            Plurimath::Math::Formula.new([
-                              Plurimath::Math::Symbol.new("-"),
-                              Plurimath::Math::Symbol.new("k")
-                            ])
-                          ])
+                          Plurimath::Math::Function::Td.new(
+                            [Plurimath::Math::Symbol.new("&#x22ef;")],
+                            { columnalign: "center" }
+                          ),
+                          Plurimath::Math::Function::Td.new(
+                            [
+                              Plurimath::Math::Function::Mbox.new(
+                                Plurimath::Math::Formula.new([
+                                  Plurimath::Math::Symbol.new("d"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("g"),
+                                  Plurimath::Math::Symbol.new("r"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("o"),
+                                  Plurimath::Math::Symbol.new("f"),
+                                  Plurimath::Math::Symbol.new("f"),
+                                  Plurimath::Math::Symbol.new("r"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("d"),
+                                  Plurimath::Math::Symbol.new("o"),
+                                  Plurimath::Math::Symbol.new("m"),
+                                  Plurimath::Math::Number.new("1"),
+                                  Plurimath::Math::Symbol.new(","),
+                                  Plurimath::Math::Symbol.new("n"),
+                                  Plurimath::Math::Symbol.new("o"),
+                                  Plurimath::Math::Symbol.new("d"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Number.new("1"),
+                                ])
+                              ),
+                            ],
+                            { columnalign: "center" }
+                          ),
                         ]),
                         Plurimath::Math::Function::Tr.new([
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([])
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
                         ]),
                         Plurimath::Math::Function::Tr.new([
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([])
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
                         ]),
                         Plurimath::Math::Function::Tr.new([
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([])
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
                         ]),
                         Plurimath::Math::Function::Tr.new([
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([
-                            Plurimath::Math::Formula.new([
-                              Plurimath::Math::Symbol.new("-"),
-                              Plurimath::Math::Symbol.new("k")
-                            ])
-                          ]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([
-                            Plurimath::Math::Symbol.new("+"),
-                            Plurimath::Math::Symbol.new("k")
-                          ])
-                        ])
+                          Plurimath::Math::Function::Td.new(
+                            [Plurimath::Math::Symbol.new("&#x22ef;")],
+                            { columnalign: "center" }
+                          ),
+                          Plurimath::Math::Function::Td.new(
+                            [
+                              Plurimath::Math::Function::Mbox.new(
+                                Plurimath::Math::Formula.new([
+                                  Plurimath::Math::Symbol.new("d"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("g"),
+                                  Plurimath::Math::Symbol.new("r"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("o"),
+                                  Plurimath::Math::Symbol.new("f"),
+                                  Plurimath::Math::Symbol.new("f"),
+                                  Plurimath::Math::Symbol.new("r"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("d"),
+                                  Plurimath::Math::Symbol.new("o"),
+                                  Plurimath::Math::Symbol.new("m"),
+                                  Plurimath::Math::Number.new("2"),
+                                  Plurimath::Math::Symbol.new(","),
+                                  Plurimath::Math::Symbol.new("n"),
+                                  Plurimath::Math::Symbol.new("o"),
+                                  Plurimath::Math::Symbol.new("d"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Number.new("2"),
+                                ])
+                              ),
+                            ],
+                            { columnalign: "center" }
+                          ),
+                        ]),
                       ],
                       nil,
-                      [
-                        Plurimath::Math::Symbol.new("c"),
-                        Plurimath::Math::Symbol.new("c"),
-                        Plurimath::Math::Symbol.new("c"),
-                        Plurimath::Math::Symbol.new("c"),
-                        Plurimath::Math::Symbol.new("c"),
-                        Plurimath::Math::Symbol.new("c"),
-                        Plurimath::Math::Symbol.new("c"),
-                      ],
+                      nil,
+                      {}
                     ),
-                    Plurimath::Math::Function::Right.new(")")
-                  ])
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Table::Array.new(
-                    [
-                      Plurimath::Math::Function::Tr.new([
-                        Plurimath::Math::Function::Td.new([]),
-                        Plurimath::Math::Function::Td.new([])
-                      ]),
-                      Plurimath::Math::Function::Tr.new([
-                        Plurimath::Math::Function::Td.new([
-                          Plurimath::Math::Symbol.new("&#x22ef;")
-                        ]),
-                        Plurimath::Math::Function::Td.new([
-                          Plurimath::Math::Function::Mbox.new(
-                            Plurimath::Math::Formula.new([
-                              Plurimath::Math::Symbol.new("d"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("g"),
-                              Plurimath::Math::Symbol.new("r"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("o"),
-                              Plurimath::Math::Symbol.new("f"),
-                              Plurimath::Math::Symbol.new("f"),
-                              Plurimath::Math::Symbol.new("r"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("d"),
-                              Plurimath::Math::Symbol.new("o"),
-                              Plurimath::Math::Symbol.new("m"),
-                              Plurimath::Math::Number.new("1"),
-                              Plurimath::Math::Symbol.new(","),
-                              Plurimath::Math::Symbol.new("n"),
-                              Plurimath::Math::Symbol.new("o"),
-                              Plurimath::Math::Symbol.new("d"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Number.new("1"),
-                            ])
-                          )
-                        ])
-                      ]),
-                      Plurimath::Math::Function::Tr.new([
-                        Plurimath::Math::Function::Td.new([]),
-                        Plurimath::Math::Function::Td.new([])
-                      ]),
-                      Plurimath::Math::Function::Tr.new([
-                        Plurimath::Math::Function::Td.new([]),
-                        Plurimath::Math::Function::Td.new([])
-                      ]),
-                      Plurimath::Math::Function::Tr.new([
-                        Plurimath::Math::Function::Td.new([]),
-                        Plurimath::Math::Function::Td.new([])
-                      ]),
-                      Plurimath::Math::Function::Tr.new([
-                        Plurimath::Math::Function::Td.new([
-                          Plurimath::Math::Symbol.new("&#x22ef;")
-                        ]),
-                        Plurimath::Math::Function::Td.new([
-                          Plurimath::Math::Function::Mbox.new(
-                            Plurimath::Math::Formula.new([
-                              Plurimath::Math::Symbol.new("d"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("g"),
-                              Plurimath::Math::Symbol.new("r"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("o"),
-                              Plurimath::Math::Symbol.new("f"),
-                              Plurimath::Math::Symbol.new("f"),
-                              Plurimath::Math::Symbol.new("r"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("d"),
-                              Plurimath::Math::Symbol.new("o"),
-                              Plurimath::Math::Symbol.new("m"),
-                              Plurimath::Math::Number.new("2"),
-                              Plurimath::Math::Symbol.new(","),
-                              Plurimath::Math::Symbol.new("n"),
-                              Plurimath::Math::Symbol.new("o"),
-                              Plurimath::Math::Symbol.new("d"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Number.new("2"),
-                            ])
-                          )
-                        ])
-                      ])
-                    ],
-                    nil,
-                    [
-                      Plurimath::Math::Symbol.new("c"),
-                      Plurimath::Math::Symbol.new("c"),
-                    ],
-                  )
-                ])
+                  ],
+                  { columnalign: "center" }
+                ),
               ]),
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([]),
-                Plurimath::Math::Function::Td.new([])
+                Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
               ]),
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Table::Array.new(
-                    [
-                      Plurimath::Math::Function::Tr.new([
-                        Plurimath::Math::Function::Td.new([
-                          Plurimath::Math::Symbol.new("&#x22ee;")
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Table::Array.new(
+                      [
+                        Plurimath::Math::Function::Tr.new([
+                          Plurimath::Math::Function::Td.new(
+                            [Plurimath::Math::Symbol.new("&#x22ee;")],
+                            { columnalign: "center" }
+                          ),
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
+                          Plurimath::Math::Function::Td.new(
+                            [Plurimath::Math::Symbol.new("&#x22ee;")],
+                            { columnalign: "center" }
+                          ),
                         ]),
-                        Plurimath::Math::Function::Td.new([]),
-                        Plurimath::Math::Function::Td.new([]),
-                        Plurimath::Math::Function::Td.new([]),
-                        Plurimath::Math::Function::Td.new([]),
-                        Plurimath::Math::Function::Td.new([
-                          Plurimath::Math::Symbol.new("&#x22ee;")
-                        ])
-                      ])
-                    ],
-                    nil,
-                    [
-                      Plurimath::Math::Symbol.new("c"),
-                      Plurimath::Math::Symbol.new("c"),
-                      Plurimath::Math::Symbol.new("c"),
-                      Plurimath::Math::Symbol.new("c"),
-                      Plurimath::Math::Symbol.new("c"),
-                      Plurimath::Math::Symbol.new("c"),
-                    ],
-                  )
-                ]),
-                Plurimath::Math::Function::Td.new([])
+                      ],
+                      nil,
+                      nil,
+                      {}
+                    ),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
               ]),
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Table::Array.new(
-                    [
-                      Plurimath::Math::Function::Tr.new([
-                        Plurimath::Math::Function::Td.new([]),
-                        Plurimath::Math::Function::Td.new([
-                          Plurimath::Math::Function::Mbox.new(
-                            Plurimath::Math::Formula.new([
-                              Plurimath::Math::Symbol.new("d"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("g"),
-                              Plurimath::Math::Symbol.new("r"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("o"),
-                              Plurimath::Math::Symbol.new("f"),
-                            ])
-                          )
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Table::Array.new(
+                      [
+                        Plurimath::Math::Function::Tr.new([
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
+                          Plurimath::Math::Function::Td.new(
+                            [
+                              Plurimath::Math::Function::Mbox.new(
+                                Plurimath::Math::Formula.new([
+                                  Plurimath::Math::Symbol.new("d"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("g"),
+                                  Plurimath::Math::Symbol.new("r"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("o"),
+                                  Plurimath::Math::Symbol.new("f"),
+                                ])
+                              ),
+                            ],
+                            { columnalign: "center" }
+                          ),
+                          Plurimath::Math::Function::Td.new(
+                            [
+                              Plurimath::Math::Function::Mbox.new(
+                                Plurimath::Math::Formula.new([
+                                  Plurimath::Math::Symbol.new("d"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("g"),
+                                  Plurimath::Math::Symbol.new("r"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("o"),
+                                  Plurimath::Math::Symbol.new("f"),
+                                ])
+                              ),
+                            ],
+                            { columnalign: "center" }
+                          ),
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
                         ]),
-                        Plurimath::Math::Function::Td.new([
-                          Plurimath::Math::Function::Mbox.new(
-                            Plurimath::Math::Formula.new([
-                              Plurimath::Math::Symbol.new("d"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("g"),
-                              Plurimath::Math::Symbol.new("r"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("o"),
-                              Plurimath::Math::Symbol.new("f"),
-                            ])
-                          )
+                        Plurimath::Math::Function::Tr.new([
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
+                          Plurimath::Math::Function::Td.new(
+                            [
+                              Plurimath::Math::Function::Mbox.new(
+                                Plurimath::Math::Formula.new([
+                                  Plurimath::Math::Symbol.new("f"),
+                                  Plurimath::Math::Symbol.new("r"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("d"),
+                                  Plurimath::Math::Symbol.new("o"),
+                                  Plurimath::Math::Symbol.new("m"),
+                                  Plurimath::Math::Number.new("1"),
+                                  Plurimath::Math::Symbol.new(","),
+                                ])
+                              ),
+                            ],
+                            { columnalign: "center" }
+                          ),
+                          Plurimath::Math::Function::Td.new(
+                            [
+                              Plurimath::Math::Function::Mbox.new(
+                                Plurimath::Math::Formula.new([
+                                  Plurimath::Math::Symbol.new("f"),
+                                  Plurimath::Math::Symbol.new("r"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("d"),
+                                  Plurimath::Math::Symbol.new("o"),
+                                  Plurimath::Math::Symbol.new("m"),
+                                  Plurimath::Math::Number.new("2"),
+                                  Plurimath::Math::Symbol.new(","),
+                                ])
+                              ),
+                            ],
+                            { columnalign: "center" }
+                          ),
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
                         ]),
-                        Plurimath::Math::Function::Td.new([])
-                      ]),
-                      Plurimath::Math::Function::Tr.new([
-                        Plurimath::Math::Function::Td.new([]),
-                        Plurimath::Math::Function::Td.new([
-                          Plurimath::Math::Function::Mbox.new(
-                            Plurimath::Math::Formula.new([
-                              Plurimath::Math::Symbol.new("f"),
-                              Plurimath::Math::Symbol.new("r"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("d"),
-                              Plurimath::Math::Symbol.new("o"),
-                              Plurimath::Math::Symbol.new("m"),
-                              Plurimath::Math::Number.new("1"),
-                              Plurimath::Math::Symbol.new(","),
-                            ])
-                          )
+                        Plurimath::Math::Function::Tr.new([
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
+                          Plurimath::Math::Function::Td.new(
+                            [
+                              Plurimath::Math::Function::Mbox.new(
+                                Plurimath::Math::Formula.new([
+                                  Plurimath::Math::Symbol.new("n"),
+                                  Plurimath::Math::Symbol.new("o"),
+                                  Plurimath::Math::Symbol.new("d"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Number.new("1"),
+                                ])
+                              ),
+                            ],
+                            { columnalign: "center" }
+                          ),
+                          Plurimath::Math::Function::Td.new(
+                            [
+                              Plurimath::Math::Function::Mbox.new(
+                                Plurimath::Math::Formula.new([
+                                  Plurimath::Math::Symbol.new("n"),
+                                  Plurimath::Math::Symbol.new("o"),
+                                  Plurimath::Math::Symbol.new("d"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Number.new("2"),
+                                ])
+                              ),
+                            ],
+                            { columnalign: "center" }
+                          ),
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
                         ]),
-                        Plurimath::Math::Function::Td.new([
-                          Plurimath::Math::Function::Mbox.new(
-                            Plurimath::Math::Formula.new([
-                              Plurimath::Math::Symbol.new("f"),
-                              Plurimath::Math::Symbol.new("r"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Symbol.new("d"),
-                              Plurimath::Math::Symbol.new("o"),
-                              Plurimath::Math::Symbol.new("m"),
-                              Plurimath::Math::Number.new("2"),
-                              Plurimath::Math::Symbol.new(","),
-                            ])
-                          )
-                        ]),
-                        Plurimath::Math::Function::Td.new([])
-                      ]),
-                      Plurimath::Math::Function::Tr.new([
-                        Plurimath::Math::Function::Td.new([]),
-                        Plurimath::Math::Function::Td.new([
-                          Plurimath::Math::Function::Mbox.new(
-                            Plurimath::Math::Formula.new([
-                              Plurimath::Math::Symbol.new("n"),
-                              Plurimath::Math::Symbol.new("o"),
-                              Plurimath::Math::Symbol.new("d"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Number.new("1"),
-                            ])
-                          )
-                        ]),
-                        Plurimath::Math::Function::Td.new([
-                          Plurimath::Math::Function::Mbox.new(
-                            Plurimath::Math::Formula.new([
-                              Plurimath::Math::Symbol.new("n"),
-                              Plurimath::Math::Symbol.new("o"),
-                              Plurimath::Math::Symbol.new("d"),
-                              Plurimath::Math::Symbol.new("e"),
-                              Plurimath::Math::Number.new("2"),
-                            ])
-                          )
-                        ]),
-                        Plurimath::Math::Function::Td.new([])
-                      ])
-                    ],
-                    nil,
-                    [
-                      Plurimath::Math::Symbol.new("c"),
-                      Plurimath::Math::Symbol.new("c"),
-                      Plurimath::Math::Symbol.new("c"),
-                      Plurimath::Math::Symbol.new("c"),
-                    ],
-                  )
-                ]),
-                Plurimath::Math::Function::Td.new([])
-              ])
+                      ],
+                      nil,
+                      nil,
+                      {}
+                    ),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+              ]),
             ],
             nil,
-            [
-              Plurimath::Math::Symbol.new("c"),
-              Plurimath::Math::Symbol.new("c"),
-            ],
-          )
+            nil,
+            {}
+          ),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -9488,102 +10309,114 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("d"),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("t"),
-                      Plurimath::Math::Symbol.new("x")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("d"),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("t"),
+                        Plurimath::Math::Symbol.new("x")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("d"),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("t"),
-                      Plurimath::Math::Symbol.new("y")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("d"),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("t"),
+                        Plurimath::Math::Symbol.new("y")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("d"),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("t"),
-                      Plurimath::Math::Symbol.new("z")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("d"),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("t"),
+                        Plurimath::Math::Symbol.new("z")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("d"),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("r"),
-                      Plurimath::Math::Symbol.new("x")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("d"),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("r"),
+                        Plurimath::Math::Symbol.new("x")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("d"),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("r"),
-                      Plurimath::Math::Symbol.new("y")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("d"),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("r"),
+                        Plurimath::Math::Symbol.new("y")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("d"),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("r"),
-                      Plurimath::Math::Symbol.new("z")
-                    )
-                  ])
-                ])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("d"),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("r"),
+                        Plurimath::Math::Symbol.new("z")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -9611,102 +10444,114 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("k"),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("t"),
-                      Plurimath::Math::Symbol.new("x"),
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("k"),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("t"),
+                        Plurimath::Math::Symbol.new("x")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("k"),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("t"),
-                      Plurimath::Math::Symbol.new("y"),
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("k"),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("t"),
+                        Plurimath::Math::Symbol.new("y")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("k"),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("t"),
-                      Plurimath::Math::Symbol.new("z"),
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("k"),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("t"),
+                        Plurimath::Math::Symbol.new("z")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("k"),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("r"),
-                      Plurimath::Math::Symbol.new("x"),
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("k"),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("r"),
+                        Plurimath::Math::Symbol.new("x")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("k"),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("r"),
-                      Plurimath::Math::Symbol.new("y"),
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("k"),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("r"),
+                        Plurimath::Math::Symbol.new("y")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("k"),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("r"),
-                      Plurimath::Math::Symbol.new("z"),
-                    )
-                  ])
-                ])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("k"),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("r"),
+                        Plurimath::Math::Symbol.new("z")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -9740,153 +10585,183 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("x")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("m"),
+                        Plurimath::Math::Symbol.new("x")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("y")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("m"),
+                        Plurimath::Math::Symbol.new("y")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("z")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("m"),
+                        Plurimath::Math::Symbol.new("z")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("i"),
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("x"),
-                        Plurimath::Math::Symbol.new("x"),
-                      ]),
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("i"),
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("x"),
-                        Plurimath::Math::Symbol.new("y"),
-                      ]),
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("i"),
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("x"),
-                        Plurimath::Math::Symbol.new("z"),
-                      ]),
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("x"),
+                          Plurimath::Math::Symbol.new("x"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("x"),
+                          Plurimath::Math::Symbol.new("y"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("x"),
+                          Plurimath::Math::Symbol.new("z"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("i"),
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("x"),
-                        Plurimath::Math::Symbol.new("y"),
-                      ]),
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("i"),
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("y"),
-                        Plurimath::Math::Symbol.new("y"),
-                      ])
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("i"),
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("y"),
-                        Plurimath::Math::Symbol.new("z"),
-                      ])
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("x"),
+                          Plurimath::Math::Symbol.new("y"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("y"),
+                          Plurimath::Math::Symbol.new("y"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("y"),
+                          Plurimath::Math::Symbol.new("z"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("i"),
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("x"),
-                        Plurimath::Math::Symbol.new("z"),
-                      ]),
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("i"),
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("y"),
-                        Plurimath::Math::Symbol.new("z"),
-                      ])
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("i"),
-                      Plurimath::Math::Formula.new([
-                        Plurimath::Math::Symbol.new("z"),
-                        Plurimath::Math::Symbol.new("z"),
-                      ])
-                    )
-                  ])
-                ])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("x"),
+                          Plurimath::Math::Symbol.new("z"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("y"),
+                          Plurimath::Math::Symbol.new("z"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("z"),
+                          Plurimath::Math::Symbol.new("z"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c"),
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -11091,7 +11966,7 @@ RSpec.describe Plurimath::Latex::Parser do
               ])
             ],
             "(",
-            [],
+            ")",
           ),
           Plurimath::Math::Symbol.new("="),
           Plurimath::Math::Function::FontStyle::Bold.new(
@@ -11132,7 +12007,7 @@ RSpec.describe Plurimath::Latex::Parser do
               ])
             ],
             "(",
-            [],
+            ")",
           ),
           Plurimath::Math::Symbol.new(",")
         ])
@@ -11233,7 +12108,7 @@ RSpec.describe Plurimath::Latex::Parser do
           Plurimath::Math::Function::Power.new(
             Plurimath::Math::Function::FontStyle::Bold.new(
               Plurimath::Math::Symbol.new("F"),
-              "bf",
+              "bf"
             ),
             Plurimath::Math::Symbol.new("t")
           ),
@@ -11243,29 +12118,34 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("n"),
-                      Plurimath::Math::Symbol.new("y")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("n"),
+                        Plurimath::Math::Symbol.new("y")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("n"),
-                      Plurimath::Math::Symbol.new("z")
-                    )
-                  ])
-                ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("n"),
+                        Plurimath::Math::Symbol.new("z")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c")
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -11295,29 +12175,34 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("n"),
-                      Plurimath::Math::Symbol.new("y")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("n"),
+                        Plurimath::Math::Symbol.new("y")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("n"),
-                      Plurimath::Math::Symbol.new("z")
-                    )
-                  ])
-                ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("n"),
+                        Plurimath::Math::Symbol.new("z")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c")
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -11346,70 +12231,75 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::FontStyle.new(
-                        Plurimath::Math::Symbol.new("-"),
-                        "displaystyle"
-                      ),
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Function::Power.new(
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Function::FontStyle.new(
+                          Plurimath::Math::Symbol.new("-"),
+                          "displaystyle"
+                        ),
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Function::Power.new(
+                              Plurimath::Math::Symbol.new("&#x2202;"),
+                              Plurimath::Math::Number.new("2")
+                            ),
+                            Plurimath::Math::Symbol.new("v"),
+                          ]),
+                          Plurimath::Math::Formula.new([
                             Plurimath::Math::Symbol.new("&#x2202;"),
-                            Plurimath::Math::Number.new("2")
-                          ),
-                          Plurimath::Math::Symbol.new("v")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Function::Power.new(
-                            Plurimath::Math::Symbol.new("x"),
-                            Plurimath::Math::Number.new("2")
-                          )
-                        ])
-                      )
-                    ])
-                  ])
+                            Plurimath::Math::Function::Power.new(
+                              Plurimath::Math::Symbol.new("x"),
+                              Plurimath::Math::Number.new("2")
+                            ),
+                          ])
+                        ),
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("["),
-                    Plurimath::Math::Number.new("2"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("]"),
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::FontStyle.new(
-                        Plurimath::Math::Symbol.new("-"),
-                        "displaystyle"
-                      ),
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Function::Power.new(
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("["),
+                      Plurimath::Math::Number.new("2"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Function::FontStyle.new(
+                          Plurimath::Math::Symbol.new("-"),
+                          "displaystyle"
+                        ),
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Function::Power.new(
+                              Plurimath::Math::Symbol.new("&#x2202;"),
+                              Plurimath::Math::Number.new("2")
+                            ),
+                            Plurimath::Math::Symbol.new("w"),
+                          ]),
+                          Plurimath::Math::Formula.new([
                             Plurimath::Math::Symbol.new("&#x2202;"),
-                            Plurimath::Math::Number.new("2")
-                          ),
-                          Plurimath::Math::Symbol.new("w")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Function::Power.new(
-                            Plurimath::Math::Symbol.new("x"),
-                            Plurimath::Math::Number.new("2")
-                          )
-                        ])
-                      )
-                    ])
-                  ])
-                ])
+                            Plurimath::Math::Function::Power.new(
+                              Plurimath::Math::Symbol.new("x"),
+                              Plurimath::Math::Number.new("2")
+                            ),
+                          ])
+                        ),
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c")
-              ]
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -11433,52 +12323,57 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("&#x3b8;")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("y")
-                        ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("&#x2202;"),
+                            Plurimath::Math::Symbol.new("&#x3b8;"),
+                          ]),
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("&#x2202;"),
+                            Plurimath::Math::Symbol.new("y"),
+                          ])
+                        ),
+                        "displaystyle"
                       ),
-                      "displaystyle"
-                    )
-                  ])
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("["),
-                    Plurimath::Math::Number.new("3"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("]"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("&#x3b8;")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("z")
-                        ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("["),
+                      Plurimath::Math::Number.new("3"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("&#x2202;"),
+                            Plurimath::Math::Symbol.new("&#x3b8;"),
+                          ]),
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("&#x2202;"),
+                            Plurimath::Math::Symbol.new("z"),
+                          ])
+                        ),
+                        "displaystyle"
                       ),
-                      "displaystyle"
-                    )
-                  ])
-                ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c")
-              ]
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -11513,29 +12408,34 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("n"),
-                      Plurimath::Math::Symbol.new("x")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("n"),
+                        Plurimath::Math::Symbol.new("x")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("n"),
-                      Plurimath::Math::Symbol.new("y")
-                    )
-                  ])
-                ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("n"),
+                        Plurimath::Math::Symbol.new("y")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c")
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -11563,78 +12463,83 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::FontStyle.new(
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Function::FontStyle.new(
+                          Plurimath::Math::Function::Frac.new(
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("&#x2202;"),
+                              Plurimath::Math::Symbol.new("w"),
+                            ]),
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("&#x2202;"),
+                              Plurimath::Math::Symbol.new("x"),
+                            ])
+                          ),
+                          "displaystyle"
+                        ),
+                        Plurimath::Math::Symbol.new("+"),
                         Plurimath::Math::Function::Frac.new(
                           Plurimath::Math::Formula.new([
                             Plurimath::Math::Symbol.new("&#x2202;"),
-                            Plurimath::Math::Symbol.new("w")
+                            Plurimath::Math::Symbol.new("u"),
                           ]),
                           Plurimath::Math::Formula.new([
                             Plurimath::Math::Symbol.new("&#x2202;"),
-                            Plurimath::Math::Symbol.new("x")
+                            Plurimath::Math::Symbol.new("z"),
                           ])
                         ),
-                        "displaystyle"
-                      ),
-                      Plurimath::Math::Symbol.new("+"),
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("u")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("z")
-                        ])
-                      )
-                    ])
-                  ])
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("["),
-                    Plurimath::Math::Number.new("2"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("]"),
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::FontStyle.new(
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("["),
+                      Plurimath::Math::Number.new("2"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Function::FontStyle.new(
+                          Plurimath::Math::Function::Frac.new(
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("&#x2202;"),
+                              Plurimath::Math::Symbol.new("w"),
+                            ]),
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("&#x2202;"),
+                              Plurimath::Math::Symbol.new("y"),
+                            ])
+                          ),
+                          "displaystyle"
+                        ),
+                        Plurimath::Math::Symbol.new("+"),
                         Plurimath::Math::Function::Frac.new(
                           Plurimath::Math::Formula.new([
                             Plurimath::Math::Symbol.new("&#x2202;"),
-                            Plurimath::Math::Symbol.new("w")
+                            Plurimath::Math::Symbol.new("v"),
                           ]),
                           Plurimath::Math::Formula.new([
                             Plurimath::Math::Symbol.new("&#x2202;"),
-                            Plurimath::Math::Symbol.new("y")
+                            Plurimath::Math::Symbol.new("z"),
                           ])
                         ),
-                        "displaystyle"
-                      ),
-                      Plurimath::Math::Symbol.new("+"),
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("v")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("z")
-                        ])
-                      )
-                    ])
-                  ])
-                ])
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c")
-              ]
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -11662,83 +12567,93 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("u")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("x")
-                        ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("&#x2202;"),
+                            Plurimath::Math::Symbol.new("u"),
+                          ]),
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("&#x2202;"),
+                            Plurimath::Math::Symbol.new("x"),
+                          ])
+                        ),
+                        "displaystyle"
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("u")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("y")
-                        ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("&#x2202;"),
+                            Plurimath::Math::Symbol.new("u"),
+                          ]),
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("&#x2202;"),
+                            Plurimath::Math::Symbol.new("y"),
+                          ])
+                        ),
+                        "displaystyle"
                       ),
-                      "displaystyle"
-                    )
-                  ])
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("["),
-                    Plurimath::Math::Number.new("2"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("]"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("v")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("x")
-                        ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("["),
+                      Plurimath::Math::Number.new("2"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("&#x2202;"),
+                            Plurimath::Math::Symbol.new("v"),
+                          ]),
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("&#x2202;"),
+                            Plurimath::Math::Symbol.new("x"),
+                          ])
+                        ),
+                        "displaystyle"
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("v")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("y")
-                        ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("&#x2202;"),
+                            Plurimath::Math::Symbol.new("v"),
+                          ]),
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("&#x2202;"),
+                            Plurimath::Math::Symbol.new("y"),
+                          ])
+                        ),
+                        "displaystyle"
                       ),
-                      "displaystyle"
-                    )
-                  ])
-                ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c")
-              ]
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -11766,117 +12681,127 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::FontStyle.new(
-                        Plurimath::Math::Symbol.new("-"),
-                        "displaystyle"
-                      ),
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Function::Power.new(
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Function::FontStyle.new(
+                          Plurimath::Math::Symbol.new("-"),
+                          "displaystyle"
+                        ),
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Function::Power.new(
+                              Plurimath::Math::Symbol.new("&#x2202;"),
+                              Plurimath::Math::Number.new("2")
+                            ),
+                            Plurimath::Math::Symbol.new("w"),
+                          ]),
+                          Plurimath::Math::Formula.new([
                             Plurimath::Math::Symbol.new("&#x2202;"),
-                            Plurimath::Math::Number.new("2")
-                          ),
-                          Plurimath::Math::Symbol.new("w")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Function::Power.new(
+                            Plurimath::Math::Function::Power.new(
+                              Plurimath::Math::Symbol.new("x"),
+                              Plurimath::Math::Number.new("2")
+                            ),
+                          ])
+                        ),
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Function::FontStyle.new(
+                          Plurimath::Math::Symbol.new("-"),
+                          "displaystyle"
+                        ),
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Function::Power.new(
+                              Plurimath::Math::Symbol.new("&#x2202;"),
+                              Plurimath::Math::Number.new("2")
+                            ),
+                            Plurimath::Math::Symbol.new("w"),
+                          ]),
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("&#x2202;"),
                             Plurimath::Math::Symbol.new("x"),
-                            Plurimath::Math::Number.new("2")
-                          )
-                        ])
-                      )
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::FontStyle.new(
-                        Plurimath::Math::Symbol.new("-"),
-                        "displaystyle"
-                      ),
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Function::Power.new(
                             Plurimath::Math::Symbol.new("&#x2202;"),
-                            Plurimath::Math::Number.new("2")
-                          ),
-                          Plurimath::Math::Symbol.new("w")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("x"),
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("y")
-                        ])
-                      )
-                    ])
-                  ])
+                            Plurimath::Math::Symbol.new("y"),
+                          ])
+                        ),
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("["),
-                    Plurimath::Math::Number.new("2"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("m"),
-                    Plurimath::Math::Symbol.new("]"),
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::FontStyle.new(
-                        Plurimath::Math::Symbol.new("-"),
-                        "displaystyle"
-                      ),
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Function::Power.new(
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("["),
+                      Plurimath::Math::Number.new("2"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Function::FontStyle.new(
+                          Plurimath::Math::Symbol.new("-"),
+                          "displaystyle"
+                        ),
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Function::Power.new(
+                              Plurimath::Math::Symbol.new("&#x2202;"),
+                              Plurimath::Math::Number.new("2")
+                            ),
+                            Plurimath::Math::Symbol.new("w"),
+                          ]),
+                          Plurimath::Math::Formula.new([
                             Plurimath::Math::Symbol.new("&#x2202;"),
-                            Plurimath::Math::Number.new("2")
-                          ),
-                          Plurimath::Math::Symbol.new("w")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("x"),
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("y")
-                        ])
-                      )
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::FontStyle.new(
-                        Plurimath::Math::Symbol.new("-"),
-                        "displaystyle"
-                      ),
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Function::Power.new(
+                            Plurimath::Math::Symbol.new("x"),
                             Plurimath::Math::Symbol.new("&#x2202;"),
-                            Plurimath::Math::Number.new("2")
-                          ),
-                          Plurimath::Math::Symbol.new("w")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Function::Power.new(
                             Plurimath::Math::Symbol.new("y"),
-                            Plurimath::Math::Number.new("2")
-                          )
-                        ])
-                      )
-                    ])
-                  ])
-                ])
+                          ])
+                        ),
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Function::FontStyle.new(
+                          Plurimath::Math::Symbol.new("-"),
+                          "displaystyle"
+                        ),
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Function::Power.new(
+                              Plurimath::Math::Symbol.new("&#x2202;"),
+                              Plurimath::Math::Number.new("2")
+                            ),
+                            Plurimath::Math::Symbol.new("w"),
+                          ]),
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("&#x2202;"),
+                            Plurimath::Math::Function::Power.new(
+                              Plurimath::Math::Symbol.new("y"),
+                              Plurimath::Math::Number.new("2")
+                            ),
+                          ])
+                        ),
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c"),
-                Plurimath::Math::Symbol.new("c")
-              ]
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -12310,29 +13235,34 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("n"),
-                      Plurimath::Math::Symbol.new("x")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("n"),
+                        Plurimath::Math::Symbol.new("x")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("n"),
-                      Plurimath::Math::Symbol.new("y")
-                    )
-                  ])
-                ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("n"),
+                        Plurimath::Math::Symbol.new("y")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c")
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -12463,7 +13393,7 @@ RSpec.describe Plurimath::Latex::Parser do
               ])
             ],
             "[",
-            [],
+            "]",
           )
         ])
         expect(formula).to eq(expected_value)
@@ -12611,7 +13541,7 @@ RSpec.describe Plurimath::Latex::Parser do
               ])
             ],
             "[",
-            [],
+            "]",
           )
         ])
         expect(formula).to eq(expected_value)

--- a/spec/plurimath/latex_spec.rb
+++ b/spec/plurimath/latex_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../lib/plurimath/math'
+require_relative '../../spec/spec_helper'
 
 RSpec.describe Plurimath::Latex do
 
@@ -29,6 +29,2162 @@ RSpec.describe Plurimath::Latex do
           ),
         ])
         expect(formula).to eq(expected_value)
+      end
+    end
+  end
+
+  describe ".to_mathml" do
+    subject(:formula) { described_class.new(string.gsub(/\s/, "")).to_formula }
+
+    context "contains example #01" do
+      let(:string) { '\\cos{45}' }
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mrow>
+                <mi>cos</mi>
+                <mn>45</mn>
+              </mrow>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "\\cos{45}"
+        expect(formula.to_latex).to be_equivalent_to(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #02" do
+      let(:string) { '1 \\over 2' }
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mfrac>
+                <mrow>
+                  <mn>1</mn>
+                </mrow>
+                <mrow>
+                  <mn>2</mn>
+                </mrow>
+              </mfrac>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "{1 \\over 2}"
+        expect(formula.to_latex).to be_equivalent_to(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #03" do
+      let(:string) { "L' \\over {1\\over2}" }
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mfrac>
+                <mrow>
+                  <mi>L</mi>
+                  <mo>&#x27;</mo>
+                </mrow>
+                <mrow>
+                  <mfrac>
+                    <mrow>
+                      <mn>1</mn>
+                    </mrow>
+                    <mrow>
+                      <mn>2</mn>
+                    </mrow>
+                  </mfrac>
+                </mrow>
+              </mfrac>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "L{' \\over {1 \\over 2}}"
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #04" do
+      let(:string) { '\\left\\{\\right.' }
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mrow>
+                <mo>{</mo>
+                <mo/>
+              </mrow>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "\\left \\{ \\right"
+        expect(formula.to_latex).to be_equivalent_to(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #05" do
+      let(:string) { '\\begin{matrix}a & b \\\\ c & d \\end{matrix}' }
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mtable>
+                <mtr>
+                  <mtd>
+                    <mi>a</mi>
+                  </mtd>
+                  <mtd>
+                    <mi>b</mi>
+                  </mtd>
+                </mtr>
+                <mtr>
+                  <mtd>
+                    <mi>c</mi>
+                  </mtd>
+                  <mtd>
+                    <mi>d</mi>
+                  </mtd>
+                </mtr>
+              </mtable>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "\\begin{matrix}a & b \\\\ c & d\\end{matrix}"
+        expect(formula.to_latex).to be_equivalent_to(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #06" do
+      let(:string) do
+        <<~LATEX
+          \\left\\{
+            \\begin{array}{ l|cr }{ 3x - 5y + 4z = 0} & d \\\\ { x - y + 8z = 0} & e \\\\{ 2x - 6y + z = 0} & c \\end{array}
+          \\right\\}
+        LATEX
+      end
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mrow>
+                <mo>{</mo>
+                <mtable columnlines="solid none">
+                  <mtr>
+                    <mtd columnalign="left">
+                      <mrow>
+                        <mn>3</mn>
+                        <mi>x</mi>
+                        <mo>&#x2212;</mo>
+                        <mn>5</mn>
+                        <mi>y</mi>
+                        <mo>+</mo>
+                        <mn>4</mn>
+                        <mi>z</mi>
+                        <mo>=</mo>
+                        <mn>0</mn>
+                      </mrow>
+                    </mtd>
+                    <mtd columnalign="center">
+                      <mi>d</mi>
+                    </mtd>
+                  </mtr>
+                  <mtr>
+                    <mtd columnalign="left">
+                      <mrow>
+                        <mi>x</mi>
+                        <mo>&#x2212;</mo>
+                        <mi>y</mi>
+                        <mo>+</mo>
+                        <mn>8</mn>
+                        <mi>z</mi>
+                        <mo>=</mo>
+                        <mn>0</mn>
+                      </mrow>
+                    </mtd>
+                    <mtd columnalign="center">
+                      <mi>e</mi>
+                    </mtd>
+                  </mtr>
+                  <mtr>
+                    <mtd columnalign="left">
+                      <mrow>
+                        <mn>2</mn>
+                        <mi>x</mi>
+                        <mo>&#x2212;</mo>
+                        <mn>6</mn>
+                        <mi>y</mi>
+                        <mo>+</mo>
+                        <mi>z</mi>
+                        <mo>=</mo>
+                        <mn>0</mn>
+                      </mrow>
+                    </mtd>
+                    <mtd columnalign="center">
+                      <mi>c</mi>
+                    </mtd>
+                  </mtr>
+                </mtable>
+                <mo>}</mo>
+              </mrow>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "\\left \\{ \\begin{array}{l|c}3 x - 5 y + 4 z = 0 & d \\\\ x - y + 8 z = 0 & e \\\\ 2 x - 6 y + z = 0 & c\\end{array} \\right \\}"
+        expect(formula.to_latex).to be_equivalent_to(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #07" do
+      let(:string) { "\\begin{matrix*}[r]a & b \\\\ c & d \\end{matrix*}" }
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mtable>
+                <mtr>
+                  <mtd columnalign="right">
+                    <mi>a</mi>
+                  </mtd>
+                  <mtd columnalign="right">
+                    <mi>b</mi>
+                  </mtd>
+                </mtr>
+                <mtr>
+                  <mtd columnalign="right">
+                    <mi>c</mi>
+                  </mtd>
+                  <mtd columnalign="right">
+                    <mi>d</mi>
+                  </mtd>
+                </mtr>
+              </mtable>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "\\begin{matrix*}[r]a & b \\\\ c & d\\end{matrix*}"
+        expect(formula.to_latex).to be_equivalent_to(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #08" do
+      let(:string) { "\\begin{matrix*}[r]a & b \\\\ c & d \\end{matrix*}" }
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mtable>
+                <mtr>
+                  <mtd columnalign="right">
+                    <mi>a</mi>
+                  </mtd>
+                  <mtd columnalign="right">
+                    <mi>b</mi>
+                  </mtd>
+                </mtr>
+                <mtr>
+                  <mtd columnalign="right">
+                    <mi>c</mi>
+                  </mtd>
+                  <mtd columnalign="right">
+                    <mi>d</mi>
+                  </mtd>
+                </mtr>
+              </mtable>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "\\begin{matrix*}[r]a & b \\\\ c & d\\end{matrix*}"
+        expect(formula.to_latex).to be_equivalent_to(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #09" do
+      let(:string) { "\\begin{matrix}-a & b \\\\ c & d \\end{matrix}" }
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mtable>
+                <mtr>
+                  <mtd>
+                    <mrow>
+                      <mo>&#x2212;</mo>
+                      <mi>a</mi>
+                    </mrow>
+                  </mtd>
+                  <mtd>
+                    <mi>b</mi>
+                  </mtd>
+                </mtr>
+                <mtr>
+                  <mtd>
+                    <mi>c</mi>
+                  </mtd>
+                  <mtd>
+                    <mi>d</mi>
+                  </mtd>
+                </mtr>
+              </mtable>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "\\begin{matrix}- a & b \\\\ c & d\\end{matrix}"
+        expect(formula.to_latex).to be_equivalent_to(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #10" do
+      let(:string) { "\\begin{matrix}-\\end{matrix}" }
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mtable>
+                <mtr>
+                  <mtd>
+                    <mo>&#x2212;</mo>
+                  </mtd>
+                </mtr>
+              </mtable>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "\\begin{matrix}-\\end{matrix}"
+        expect(formula.to_latex).to be_equivalent_to(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #11" do
+      let(:string) { "\\begin{matrix}a_{1} & b_{2} \\\\ c_{3} & d_{4} \\end{matrix}" }
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mtable>
+                <mtr>
+                  <mtd>
+                    <msub>
+                      <mi>a</mi>
+                      <mn>1</mn>
+                    </msub>
+                  </mtd>
+                  <mtd>
+                    <msub>
+                      <mi>b</mi>
+                      <mn>2</mn>
+                    </msub>
+                  </mtd>
+                </mtr>
+                <mtr>
+                  <mtd>
+                    <msub>
+                      <mi>c</mi>
+                      <mn>3</mn>
+                    </msub>
+                  </mtd>
+                  <mtd>
+                    <msub>
+                      <mi>d</mi>
+                      <mn>4</mn>
+                    </msub>
+                  </mtd>
+                </mtr>
+              </mtable>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "\\begin{matrix}a_{1} & b_{2} \\\\ c_{3} & d_{4}\\end{matrix}"
+        expect(formula.to_latex).to be_equivalent_to(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #12" do
+      let(:string) { "\\begin{array}{cc} 1 & 2 \\\\ 3 & 4 \\end{array}" }
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mtable>
+                <mtr>
+                  <mtd columnalign="center">
+                    <mn>1</mn>
+                  </mtd>
+                  <mtd columnalign="center">
+                    <mn>2</mn>
+                  </mtd>
+                </mtr>
+                <mtr>
+                  <mtd columnalign="center">
+                    <mn>3</mn>
+                  </mtd>
+                  <mtd columnalign="center">
+                    <mn>4</mn>
+                  </mtd>
+                </mtr>
+              </mtable>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "\\begin{array}{cc}1 & 2 \\\\ 3 & 4\\end{array}"
+        expect(formula.to_latex).to be_equivalent_to(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #13" do
+      let(:string) do
+        <<~LATEX
+          \\begin{bmatrix}
+            a_{1,1} & a_{1,2} & \\cdots & a_{1,n} \\\\
+            a_{2,1} & a_{2,2} & \\cdots & a_{2,n} \\\\
+            \\vdots & \\vdots & \\ddots & \\vdots \\\\
+            a_{m,1} & a_{m,2} & \\cdots & a_{m,n}
+          \\end{bmatrix}
+        LATEX
+      end
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mfenced open="[" close="]">
+                <mtable>
+                  <mtr>
+                    <mtd>
+                      <msub>
+                        <mi>a</mi>
+                        <mrow>
+                          <mn>1</mn>
+                          <mo>,</mo>
+                          <mn>1</mn>
+                        </mrow>
+                      </msub>
+                    </mtd>
+                    <mtd>
+                      <msub>
+                        <mi>a</mi>
+                        <mrow>
+                          <mn>1</mn>
+                          <mo>,</mo>
+                          <mn>2</mn>
+                        </mrow>
+                      </msub>
+                    </mtd>
+                    <mtd>
+                      <mo>&#x22ef;</mo>
+                    </mtd>
+                    <mtd>
+                      <msub>
+                        <mi>a</mi>
+                        <mrow>
+                          <mn>1</mn>
+                          <mo>,</mo>
+                          <mi>n</mi>
+                        </mrow>
+                      </msub>
+                    </mtd>
+                  </mtr>
+                  <mtr>
+                    <mtd>
+                      <msub>
+                        <mi>a</mi>
+                        <mrow>
+                          <mn>2</mn>
+                          <mo>,</mo>
+                          <mn>1</mn>
+                        </mrow>
+                      </msub>
+                    </mtd>
+                    <mtd>
+                      <msub>
+                        <mi>a</mi>
+                        <mrow>
+                          <mn>2</mn>
+                          <mo>,</mo>
+                          <mn>2</mn>
+                        </mrow>
+                      </msub>
+                    </mtd>
+                    <mtd>
+                      <mo>&#x22ef;</mo>
+                    </mtd>
+                    <mtd>
+                      <msub>
+                        <mi>a</mi>
+                        <mrow>
+                          <mn>2</mn>
+                          <mo>,</mo>
+                          <mi>n</mi>
+                        </mrow>
+                      </msub>
+                    </mtd>
+                  </mtr>
+                  <mtr>
+                    <mtd>
+                      <mo>&#x22ee;</mo>
+                    </mtd>
+                    <mtd>
+                      <mo>&#x22ee;</mo>
+                    </mtd>
+                    <mtd>
+                      <mo>&#x22f1;</mo>
+                    </mtd>
+                    <mtd>
+                      <mo>&#x22ee;</mo>
+                    </mtd>
+                  </mtr>
+                  <mtr>
+                    <mtd>
+                      <msub>
+                        <mi>a</mi>
+                        <mrow>
+                          <mi>m</mi>
+                          <mo>,</mo>
+                          <mn>1</mn>
+                        </mrow>
+                      </msub>
+                    </mtd>
+                    <mtd>
+                      <msub>
+                        <mi>a</mi>
+                        <mrow>
+                          <mi>m</mi>
+                          <mo>,</mo>
+                          <mn>2</mn>
+                        </mrow>
+                      </msub>
+                    </mtd>
+                    <mtd>
+                      <mo>&#x22ef;</mo>
+                    </mtd>
+                    <mtd>
+                      <msub>
+                        <mi>a</mi>
+                        <mrow>
+                          <mi>m</mi>
+                          <mo>,</mo>
+                          <mi>n</mi>
+                        </mrow>
+                      </msub>
+                    </mtd>
+                  </mtr>
+                </mtable>
+              </mfenced>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "\\begin{bmatrix}a_{1 , 1} & a_{1 , 2} & \\cdots & a_{1 , n} \\\\ a_{2 , 1} & a_{2 , 2} & \\cdots & a_{2 , n} \\\\ \\vdots & \\vdots & \\ddots & \\vdots \\\\ a_{m , 1} & a_{m , 2} & \\cdots & a_{m , n}\\end{bmatrix}"
+        expect(formula.to_latex).to be_equivalent_to(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #14" do
+      let(:string) { "\\sqrt { ( - 25 ) ^ { 2 } } = \\pm 25" }
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <msqrt>
+                <mrow>
+                  <mo>(</mo>
+                  <mo>&#x2212;</mo>
+                  <mn>25</mn>
+                  <msup>
+                    <mo>)</mo>
+                    <mn>2</mn>
+                  </msup>
+                </mrow>
+              </msqrt>
+              <mo>=</mo>
+              <mo>&#xb1;</mo>
+              <mn>25</mn>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "\\sqrt{( - 25 )^{2}} = \\pm 25"
+        expect(formula.to_latex).to be_equivalent_to(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #15" do
+      let(:string) { "\\left(- x^{3} + 5\\right)^{5}" }
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <msup>
+                <mrow>
+                  <mo>(</mo>
+                  <mrow>
+                    <mo>&#x2212;</mo>
+                    <msup>
+                      <mi>x</mi>
+                      <mn>3</mn>
+                    </msup>
+                    <mo>+</mo>
+                    <mn>5</mn>
+                  </mrow>
+                  <mo>)</mo>
+                </mrow>
+                <mn>5</mn>
+              </msup>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "\\left ( - x^{3} + 5 \\right )^{5}"
+        expect(formula.to_latex).to be_equivalent_to(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #16" do
+      let(:string) do
+        <<~LATEX
+          \\begin{array}{rcl}
+            ABC&=&a\\\\
+            A&=&abc
+          \\end{array}
+        LATEX
+      end
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mtable>
+                <mtr>
+                  <mtd columnalign="right">
+                    <mi>A</mi>
+                    <mi>B</mi>
+                    <mi>C</mi>
+                  </mtd>
+                  <mtd columnalign="center">
+                    <mo>=</mo>
+                  </mtd>
+                  <mtd columnalign="left">
+                    <mi>a</mi>
+                  </mtd>
+                </mtr>
+                <mtr>
+                  <mtd columnalign="right">
+                    <mi>A</mi>
+                  </mtd>
+                  <mtd columnalign="center">
+                    <mo>=</mo>
+                  </mtd>
+                  <mtd columnalign="left">
+                    <mi>a</mi>
+                    <mi>b</mi>
+                    <mi>c</mi>
+                  </mtd>
+                </mtr>
+              </mtable>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "\\begin{array}{rcl}A B C & = & a \\\\ A & = & a b c\\end{array}"
+        expect(formula.to_latex).to be_equivalent_to(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #17" do
+      let(:string) do
+        <<~LATEX
+          \\begin{array}{c|r}
+            1 & 2 \\\\
+            3 & 4 \\\\
+            \\hline 5 & 6
+          \\end{array}
+        LATEX
+      end
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mtable rowline="none none solid" columnlines="solid none">
+                <mtr>
+                  <mtd columnalign="center">
+                    <mn>1</mn>
+                  </mtd>
+                  <mtd columnalign="right">
+                    <mn>2</mn>
+                  </mtd>
+                </mtr>
+                <mtr>
+                  <mtd columnalign="center">
+                    <mn>3</mn>
+                  </mtd>
+                  <mtd columnalign="right">
+                    <mn>4</mn>
+                  </mtd>
+                </mtr>
+                <mtr>
+                  <mtd columnalign="center">
+                    <mn>5</mn>
+                  </mtd>
+                  <mtd columnalign="right">
+                    <mn>6</mn>
+                  </mtd>
+                </mtr>
+              </mtable>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "\\begin{array}{c|r}1 & 2 \\\\ 3 & 4 \\\\ \\hline 5 & 6\\end{array}"
+        expect(formula.to_latex).to be_equivalent_to(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #18" do
+      let(:string) do
+        <<~LATEX
+          \\begin{array}{cr}
+            1 & 2 \\\\
+            \\hline 3 & 4 \\\\
+            \\hline 5 & 6
+          \\end{array}
+        LATEX
+      end
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mtable rowline="none solid solid">
+                <mtr>
+                  <mtd columnalign="center">
+                    <mn>1</mn>
+                  </mtd>
+                  <mtd columnalign="right">
+                    <mn>2</mn>
+                  </mtd>
+                </mtr>
+                <mtr>
+                  <mtd columnalign="center">
+                    <mn>3</mn>
+                  </mtd>
+                  <mtd columnalign="right">
+                    <mn>4</mn>
+                  </mtd>
+                </mtr>
+                <mtr>
+                  <mtd columnalign="center">
+                    <mn>5</mn>
+                  </mtd>
+                  <mtd columnalign="right">
+                    <mn>6</mn>
+                  </mtd>
+                </mtr>
+              </mtable>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "\\begin{array}{cr}1 & 2 \\\\ \\hline 3 & 4 \\\\ \\hline 5 & 6\\end{array}"
+        expect(formula.to_latex).to be_equivalent_to(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #19" do
+      let(:string) { "\\mathrm{...}" }
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mstyle mathvariant="normal">
+                <mrow>
+                  <mo>&#xb7;</mo>
+                  <mo>&#xb7;</mo>
+                  <mo>&#xb7;</mo>
+                </mrow>
+              </mstyle>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "\\mathrm{. . .}"
+        expect(formula.to_latex).to be_equivalent_to(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #20" do
+      let(:string) { "\\frac{x + 4}{x + \\frac{123 \\left(\\sqrt{x} + 5\\right)}{x + 4} - 8}" }
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mfrac>
+                <mrow>
+                  <mi>x</mi>
+                  <mo>+</mo>
+                  <mn>4</mn>
+                </mrow>
+                <mrow>
+                  <mi>x</mi>
+                  <mo>+</mo>
+                  <mfrac>
+                    <mrow>
+                      <mn>123</mn>
+                      <mrow>
+                        <mo>(</mo>
+                        <mrow>
+                          <msqrt>
+                            <mi>x</mi>
+                          </msqrt>
+                          <mo>+</mo>
+                          <mn>5</mn>
+                        </mrow>
+                        <mo>)</mo>
+                      </mrow>
+                    </mrow>
+                    <mrow>
+                      <mi>x</mi>
+                      <mo>+</mo>
+                      <mn>4</mn>
+                    </mrow>
+                  </mfrac>
+                  <mo>&#x2212;</mo>
+                  <mn>8</mn>
+                </mrow>
+              </mfrac>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "\\frac{x + 4}{x + \\frac{123 \\left ( \\sqrt{x} + 5 \\right )}{x + 4} - 8}"
+        expect(formula.to_latex).to be_equivalent_to(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #21" do
+      let(:string) { "\\sqrt {\\sqrt {\\left( x^{3}\\right) + v}}" }
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <msqrt>
+                <msqrt>
+                  <mrow>
+                    <mrow>
+                      <mo>(</mo>
+                      <msup>
+                        <mi>x</mi>
+                        <mn>3</mn>
+                      </msup>
+                      <mo>)</mo>
+                    </mrow>
+                    <mo>+</mo>
+                    <mi>v</mi>
+                  </mrow>
+                </msqrt>
+              </msqrt>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "\\sqrt{\\sqrt{\\left ( x^{3} \\right ) + v}}"
+        expect(formula.to_latex).to be_equivalent_to(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #22" do
+      let(:string) { "\\left(x\\right){5}" }
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mrow>
+                <mo>(</mo>
+                <mi>x</mi>
+                <mo>)</mo>
+              </mrow>
+              <mn>5</mn>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "\\left ( x \\right ) 5"
+        expect(formula.to_latex).to be_equivalent_to(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #23" do
+      let(:string) { "\\sqrt[3]{}" }
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mroot>
+                <mrow/>
+                <mrow>
+                  <mn>3</mn>
+                </mrow>
+              </mroot>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "\\sqrt[3]{}"
+        expect(formula.to_latex).to be_equivalent_to(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #24" do
+      let(:string) { "1_{}" }
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <msub>
+                <mn>1</mn>
+              </msub>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "1_{}"
+        expect(formula.to_latex).to be_equivalent_to(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #25" do
+      let(:string) { "\\array{}" }
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mtable>
+                <mtr>
+                  <mtd/>
+                </mtr>
+              </mtable>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "\\begin{array}\\end{array}"
+        expect(formula.to_latex).to be_equivalent_to(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #26" do
+      let(:string) { "\\array{{}}" }
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mtable>
+                <mtr>
+                  <mtd/>
+                </mtr>
+              </mtable>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "\\begin{array}\\end{array}"
+        expect(formula.to_latex).to be_equivalent_to(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #27" do
+      let(:string) do
+        <<~LATEX
+          \\left[
+            \\begin{matrix}
+              1 & 0 & 0 & 0\\\\
+              0 & 1 & 0 & 0\\\\
+              0 & 0 & 1 & 0\\\\
+              0 & 0 & 0 & 1
+            \\end{matrix}
+          \\right]
+        LATEX
+      end
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mrow>
+                <mo>[</mo>
+                <mtable>
+                  <mtr>
+                    <mtd>
+                      <mn>1</mn>
+                    </mtd>
+                    <mtd>
+                      <mn>0</mn>
+                    </mtd>
+                    <mtd>
+                      <mn>0</mn>
+                    </mtd>
+                    <mtd>
+                      <mn>0</mn>
+                    </mtd>
+                  </mtr>
+                  <mtr>
+                    <mtd>
+                      <mn>0</mn>
+                    </mtd>
+                    <mtd>
+                      <mn>1</mn>
+                    </mtd>
+                    <mtd>
+                      <mn>0</mn>
+                    </mtd>
+                    <mtd>
+                      <mn>0</mn>
+                    </mtd>
+                  </mtr>
+                  <mtr>
+                    <mtd>
+                      <mn>0</mn>
+                    </mtd>
+                    <mtd>
+                      <mn>0</mn>
+                    </mtd>
+                    <mtd>
+                      <mn>1</mn>
+                    </mtd>
+                    <mtd>
+                      <mn>0</mn>
+                    </mtd>
+                  </mtr>
+                  <mtr>
+                    <mtd>
+                      <mn>0</mn>
+                    </mtd>
+                    <mtd>
+                      <mn>0</mn>
+                    </mtd>
+                    <mtd>
+                      <mn>0</mn>
+                    </mtd>
+                    <mtd>
+                      <mn>1</mn>
+                    </mtd>
+                  </mtr>
+                </mtable>
+                <mo>]</mo>
+              </mrow>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "\\left [ \\begin{matrix}1 & 0 & 0 & 0 \\\\ 0 & 1 & 0 & 0 \\\\ 0 & 0 & 1 & 0 \\\\ 0 & 0 & 0 & 1\\end{matrix} \\right ]"
+        expect(formula.to_latex).to be_equivalent_to(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #28" do
+      let(:string) do
+        <<~LATEX
+          x^{x^{x^{x}}}
+          \\left(
+            x^{x^{x}}
+            \\left(
+              x^{x}
+              \\left(
+                \\log{\\left(x \\right)} + 1
+              \\right) \\log{\\left(x \\right)} + \\frac{x^{x}}{x}
+            \\right) \\log{\\left(x \\right)} + \\frac{x^{x^{x}}}{x}
+          \\right)
+        LATEX
+      end
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <msup>
+                <mi>x</mi>
+                <msup>
+                  <mi>x</mi>
+                  <msup>
+                    <mi>x</mi>
+                    <mi>x</mi>
+                  </msup>
+                </msup>
+              </msup>
+              <mrow>
+                <mo>(</mo>
+                <mrow>
+                  <msup>
+                    <mi>x</mi>
+                    <msup>
+                      <mi>x</mi>
+                      <mi>x</mi>
+                    </msup>
+                  </msup>
+                  <mrow>
+                    <mo>(</mo>
+                    <mrow>
+                      <msup>
+                        <mi>x</mi>
+                        <mi>x</mi>
+                      </msup>
+                      <mrow>
+                        <mo>(</mo>
+                        <mrow>
+                          <mi>log</mi>
+                          <mrow>
+                            <mo>(</mo>
+                            <mi>x</mi>
+                            <mo>)</mo>
+                          </mrow>
+                          <mo>+</mo>
+                          <mn>1</mn>
+                        </mrow>
+                        <mo>)</mo>
+                      </mrow>
+                      <mi>log</mi>
+                      <mrow>
+                        <mo>(</mo>
+                        <mi>x</mi>
+                        <mo>)</mo>
+                      </mrow>
+                      <mo>+</mo>
+                      <mfrac>
+                        <msup>
+                          <mi>x</mi>
+                          <mi>x</mi>
+                        </msup>
+                        <mi>x</mi>
+                      </mfrac>
+                    </mrow>
+                    <mo>)</mo>
+                  </mrow>
+                  <mi>log</mi>
+                  <mrow>
+                    <mo>(</mo>
+                    <mi>x</mi>
+                    <mo>)</mo>
+                  </mrow>
+                  <mo>+</mo>
+                  <mfrac>
+                    <msup>
+                      <mi>x</mi>
+                      <msup>
+                        <mi>x</mi>
+                        <mi>x</mi>
+                      </msup>
+                    </msup>
+                    <mi>x</mi>
+                  </mfrac>
+                </mrow>
+                <mo>)</mo>
+              </mrow>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "x^{x^{x^{x}}} \\left ( x^{x^{x}} \\left ( x^{x} \\left ( \\log \\left ( x \\right ) + 1 \\right ) \\log \\left ( x \\right ) + \\frac{x^{x}}{x} \\right ) \\log \\left ( x \\right ) + \\frac{x^{x^{x}}}{x} \\right )"
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #29" do
+      let(:string) { "\\log_2{x}" }
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <msubsup>
+                <mi>log</mi>
+                <mn>2</mn>
+              </msubsup>
+              <mi>x</mi>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "\\log_{2} x"
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #30" do
+      let(:string) { "\\sqrt[]{3}" }
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mroot>
+                <mn>3</mn>
+                <mrow/>
+              </mroot>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "\\sqrt[]{3}"
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #31" do
+      let(:string) { "\\frac{3}{\\frac{1}{2}{x}^{2}}" }
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mfrac>
+                <mn>3</mn>
+                <mrow>
+                  <mfrac>
+                    <mn>1</mn>
+                    <mn>2</mn>
+                  </mfrac>
+                  <msup>
+                    <mi>x</mi>
+                    <mn>2</mn>
+                  </msup>
+                </mrow>
+              </mfrac>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "\\frac{3}{\\frac{1}{2} x^{2}}"
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #32" do
+      let(:string) { "\\frac{3}{\\frac{1}{2}{x}^{2}-\\frac{3\\sqrt[]{3}}{2}x+3}" }
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mfrac>
+                <mn>3</mn>
+                <mrow>
+                  <mfrac>
+                    <mn>1</mn>
+                    <mn>2</mn>
+                  </mfrac>
+                  <msup>
+                    <mi>x</mi>
+                    <mn>2</mn>
+                  </msup>
+                  <mo>&#x2212;</mo>
+                  <mfrac>
+                    <mrow>
+                      <mn>3</mn>
+                      <mroot>
+                        <mn>3</mn>
+                        <mrow/>
+                      </mroot>
+                    </mrow>
+                    <mn>2</mn>
+                  </mfrac>
+                  <mi>x</mi>
+                  <mo>+</mo>
+                  <mn>3</mn>
+                </mrow>
+              </mfrac>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "\\frac{3}{\\frac{1}{2} x^{2} - \\frac{3 \\sqrt[]{3}}{2} x + 3}"
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #33" do
+      let(:string) { "^3" }
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mo>^</mo>
+              <mn>3</mn>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "^ 3"
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #34" do
+      let(:string) { "\\lim_{x \\to +\\infty} f(x)" }
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <munder>
+                <mo>lim</mo>
+                <mrow>
+                  <mi>x</mi>
+                  <mo>&#x2192;</mo>
+                  <mo>+</mo>
+                  <mo>&#x221e;</mo>
+                </mrow>
+              </munder>
+              <mi>f</mi>
+              <mo>(</mo>
+              <mi>x</mi>
+              <mo>)</mo>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "\\lim_{x \\to + \\infty} f ( x )"
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #35" do
+      let(:string) { "\\inf_{x > s}f(x)" }
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <munder>
+                <mo>inf</mo>
+                <mrow>
+                  <mi>x</mi>
+                  <mo>&#x3e;</mo>
+                  <mi>s</mi>
+                </mrow>
+              </munder>
+              <mi>f</mi>
+              <mo>(</mo>
+              <mi>x</mi>
+              <mo>)</mo>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "\\inf_{x > s} f ( x )"
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #36" do
+      let(:string) { "\\sup_{x \\in \\mathbb{R}}f(x)" }
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <msub>
+                <mo>sup</mo>
+                <mrow>
+                  <mi>x</mi>
+                  <mo>&#x2208;</mo>
+                  <mstyle mathvariant="double-struck">
+                    <mi>R</mi>
+                  </mstyle>
+                </mrow>
+              </msub>
+              <mi>f</mi>
+              <mo>(</mo>
+              <mi>x</mi>
+              <mo>)</mo>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "\\sup_{x \\in \\mathbb{R}} f ( x )"
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #37" do
+      let(:string) { "\\max_{x \\in \\[a,b\\]}f(x)" }
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <munder>
+                <mrow>
+                  <mi>max</mi>
+                </mrow>
+                <mrow>
+                  <mi>x</mi>
+                  <mo>&#x2208;</mo>
+                  <mo>[</mo>
+                  <mi>a</mi>
+                  <mo>,</mo>
+                  <mi>b</mi>
+                  <mo>]</mo>
+                </mrow>
+              </munder>
+              <mi>f</mi>
+              <mo>(</mo>
+              <mi>x</mi>
+              <mo>)</mo>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "\\max_{x \\in [ a , b ]} f ( x )"
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #38" do
+      let(:string) { "\\min_{x \\in \\[\\alpha,\\beta\\]}f(x)" }
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <munder>
+                <mrow>
+                  <mi>min</mi>
+                </mrow>
+                <mrow>
+                  <mi>x</mi>
+                  <mo>&#x2208;</mo>
+                  <mo>[</mo>
+                  <mi>&#x3b1;</mi>
+                  <mo>,</mo>
+                  <mi>&#x3b2;</mi>
+                  <mo>]</mo>
+                </mrow>
+              </munder>
+              <mi>f</mi>
+              <mo>(</mo>
+              <mi>x</mi>
+              <mo>)</mo>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "\\min_{x \\in [ \\alpha , \\beta ]} f ( x )"
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #39" do
+      let(:string) { "\\int\\limits_{0}^{\\pi}" }
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <munderover>
+                <mo>&#x222b;</mo>
+                <mn>0</mn>
+                <mi>&#x3c0;</mi>
+              </munderover>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "\\int\\limits_{0}^{\\pi}"
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #40" do
+      let(:string) { "\\sum_{\\substack{1\\le i\\le n\\\\ i\\ne j}}" }
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <munder>
+                <mo>&#x2211;</mo>
+                <mtable>
+                  <mtr>
+                    <mtd>
+                      <mn>1</mn>
+                      <mo>&#x2264;</mo>
+                      <mi>i</mi>
+                      <mo>&#x2264;</mo>
+                      <mi>n</mi>
+                    </mtd>
+                  </mtr>
+                  <mtr>
+                    <mtd>
+                      <mi>i</mi>
+                      <mo>&#x2260;</mo>
+                      <mi>j</mi>
+                    </mtd>
+                  </mtr>
+                </mtable>
+              </munder>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "\\sum_{\\substack{1 \\le i \\le n\\\\i \\ne j}}"
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #41" do
+      let(:string) { "\\mathrm{AA}" }
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mstyle mathvariant="normal">
+                <mrow>
+                  <mi>A</mi>
+                  <mi>A</mi>
+                </mrow>
+              </mstyle>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "\\mathrm{A A}"
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #42" do
+      let(:string) { "(1+(x-y)^{2})" }
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mo>(</mo>
+              <mn>1</mn>
+              <mo>+</mo>
+              <mo>(</mo>
+              <mi>x</mi>
+              <mo>&#x2212;</mo>
+              <mi>y</mi>
+              <msup>
+                <mo>)</mo>
+                <mn>2</mn>
+              </msup>
+              <mo>)</mo>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "( 1 + ( x - y )^{2} )"
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #43" do
+      let(:string) do
+        <<~LATEX
+          \\begin{array}{cc}
+            \\left(
+              \\begin{array}{ccccccc}
+                & & & & & & \\\\
+                & +k & & & & -k  \\\\
+                & & & & & & \\\\
+                & & & & & & \\\\
+                & & & & & & \\\\
+                & -k & & & & +k
+              \\end{array}
+            \\right) &
+            \\begin{array}{cc}
+              & \\\\
+              \\cdots & \\mbox{degree of freedom 1, node 1} \\\\
+              & \\\\
+              & \\\\
+              & \\\\
+              \\cdots & \\mbox{degree of freedom 2, node 2}
+            \\end{array} \\\\ & \\\\
+            \\begin{array}{cccccc}
+              \\vdots & & & & & \\vdots
+            \\end{array} & \\\\
+            \\begin{array}{cccc}
+              & \\mbox{degree of}  & \\mbox{degree of}  & \\\\
+              & \\mbox{freedom 1,} & \\mbox{freedom 2,} & \\\\
+              & \\mbox{node 1} & \\mbox{node 2}  &
+            \\end{array}    &
+          \\end{array}
+        LATEX
+      end
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mtable>
+                <mtr>
+                  <mtd columnalign="center">
+                    <mrow>
+                      <mo>(</mo>
+                      <mtable>
+                        <mtr>
+                          <mtd columnalign="center"/>
+                          <mtd columnalign="center"/>
+                          <mtd columnalign="center"/>
+                          <mtd columnalign="center"/>
+                          <mtd columnalign="center"/>
+                          <mtd columnalign="center"/>
+                          <mtd columnalign="center"/>
+                        </mtr>
+                        <mtr>
+                          <mtd columnalign="center"/>
+                          <mtd columnalign="center">
+                            <mo>+</mo>
+                            <mi>k</mi>
+                          </mtd>
+                          <mtd columnalign="center"/>
+                          <mtd columnalign="center"/>
+                          <mtd columnalign="center"/>
+                          <mtd columnalign="center">
+                            <mrow>
+                              <mo>&#x2212;</mo>
+                              <mi>k</mi>
+                            </mrow>
+                          </mtd>
+                        </mtr>
+                        <mtr>
+                          <mtd columnalign="center"/>
+                          <mtd columnalign="center"/>
+                          <mtd columnalign="center"/>
+                          <mtd columnalign="center"/>
+                          <mtd columnalign="center"/>
+                          <mtd columnalign="center"/>
+                          <mtd columnalign="center"/>
+                        </mtr>
+                        <mtr>
+                          <mtd columnalign="center"/>
+                          <mtd columnalign="center"/>
+                          <mtd columnalign="center"/>
+                          <mtd columnalign="center"/>
+                          <mtd columnalign="center"/>
+                          <mtd columnalign="center"/>
+                          <mtd columnalign="center"/>
+                        </mtr>
+                        <mtr>
+                          <mtd columnalign="center"/>
+                          <mtd columnalign="center"/>
+                          <mtd columnalign="center"/>
+                          <mtd columnalign="center"/>
+                          <mtd columnalign="center"/>
+                          <mtd columnalign="center"/>
+                          <mtd columnalign="center"/>
+                        </mtr>
+                        <mtr>
+                          <mtd columnalign="center"/>
+                          <mtd columnalign="center">
+                            <mrow>
+                              <mo>&#x2212;</mo>
+                              <mi>k</mi>
+                            </mrow>
+                          </mtd>
+                          <mtd columnalign="center"/>
+                          <mtd columnalign="center"/>
+                          <mtd columnalign="center"/>
+                          <mtd columnalign="center">
+                            <mo>+</mo>
+                            <mi>k</mi>
+                          </mtd>
+                        </mtr>
+                      </mtable>
+                      <mo>)</mo>
+                    </mrow>
+                  </mtd>
+                  <mtd columnalign="center">
+                    <mtable>
+                      <mtr>
+                        <mtd columnalign="center"/>
+                        <mtd columnalign="center"/>
+                      </mtr>
+                      <mtr>
+                        <mtd columnalign="center">
+                          <mo>&#x22ef;</mo>
+                        </mtd>
+                        <mtd columnalign="center">
+                          <mtext>
+                            <mrow>
+                              <mi>d</mi>
+                              <mi>e</mi>
+                              <mi>g</mi>
+                              <mi>r</mi>
+                              <mi>e</mi>
+                              <mi>e</mi>
+                              <mi>o</mi>
+                              <mi>f</mi>
+                              <mi>f</mi>
+                              <mi>r</mi>
+                              <mi>e</mi>
+                              <mi>e</mi>
+                              <mi>d</mi>
+                              <mi>o</mi>
+                              <mi>m</mi>
+                              <mn>1</mn>
+                              <mo>,</mo>
+                              <mi>n</mi>
+                              <mi>o</mi>
+                              <mi>d</mi>
+                              <mi>e</mi>
+                              <mn>1</mn>
+                            </mrow>
+                          </mtext>
+                        </mtd>
+                      </mtr>
+                      <mtr>
+                        <mtd columnalign="center"/>
+                        <mtd columnalign="center"/>
+                      </mtr>
+                      <mtr>
+                        <mtd columnalign="center"/>
+                        <mtd columnalign="center"/>
+                      </mtr>
+                      <mtr>
+                        <mtd columnalign="center"/>
+                        <mtd columnalign="center"/>
+                      </mtr>
+                      <mtr>
+                        <mtd columnalign="center">
+                          <mo>&#x22ef;</mo>
+                        </mtd>
+                        <mtd columnalign="center">
+                          <mtext>
+                            <mrow>
+                              <mi>d</mi>
+                              <mi>e</mi>
+                              <mi>g</mi>
+                              <mi>r</mi>
+                              <mi>e</mi>
+                              <mi>e</mi>
+                              <mi>o</mi>
+                              <mi>f</mi>
+                              <mi>f</mi>
+                              <mi>r</mi>
+                              <mi>e</mi>
+                              <mi>e</mi>
+                              <mi>d</mi>
+                              <mi>o</mi>
+                              <mi>m</mi>
+                              <mn>2</mn>
+                              <mo>,</mo>
+                              <mi>n</mi>
+                              <mi>o</mi>
+                              <mi>d</mi>
+                              <mi>e</mi>
+                              <mn>2</mn>
+                            </mrow>
+                          </mtext>
+                        </mtd>
+                      </mtr>
+                    </mtable>
+                  </mtd>
+                </mtr>
+                <mtr>
+                  <mtd columnalign="center"/>
+                  <mtd columnalign="center"/>
+                </mtr>
+                <mtr>
+                  <mtd columnalign="center">
+                    <mtable>
+                      <mtr>
+                        <mtd columnalign="center">
+                          <mo>&#x22ee;</mo>
+                        </mtd>
+                        <mtd columnalign="center"/>
+                        <mtd columnalign="center"/>
+                        <mtd columnalign="center"/>
+                        <mtd columnalign="center"/>
+                        <mtd columnalign="center">
+                          <mo>&#x22ee;</mo>
+                        </mtd>
+                      </mtr>
+                    </mtable>
+                  </mtd>
+                  <mtd columnalign="center"/>
+                </mtr>
+                <mtr>
+                  <mtd columnalign="center">
+                    <mtable>
+                      <mtr>
+                        <mtd columnalign="center"/>
+                        <mtd columnalign="center">
+                          <mtext>
+                            <mrow>
+                              <mi>d</mi>
+                              <mi>e</mi>
+                              <mi>g</mi>
+                              <mi>r</mi>
+                              <mi>e</mi>
+                              <mi>e</mi>
+                              <mi>o</mi>
+                              <mi>f</mi>
+                            </mrow>
+                          </mtext>
+                        </mtd>
+                        <mtd columnalign="center">
+                          <mtext>
+                            <mrow>
+                              <mi>d</mi>
+                              <mi>e</mi>
+                              <mi>g</mi>
+                              <mi>r</mi>
+                              <mi>e</mi>
+                              <mi>e</mi>
+                              <mi>o</mi>
+                              <mi>f</mi>
+                            </mrow>
+                          </mtext>
+                        </mtd>
+                        <mtd columnalign="center"/>
+                      </mtr>
+                      <mtr>
+                        <mtd columnalign="center"/>
+                        <mtd columnalign="center">
+                          <mtext>
+                            <mrow>
+                              <mi>f</mi>
+                              <mi>r</mi>
+                              <mi>e</mi>
+                              <mi>e</mi>
+                              <mi>d</mi>
+                              <mi>o</mi>
+                              <mi>m</mi>
+                              <mn>1</mn>
+                              <mo>,</mo>
+                            </mrow>
+                          </mtext>
+                        </mtd>
+                        <mtd columnalign="center">
+                          <mtext>
+                            <mrow>
+                              <mi>f</mi>
+                              <mi>r</mi>
+                              <mi>e</mi>
+                              <mi>e</mi>
+                              <mi>d</mi>
+                              <mi>o</mi>
+                              <mi>m</mi>
+                              <mn>2</mn>
+                              <mo>,</mo>
+                            </mrow>
+                          </mtext>
+                        </mtd>
+                        <mtd columnalign="center"/>
+                      </mtr>
+                      <mtr>
+                        <mtd columnalign="center"/>
+                        <mtd columnalign="center">
+                          <mtext>
+                            <mrow>
+                              <mi>n</mi>
+                              <mi>o</mi>
+                              <mi>d</mi>
+                              <mi>e</mi>
+                              <mn>1</mn>
+                            </mrow>
+                          </mtext>
+                        </mtd>
+                        <mtd columnalign="center">
+                          <mtext>
+                            <mrow>
+                              <mi>n</mi>
+                              <mi>o</mi>
+                              <mi>d</mi>
+                              <mi>e</mi>
+                              <mn>2</mn>
+                            </mrow>
+                          </mtext>
+                        </mtd>
+                        <mtd columnalign="center"/>
+                      </mtr>
+                    </mtable>
+                  </mtd>
+                  <mtd columnalign="center"/>
+                </mtr>
+              </mtable>
+            </mstyle>
+          </math>
+        MATHML
+        latex = <<~LATEX
+          \\begin{array}{cc}
+            \\left(
+              \\begin{array}{ccccccc}
+                & & & & & & \\\\
+                & +k & & & & -k  \\\\
+                & & & & & & \\\\
+                & & & & & & \\\\
+                & & & & & & \\\\
+                & -k & & & & +k
+              \\end{array}
+            \\right)  &
+            \\begin{array}{cc}
+              & \\\\
+              \\cdots & \\mbox{degree of freedom 1, node 1} \\\\
+              & \\\\
+              & \\\\
+              & \\\\
+              \\cdots & \\mbox{degree of freedom 2, node 2}
+            \\end{array} \\\\ & \\\\
+            \\begin{array}{cccccc}
+              \\vdots & & & & & \\vdots
+            \\end{array} & \\\\
+            \\begin{array}{cccc}
+                & \\mbox{degree of}  & \\mbox{degree of}  & \\\\
+                & \\mbox{freedom 1,} & \\mbox{freedom 2,} & \\\\
+                & \\mbox{node 1} & \\mbox{node 2}  &
+            \\end{array}    &
+          \\end{array}
+        LATEX
+        expect(formula.to_latex.gsub(/\s+/, "")).to eql(latex.gsub(/\s+/, ""))
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #44" do
+      let(:string) do
+        <<~LATEX
+          \\begin{split}
+            C_L &= {L \\over {1\\over2} \\rho_\\textrm{ref} q_\\textrm{ref}^2 S} \\\\ \\\\
+            C_D &= {D \\over {1\\over2} \\rho_\\textrm{ref} q_\\textrm{ref}^2 S} \\\\ \\\\
+            \\vec{C}_M &= {\\vec{M} \\over {1\\over2} \\rho_\\textrm{ref} q_\\textrm{ref}^2 c_\\textrm{ref} S_\\textrm{ref}},
+          \\end{split}
+        LATEX
+      end
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mtable>
+                <mtr>
+                  <mtd>
+                    <msub>
+                      <mi>C</mi>
+                      <mi>L</mi>
+                    </msub>
+                  </mtd>
+                  <mtd>
+                    <mo>=</mo>
+                    <mfrac>
+                      <mrow>
+                        <mi>L</mi>
+                      </mrow>
+                      <mrow>
+                        <mfrac>
+                          <mrow>
+                            <mn>1</mn>
+                          </mrow>
+                          <mrow>
+                            <mn>2</mn>
+                          </mrow>
+                        </mfrac>
+                        <msub>
+                          <mi>&#x3c1;</mi>
+                          <mstyle mathvariant="normal">
+                            <mrow>
+                              <mi>r</mi>
+                              <mi>e</mi>
+                              <mi>f</mi>
+                            </mrow>
+                          </mstyle>
+                        </msub>
+                        <msubsup>
+                          <mi>q</mi>
+                          <mstyle mathvariant="normal">
+                            <mrow>
+                              <mi>r</mi>
+                              <mi>e</mi>
+                              <mi>f</mi>
+                            </mrow>
+                          </mstyle>
+                          <mn>2</mn>
+                        </msubsup>
+                        <mi>S</mi>
+                      </mrow>
+                    </mfrac>
+                  </mtd>
+                </mtr>
+                <mtr>
+                  <mtd/>
+                </mtr>
+                <mtr>
+                  <mtd>
+                    <msub>
+                      <mi>C</mi>
+                      <mi>D</mi>
+                    </msub>
+                  </mtd>
+                  <mtd>
+                    <mo>=</mo>
+                    <mfrac>
+                      <mrow>
+                        <mi>D</mi>
+                      </mrow>
+                      <mrow>
+                        <mfrac>
+                          <mrow>
+                            <mn>1</mn>
+                          </mrow>
+                          <mrow>
+                            <mn>2</mn>
+                          </mrow>
+                        </mfrac>
+                        <msub>
+                          <mi>&#x3c1;</mi>
+                          <mstyle mathvariant="normal">
+                            <mrow>
+                              <mi>r</mi>
+                              <mi>e</mi>
+                              <mi>f</mi>
+                            </mrow>
+                          </mstyle>
+                        </msub>
+                        <msubsup>
+                          <mi>q</mi>
+                          <mstyle mathvariant="normal">
+                            <mrow>
+                              <mi>r</mi>
+                              <mi>e</mi>
+                              <mi>f</mi>
+                            </mrow>
+                          </mstyle>
+                          <mn>2</mn>
+                        </msubsup>
+                        <mi>S</mi>
+                      </mrow>
+                    </mfrac>
+                  </mtd>
+                </mtr>
+                <mtr>
+                  <mtd/>
+                </mtr>
+                <mtr>
+                  <mtd>
+                    <msub>
+                      <mover>
+                        <mi>C</mi>
+                        <mo>&#x2192;</mo>
+                      </mover>
+                      <mi>M</mi>
+                    </msub>
+                  </mtd>
+                  <mtd>
+                    <mo>=</mo>
+                    <mfrac>
+                      <mrow>
+                        <mover>
+                          <mi>M</mi>
+                          <mo>&#x2192;</mo>
+                        </mover>
+                      </mrow>
+                      <mrow>
+                        <mfrac>
+                          <mrow>
+                            <mn>1</mn>
+                          </mrow>
+                          <mrow>
+                            <mn>2</mn>
+                          </mrow>
+                        </mfrac>
+                        <msub>
+                          <mi>&#x3c1;</mi>
+                          <mstyle mathvariant="normal">
+                            <mrow>
+                              <mi>r</mi>
+                              <mi>e</mi>
+                              <mi>f</mi>
+                            </mrow>
+                          </mstyle>
+                        </msub>
+                        <msubsup>
+                          <mi>q</mi>
+                          <mstyle mathvariant="normal">
+                            <mrow>
+                              <mi>r</mi>
+                              <mi>e</mi>
+                              <mi>f</mi>
+                            </mrow>
+                          </mstyle>
+                          <mn>2</mn>
+                        </msubsup>
+                        <msub>
+                          <mi>c</mi>
+                          <mstyle mathvariant="normal">
+                            <mrow>
+                              <mi>r</mi>
+                              <mi>e</mi>
+                              <mi>f</mi>
+                            </mrow>
+                          </mstyle>
+                        </msub>
+                        <msub>
+                          <mi>S</mi>
+                          <mstyle mathvariant="normal">
+                            <mrow>
+                              <mi>r</mi>
+                              <mi>e</mi>
+                              <mi>f</mi>
+                            </mrow>
+                          </mstyle>
+                        </msub>
+                      </mrow>
+                    </mfrac>
+                    <mo>,</mo>
+                  </mtd>
+                </mtr>
+              </mtable>
+            </mstyle>
+          </math>
+        MATHML
+        latex = <<~LATEX
+          \\begin{split}
+            C_{L} &= {L \\over {1 \\over 2} \\rho_{\\mathrm{ref}} q_{\\mathrm{ref}}^{2} S} \\\\ \\\\
+            C_{D} &= {D \\over {1 \\over 2} \\rho_{\\mathrm{ref}} q_{\\mathrm{ref}}^{2} S} \\\\ \\\\
+            \\vec{C}_{M} &= {\\vec{M} \\over {1 \\over 2} \\rho_{\\mathrm{ref}} q_{\\mathrm{ref}}^{2} c_{\\mathrm{ref}} S_{\\mathrm{ref}}},
+          \\end{split}
+        LATEX
+        expect(formula.to_latex.gsub(/\s+/, "")).to eql(latex.gsub(/\s+/, ""))
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
       end
     end
   end

--- a/spec/plurimath/math/formula/latex_spec.rb
+++ b/spec/plurimath/math/formula/latex_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("&#x3b2;"),
         ])
       }
+      let(:expected_value) { "\\beta" }
       it "returns string of symbol" do
-        expected_value = "\\beta"
         expect(formula).to eq(expected_value)
       end
     end
@@ -25,8 +25,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "p_{\\max}" }
       it "returns string of symbol" do
-        expected_value = "p_{\\max}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -34,65 +34,73 @@ RSpec.describe Plurimath::Math::Formula do
     context "contains Formula of Array matrix with left and right" do
       let(:exp) {
         Plurimath::Math::Formula.new([
-          Plurimath::Math::Function::Left.new("("),
-          Plurimath::Math::Function::Table::Array.new(
-            [
-              Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Formula.new([
-                    Plurimath::Math::Number.new("3"),
-                    Plurimath::Math::Symbol.new("x"),
-                    Plurimath::Math::Symbol.new("-"),
-                    Plurimath::Math::Number.new("5"),
-                    Plurimath::Math::Symbol.new("y"),
-                    Plurimath::Math::Symbol.new("+"),
-                    Plurimath::Math::Number.new("4"),
-                    Plurimath::Math::Symbol.new("z"),
-                    Plurimath::Math::Symbol.new("="),
-                    Plurimath::Math::Number.new("0")
-                  ])
-                ])
-              ]),
-              Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Formula.new([
-                    Plurimath::Math::Symbol.new("x"),
-                    Plurimath::Math::Symbol.new("-"),
-                    Plurimath::Math::Symbol.new("y"),
-                    Plurimath::Math::Symbol.new("+"),
-                    Plurimath::Math::Number.new("8"),
-                    Plurimath::Math::Symbol.new("z"),
-                    Plurimath::Math::Symbol.new("="),
-                    Plurimath::Math::Number.new("0")
-                  ])
-                ])
-              ]),
-              Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Formula.new([
-                    Plurimath::Math::Number.new("2"),
-                    Plurimath::Math::Symbol.new("x"),
-                    Plurimath::Math::Symbol.new("-"),
-                    Plurimath::Math::Number.new("6"),
-                    Plurimath::Math::Symbol.new("y"),
-                    Plurimath::Math::Symbol.new("+"),
-                    Plurimath::Math::Symbol.new("z"),
-                    Plurimath::Math::Symbol.new("="),
-                    Plurimath::Math::Number.new("0")
-                  ])
-                ])
-              ])
-            ],
-            nil,
-            [
-              Plurimath::Math::Symbol.new("l")
-            ],
-          ),
-          Plurimath::Math::Function::Right.new(")"),
+          Plurimath::Math::Formula.new([
+            Plurimath::Math::Function::Left.new("("),
+            Plurimath::Math::Function::Table::Array.new(
+              [
+                Plurimath::Math::Function::Tr.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Number.new("3"),
+                      Plurimath::Math::Symbol.new("x"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("-"),
+                        Plurimath::Math::Number.new("5"),
+                      ]),
+                      Plurimath::Math::Symbol.new("y"),
+                      Plurimath::Math::Symbol.new("+"),
+                      Plurimath::Math::Number.new("4"),
+                      Plurimath::Math::Symbol.new("z"),
+                      Plurimath::Math::Symbol.new("="),
+                      Plurimath::Math::Number.new("0"),
+                    ],
+                    { columnalign: "left" }
+                  ),
+                ]),
+                Plurimath::Math::Function::Tr.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("x"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("-"),
+                        Plurimath::Math::Symbol.new("y"),
+                      ]),
+                      Plurimath::Math::Symbol.new("+"),
+                      Plurimath::Math::Number.new("8"),
+                      Plurimath::Math::Symbol.new("z"),
+                      Plurimath::Math::Symbol.new("="),
+                      Plurimath::Math::Number.new("0"),
+                    ],
+                    { columnalign: "left" }
+                  ),
+                ]),
+                Plurimath::Math::Function::Tr.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Number.new("2"),
+                      Plurimath::Math::Symbol.new("x"),
+                      Plurimath::Math::Symbol.new("-"),
+                      Plurimath::Math::Number.new("6"),
+                      Plurimath::Math::Symbol.new("y"),
+                      Plurimath::Math::Symbol.new("+"),
+                      Plurimath::Math::Symbol.new("z"),
+                      Plurimath::Math::Symbol.new("="),
+                      Plurimath::Math::Number.new("0"),
+                    ],
+                    { columnalign: "left" }
+                  ),
+                ]),
+              ],
+              nil,
+              nil,
+              {}
+            ),
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
       }
+      let(:expected_value) { "\\left(\\begin{array}{l}3x-5y+4z=0\\\\x-y+8z=0\\\\2x-6y+z=0\\end{array}\\right)" }
       it "returns string of symbol" do
-        expected_value = "\\left(\\begin{array}{l}3x-5y+4z=0\\\\x-y+8z=0\\\\2x-6y+z=0\\end{array}\\right)"
         expect(formula).to eq(expected_value)
       end
     end
@@ -180,8 +188,7 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new(",")
         ])
       }
-      it "returns string of symbol" do
-        expected_value =
+      let(:expected_value) do
         <<~Latex
           \\begin{pmatrix}
             \\hat{e}_{\\xi} \\\\ \\hat{e}_{\\eta} \\\\ \\hat{e}_{\\zeta}
@@ -191,6 +198,8 @@ RSpec.describe Plurimath::Math::Formula do
             \\hat{e}_{x} \\\\ \\hat{e}_{y} \\\\ \\hat{e}_{z}
           \\end{pmatrix},
         Latex
+      end
+      it "returns string of symbol" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -198,73 +207,92 @@ RSpec.describe Plurimath::Math::Formula do
     context "contains Formula of double left and right with Array matrix" do
       let(:exp) {
         Plurimath::Math::Formula.new([
-          Plurimath::Math::Function::Left.new("("),
-          Plurimath::Math::Function::Table::Array.new(
-            [
-              Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("V"),
-                    Plurimath::Math::Symbol.new("x")
-                  )
-                ])
-              ]),
-              Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("V"),
-                    Plurimath::Math::Symbol.new("y")
-                  )
-                ])
-              ])
-            ],
-            nil,
-            [
-              Plurimath::Math::Symbol.new("c")
-            ],
-          ),
-          Plurimath::Math::Function::Right.new(")"),
+          Plurimath::Math::Formula.new([
+            Plurimath::Math::Function::Left.new("("),
+            Plurimath::Math::Function::Table::Array.new(
+              [
+                Plurimath::Math::Function::Tr.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("V"),
+                        Plurimath::Math::Symbol.new("x")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
+                Plurimath::Math::Function::Tr.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("V"),
+                        Plurimath::Math::Symbol.new("y")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
+              ],
+              nil,
+              nil,
+              {}
+            ),
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
           Plurimath::Math::Symbol.new("="),
           Plurimath::Math::Function::Base.new(
             Plurimath::Math::Symbol.new("h"),
             Plurimath::Math::Symbol.new("s")
           ),
-          Plurimath::Math::Symbol.new("&#x3a;"),
+          Plurimath::Math::Symbol.new(":"),
           Plurimath::Math::Function::Base.new(
             Plurimath::Math::Symbol.new("D"),
             Plurimath::Math::Symbol.new("s")
           ),
-          Plurimath::Math::Symbol.new("&#x3a;"),
-          Plurimath::Math::Function::Left.new("("),
-          Plurimath::Math::Function::Table::Array.new(
-            [
-              Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("&#x03b5;"),
-                    Plurimath::Math::Symbol.new("xz")
-                  )
-                ])
-              ]),
-              Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("&#x03b5;"),
-                    Plurimath::Math::Symbol.new("yz")
-                  )
-                ])
-              ])
-            ],
-            nil,
-            [
-              Plurimath::Math::Symbol.new("c")
-            ],
-          ),
-          Plurimath::Math::Function::Right.new(")"),
+          Plurimath::Math::Symbol.new(":"),
+          Plurimath::Math::Formula.new([
+            Plurimath::Math::Function::Left.new("("),
+            Plurimath::Math::Function::Table::Array.new(
+              [
+                Plurimath::Math::Function::Tr.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("&#x03b5;"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("x"),
+                          Plurimath::Math::Symbol.new("z"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
+                Plurimath::Math::Function::Tr.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("&#x03b5;"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("y"),
+                          Plurimath::Math::Symbol.new("z"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
+              ],
+              nil,
+              nil,
+              {}
+            ),
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
       }
-      it "returns string of symbol" do
-        expected_value =
+      let(:expected_value) do
         <<~Latex
           \\left(
             \\begin{array}{c}
@@ -279,6 +307,8 @@ RSpec.describe Plurimath::Math::Formula do
                             \\end{array}
                           \\right)
         Latex
+      end
+      it "returns string of symbol" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -297,8 +327,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("x")
         ])
       }
+      let(:expected_value) { "\\inf_{x>s}fx" }
       it "returns string of symbol" do
-        expected_value = "\\inf_{x>s}fx"
         expect(formula).to eq(expected_value)
       end
     end
@@ -313,8 +343,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\int\\limits_{0}^{\\pi}" }
       it "returns string of symbol" do
-        expected_value = "\\int\\limits_{0}^{\\pi}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -335,8 +365,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\substack{\\xi2=g\\left(x\\right)}" }
       it "returns string of symbol" do
-        expected_value = "\\substack{\\xi2=g\\left(x\\right)}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -363,8 +393,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\sum_{\\substack{1\\lei\\len\\\\i\\nej}}" }
       it "returns string of symbol" do
-        expected_value = "\\sum_{\\substack{1\\lei\\len\\\\i\\nej}}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -397,8 +427,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\tan{x}+\\sec{x}+\\cos{x}+\\sin{x}+\\cot{x}+\\csc{x}" }
       it "returns string of symbol" do
-        expected_value = "\\tan{x}+\\sec{x}+\\cos{x}+\\sin{x}+\\cot{x}+\\csc{x}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -413,8 +443,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "a_{b}^{c}" }
       it "returns string of symbol" do
-        expected_value = "a_{b}^{c}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -426,8 +456,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Number.new("3")
         ])
       }
+      let(:expected_value) { "^3" }
       it "returns formula of sin from Latex string" do
-        expected_value = "^3"
         expect(formula).to eq(expected_value)
       end
     end
@@ -439,8 +469,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("x")
         ])
       }
+      let(:expected_value) { "\\logx" }
       it "returns formula of sin from Latex string" do
-        expected_value = "\\logx"
         expect(formula).to eq(expected_value)
       end
     end
@@ -454,8 +484,8 @@ RSpec.describe Plurimath::Math::Formula do
           ),
         ])
       }
+      let(:expected_value) { "\\sum_{\\beta}^{1}" }
       it "returns formula of sin from Latex string" do
-        expected_value = "\\sum_{\\beta}^{1}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -469,8 +499,8 @@ RSpec.describe Plurimath::Math::Formula do
           ),
         ])
       }
+      let(:expected_value) { "\\sum_{\\beta}^{a}" }
       it "returns formula of sin from Latex string" do
-        expected_value = "\\sum_{\\beta}^{a}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -484,8 +514,8 @@ RSpec.describe Plurimath::Math::Formula do
           ),
         ])
       }
+      let(:expected_value) { "3\\cos{\\beta}" }
       it "returns formula of sin from Latex string" do
-        expected_value = "3\\cos{\\beta}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -500,8 +530,8 @@ RSpec.describe Plurimath::Math::Formula do
           ]),
         ])
       }
+      let(:expected_value) { "a+b" }
       it "returns formula of sin from Latex string" do
-        expected_value = "a+b"
         expect(formula).to eq(expected_value)
       end
     end
@@ -520,8 +550,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Function::Right.new(")"),
         ])
       }
+      let(:expected_value) { "\\left(\\beta\\slasht\\right)" }
       it "returns formula of sin from Latex string" do
-        expected_value = "\\left(\\beta\\slasht\\right)"
         expect(formula).to eq(expected_value)
       end
     end
@@ -534,8 +564,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\overline{v}" }
       it "returns formula of sin from Latex string" do
-        expected_value = "\\overline{v}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -548,8 +578,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("a")
         ])
       }
+      let(:expected_value) { "\\oversetrightarrowa" }
       it "returns formula of sin from Latex string" do
-        expected_value = "\\oversetrightarrowa"
         expect(formula).to eq(expected_value)
       end
     end
@@ -562,8 +592,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "1_{}" }
       it "returns formula of sin from Latex string" do
-        expected_value = "1_{}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -581,8 +611,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\sum_{n=1}^{\\infty}" }
       it "returns formula of sin from Latex string" do
-        expected_value = "\\sum_{n=1}^{\\infty}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -600,8 +630,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\prod_{n=1}^{\\infty}" }
       it "returns formula of sin from Latex string" do
-        expected_value = "\\prod_{n=1}^{\\infty}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -615,8 +645,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "{a}\\mod{b}" }
       it "returns formula of sin from Latex string" do
-        expected_value = "{a}\\mod{b}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -636,8 +666,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Number.new("0"),
         ])
       }
+      let(:expected_value) { "3x-5y+4z=0" }
       it "returns formula of sin from Latex string" do
-        expected_value = "3x-5y+4z=0"
         expect(formula).to eq(expected_value)
       end
     end
@@ -651,8 +681,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Number.new("2"),
         ])
       }
+      let(:expected_value) { "3x*2" }
       it "returns formula of sin from Latex string" do
-        expected_value = "3x*2"
         expect(formula).to eq(expected_value)
       end
     end
@@ -666,8 +696,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\frac{1}{2}" }
       it "returns formula of sin from Latex string" do
-        expected_value = "\\frac{1}{2}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -701,8 +731,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\begin{array}3x-5y+4z=0\\end{array}" }
       it "returns formula of sin from Latex string" do
-        expected_value = "\\begin{array}{a}3x-5y+4z=0\\end{array}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -713,44 +743,54 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Function::Table::Array.new(
             [
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("a"),
-                    Plurimath::Math::Number.new("1"),
-                  )
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("b"),
-                    Plurimath::Math::Number.new("2"),
-                  )
-                ]),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("a"),
+                      Plurimath::Math::Number.new("1")
+                    ),
+                  ],
+                  nil
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("b"),
+                      Plurimath::Math::Number.new("2")
+                    ),
+                  ],
+                  nil
+                ),
               ]),
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("c"),
-                    Plurimath::Math::Number.new("1"),
-                  )
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("d"),
-                    Plurimath::Math::Number.new("2"),
-                  )
-                ]),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("c"),
+                      Plurimath::Math::Number.new("1")
+                    ),
+                  ],
+                  nil
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("d"),
+                      Plurimath::Math::Number.new("2")
+                    ),
+                  ],
+                  nil
+                ),
               ]),
             ],
             nil,
-            [
-              Plurimath::Math::Symbol.new("a"),
-              Plurimath::Math::Symbol.new("b"),
-            ]
-          )
+            nil,
+            {}
+          ),
         ])
       }
+      let(:expected_value) { "\\begin{array}a_{1}&b_{2}\\\\c_{1}&d_{2}\\end{array}" }
       it "returns formula of sin from Latex string" do
-        expected_value = "\\begin{array}{ab}a_{1}&b_{2}\\\\c_{1}&d_{2}\\end{array}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -776,8 +816,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\left(\\begin{matrix}2\\\\3\\end{matrix}\\right)" }
       it "returns formula of sin from Latex string" do
-        expected_value = "\\left(\\begin{matrix}2\\\\3\\end{matrix}\\right)"
         expect(formula).to eq(expected_value)
       end
     end
@@ -788,24 +828,24 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Function::Table::Array.new(
             [
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("a"),
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("b"),
-                ]),
-              ])
+                Plurimath::Math::Function::Td.new(
+                  [Plurimath::Math::Symbol.new("a")],
+                  nil
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [Plurimath::Math::Symbol.new("b")],
+                  nil
+                ),
+              ]),
             ],
             nil,
-            [
-              Plurimath::Math::Symbol.new("a"),
-              Plurimath::Math::Symbol.new("b"),
-            ]
-          )
+            nil,
+            {}
+          ),
         ])
       }
+      let(:expected_value) { "\\begin{array}a&b\\end{array}" }
       it "returns formula of sin from Latex string" do
-        expected_value = "\\begin{array}{ab}a&b\\end{array}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -837,8 +877,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\left\\{\\begin{matrix}a&b\\\\c&d\\end{matrix}\\right\\}" }
       it "returns formula of sin from Latex string" do
-        expected_value = "\\left\\{\\begin{matrix}a&b\\\\c&d\\end{matrix}\\right\\}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -862,8 +902,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\left|\\begin{matrix}a&b\\end{matrix}\\right|" }
       it "returns formula of sin from Latex string" do
-        expected_value = "\\left|\\begin{matrix}a&b\\end{matrix}\\right|"
         expect(formula).to eq(expected_value)
       end
     end
@@ -896,8 +936,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\begin{Bmatrix}-a&b\\\\c&d\\end{Bmatrix}" }
       it "returns formula of sin from Latex string" do
-        expected_value = "\\begin{Bmatrix}-a&b\\\\c&d\\end{Bmatrix}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -921,8 +961,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\left(\\begin{matrix}a&b\\end{matrix}\\right)" }
       it "returns formula of sin from Latex string" do
-        expected_value = "\\left(\\begin{matrix}a&b\\end{matrix}\\right)"
         expect(formula).to eq(expected_value)
       end
     end
@@ -933,40 +973,45 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Function::Table::Array.new(
             [
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Number.new("1"),
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("|"),
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Number.new("2"),
-                  Plurimath::Math::Symbol.new("&#x23af;"),
-                ]),
+                Plurimath::Math::Function::Td.new(
+                  [Plurimath::Math::Number.new("1")],
+                  nil
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [Plurimath::Math::Symbol.new("|")],
+                  nil
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Number.new("2"),
+                    Plurimath::Math::Symbol.new("&#x23af;"),
+                  ],
+                  nil
+                ),
               ]),
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Number.new("3"),
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("|"),
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Number.new("4"),
-                ]),
+                Plurimath::Math::Function::Td.new(
+                  [Plurimath::Math::Number.new("3")],
+                  nil
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [Plurimath::Math::Symbol.new("|")],
+                  nil
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [Plurimath::Math::Number.new("4")],
+                  nil
+                ),
               ]),
             ],
             nil,
-            [
-              Plurimath::Math::Symbol.new("a"),
-              Plurimath::Math::Symbol.new("|"),
-              Plurimath::Math::Symbol.new("b"),
-            ]
-          )
+            nil,
+            {}
+          ),
         ])
       }
+      let(:expected_value) { "\\begin{array}{|}1&2\\hline\\\\3&4\\end{array}" }
       it "returns formula of sin from Latex string" do
-        expected_value = "\\begin{array}{a|b}1&2\\hline\\\\3&4\\end{array}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -997,8 +1042,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\begin{Vmatrix}\\sqrt{-25^{2}}=\\pm25\\end{Vmatrix}" }
       it "returns formula of sin from Latex string" do
-        expected_value = "\\begin{Vmatrix}\\sqrt{-25^{2}}=\\pm25\\end{Vmatrix}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -1012,8 +1057,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\sqrt[\\beta]{\\pm}" }
       it "returns formula of sin from Latex string" do
-        expected_value = "\\sqrt[\\beta]{\\pm}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -1027,8 +1072,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("x"),
         ])
       }
+      let(:expected_value) { "\\log_{2}x" }
       it "returns formula of sin from Latex string" do
-        expected_value = "\\log_{2}x"
         expect(formula).to eq(expected_value)
       end
     end
@@ -1048,8 +1093,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("x"),
         ])
       }
+      let(:expected_value) { "\\lim_{x\\to+\\infty}fx" }
       it "returns formula of sin from Latex string" do
-        expected_value = "\\lim_{x\\to+\\infty}fx"
         expect(formula).to eq(expected_value)
       end
     end
@@ -1062,33 +1107,38 @@ RSpec.describe Plurimath::Math::Formula do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("V"),
-                      Plurimath::Math::Symbol.new("x"),
-                    ),
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("V"),
+                        Plurimath::Math::Symbol.new("x")
+                      ),
+                    ],
+                    nil
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("V"),
-                      Plurimath::Math::Symbol.new("y"),
-                    ),
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("V"),
+                        Plurimath::Math::Symbol.new("y")
+                      ),
+                    ],
+                    nil
+                  ),
                 ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("a"),
-              ]
+              nil,
+              {}
             ),
             Plurimath::Math::Function::Right.new(")"),
-          ])
+          ]),
         ])
       }
+      let(:expected_value) { "\\left(\\begin{array}V_{x}\\\\V_{y}\\end{array}\\right)" }
       it "returns formula of sin from Latex string" do
-        expected_value = "\\left(\\begin{array}{a}V_{x}\\\\V_{y}\\end{array}\\right)"
         expect(formula).to eq(expected_value)
       end
     end
@@ -1099,8 +1149,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("a+b")
         ])
       }
+      let(:expected_value) { "a+b" }
       it "returns formula of sin from Latex string" do
-        expected_value = "a+b"
         expect(formula).to eq(expected_value)
       end
     end
@@ -1113,8 +1163,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Number.new("2"),
         ])
       }
+      let(:expected_value) { "a>2" }
       it "returns formula of sin from Latex string" do
-        expected_value = "a>2"
         expect(formula).to eq(expected_value)
       end
     end
@@ -1127,8 +1177,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Number.new("2"),
         ])
       }
+      let(:expected_value) { "a<2" }
       it "returns formula of sin from Latex string" do
-        expected_value = "a<2"
         expect(formula).to eq(expected_value)
       end
     end
@@ -1139,8 +1189,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("&"),
         ])
       }
+      let(:expected_value) { "&" }
       it "returns formula of sin from Latex string" do
-        expected_value = "&"
         expect(formula).to eq(expected_value)
       end
     end
@@ -1158,8 +1208,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "R1\\beta" }
       it "returns formula of sin from Latex string" do
-        expected_value = "R1\\beta"
         expect(formula).to eq(expected_value)
       end
     end
@@ -1174,8 +1224,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\beta_{R}^{C}" }
       it "returns formula of sin from Latex string" do
-        expected_value = "\\beta_{R}^{C}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -1186,44 +1236,37 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Function::Table::Array.new(
             [
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([]),
-                Plurimath::Math::Function::Td.new([]),
-                Plurimath::Math::Function::Td.new([]),
-                Plurimath::Math::Function::Td.new([]),
-                Plurimath::Math::Function::Td.new([]),
-                Plurimath::Math::Function::Td.new([]),
-                Plurimath::Math::Function::Td.new([]),
+                Plurimath::Math::Function::Td.new([], nil),
+                Plurimath::Math::Function::Td.new([], nil),
+                Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                Plurimath::Math::Function::Td.new([], nil),
+                Plurimath::Math::Function::Td.new([], nil),
+                Plurimath::Math::Function::Td.new([], nil),
+                Plurimath::Math::Function::Td.new([], nil),
               ]),
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("+"),
-                  Plurimath::Math::Symbol.new("k")
-                ]),
-                Plurimath::Math::Function::Td.new([]),
-                Plurimath::Math::Function::Td.new([]),
-                Plurimath::Math::Function::Td.new([]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("-"),
-                  Plurimath::Math::Symbol.new("k")
-                ]),
+                Plurimath::Math::Function::Td.new([], nil),
+                Plurimath::Math::Function::Td.new(
+                  [Plurimath::Math::Symbol.new("+"), Plurimath::Math::Symbol.new("k")],
+                  nil
+                ),
+                Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                Plurimath::Math::Function::Td.new([], nil),
+                Plurimath::Math::Function::Td.new([], nil),
+                Plurimath::Math::Function::Td.new(
+                  [Plurimath::Math::Symbol.new("-"), Plurimath::Math::Symbol.new("k")],
+                  nil
+                ),
               ]),
             ],
             nil,
-            [
-              Plurimath::Math::Symbol.new("a"),
-              Plurimath::Math::Symbol.new("b"),
-              Plurimath::Math::Symbol.new("c"),
-              Plurimath::Math::Symbol.new("d"),
-              Plurimath::Math::Symbol.new("e"),
-              Plurimath::Math::Symbol.new("f"),
-              Plurimath::Math::Symbol.new("g"),
-            ]
-          )
+            nil,
+            {}
+          ),
         ])
       }
+      let(:expected_value) { "\\begin{array}{c}&&&&&&\\\\&+k&&&&-k\\end{array}" }
       it "returns formula of sin from Latex string" do
-        expected_value = "\\begin{array}{abcdefg}&&&&&&\\\\&+k&&&&-k\\end{array}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -1234,36 +1277,92 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Function::Table::Array.new(
             [
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("&#x22ef;"),
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("\\mbox{degreeoffreedom1,node1}")
-                ]),
+                Plurimath::Math::Function::Td.new(
+                  [Plurimath::Math::Symbol.new("&#x22ef;")],
+                  nil
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Mbox.new(
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Symbol.new("e"),
+                        Plurimath::Math::Symbol.new("g"),
+                        Plurimath::Math::Symbol.new("r"),
+                        Plurimath::Math::Symbol.new("e"),
+                        Plurimath::Math::Symbol.new("e"),
+                        Plurimath::Math::Symbol.new("o"),
+                        Plurimath::Math::Symbol.new("f"),
+                        Plurimath::Math::Symbol.new("f"),
+                        Plurimath::Math::Symbol.new("r"),
+                        Plurimath::Math::Symbol.new("e"),
+                        Plurimath::Math::Symbol.new("e"),
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Symbol.new("o"),
+                        Plurimath::Math::Symbol.new("m"),
+                        Plurimath::Math::Number.new("1"),
+                        Plurimath::Math::Symbol.new(","),
+                        Plurimath::Math::Symbol.new("n"),
+                        Plurimath::Math::Symbol.new("o"),
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Symbol.new("e"),
+                        Plurimath::Math::Number.new("1"),
+                      ])
+                    ),
+                  ],
+                  nil
+                ),
               ]),
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([]),
-                Plurimath::Math::Function::Td.new([]),
+                Plurimath::Math::Function::Td.new([], nil),
+                Plurimath::Math::Function::Td.new([], nil),
               ]),
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("&#x22ef;"),
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("\\mbox{degreeoffreedom2,node2}")
-                ]),
+                Plurimath::Math::Function::Td.new(
+                  [Plurimath::Math::Symbol.new("&#x22ef;")],
+                  nil
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Mbox.new(
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Symbol.new("e"),
+                        Plurimath::Math::Symbol.new("g"),
+                        Plurimath::Math::Symbol.new("r"),
+                        Plurimath::Math::Symbol.new("e"),
+                        Plurimath::Math::Symbol.new("e"),
+                        Plurimath::Math::Symbol.new("o"),
+                        Plurimath::Math::Symbol.new("f"),
+                        Plurimath::Math::Symbol.new("f"),
+                        Plurimath::Math::Symbol.new("r"),
+                        Plurimath::Math::Symbol.new("e"),
+                        Plurimath::Math::Symbol.new("e"),
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Symbol.new("o"),
+                        Plurimath::Math::Symbol.new("m"),
+                        Plurimath::Math::Number.new("2"),
+                        Plurimath::Math::Symbol.new(","),
+                        Plurimath::Math::Symbol.new("n"),
+                        Plurimath::Math::Symbol.new("o"),
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Symbol.new("e"),
+                        Plurimath::Math::Number.new("2"),
+                      ])
+                    ),
+                  ],
+                  nil
+                ),
               ]),
             ],
             nil,
-            [
-              Plurimath::Math::Symbol.new("a"),
-              Plurimath::Math::Symbol.new("b"),
-            ]
-          )
+            nil,
+            {}
+          ),
         ])
       }
+      let(:expected_value) { "\\begin{array}\\cdots&\\mbox{degreeoffreedom1,node1}\\\\&\\\\\\cdots&\\mbox{degreeoffreedom2,node2}\\end{array}" }
       it "returns formula of sin from Latex string" do
-        expected_value = "\\begin{array}{ab}\\cdots&\\mbox{degreeoffreedom1,node1}\\\\&\\\\\\cdots&\\mbox{degreeoffreedom2,node2}\\end{array}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -1431,8 +1530,7 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
-      it "returns formula of sin from Latex string" do
-        expected_value =
+      let(:expected_value) do
         <<~Latex
           \\begin{split}
             C_{L}&=\\overset{\\left(L\\right)}{\\left({1\\over2}\\rho_{ref}q_{ref}^{2}S\\right)} \\\\\\\\
@@ -1440,6 +1538,8 @@ RSpec.describe Plurimath::Math::Formula do
             \\vec{C}_{M}&=\\overset{\\left(\\vec{M}\\right)}{\\left(\\overset{\\left(1\\right)}{\\left(2\\right)}\\rho_{ref}q_{ref}^{2}c_{ref}S_{ref}\\right)},
           \\end{split}
         Latex
+      end
+      it "returns formula of sin from Latex string" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -1588,13 +1688,14 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new(","),
         ])
       }
-      it "returns formula of sin from Latex string" do
-        expected_value =
+      let(:expected_value) do
         <<~Latex
           c_{l} = {L' \\over {1\\over2} \\rho_{ref} q_{ref}^{2} c_{ref}} \\qquad
           c_{d} = {D' \\over {1\\over2} \\rho_{ref} q_{ref}^{2} c_{ref}} \\qquad
           \\vec{c}_{m} = {\\vec{M}' \\over {1\\over2} \\rho_{ref} q_{ref}^{2} c_{ref}^{2}},
         Latex
+      end
+      it "returns formula of sin from Latex string" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -1618,8 +1719,8 @@ RSpec.describe Plurimath::Math::Formula do
           ])
         ])
       }
+      let(:expected_value) { "\\left(\\frac{T}{T_{ref}}\\right)" }
       it "returns formula of sin from Latex string" do
-        expected_value = "\\left(\\frac{T}{T_{ref}}\\right)"
         expect(formula).to eq(expected_value)
       end
     end
@@ -1673,8 +1774,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new(","),
         ])
       }
+      let(:expected_value) { "\\vec{F}=F_{x}\\hat{e}_{x}+F_{y}\\hat{e}_{y}+F_{z}\\hat{e}_{z}=\\int\\vec{f},dA," }
       it "returns formula of sin from Latex string" do
-        expected_value = "\\vec{F}=F_{x}\\hat{e}_{x}+F_{y}\\hat{e}_{y}+F_{z}\\hat{e}_{z}=\\int\\vec{f},dA,"
         expect(formula).to eq(expected_value)
       end
     end
@@ -1741,8 +1842,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("."),
         ])
       }
+      let(:expected_value) { "\\vec{M}=M_{x}\\hat{e}_{x}+M_{y}\\hat{e}_{y}+M_{z}\\hat{e}_{z}=\\int\\vec{r}-\\vec{r}_{0}\\times\\vec{f},dA." }
       it "returns formula" do
-        expected_value = "\\vec{M}=M_{x}\\hat{e}_{x}+M_{y}\\hat{e}_{y}+M_{z}\\hat{e}_{z}=\\int\\vec{r}-\\vec{r}_{0}\\times\\vec{f},dA."
         expect(formula).to eq(expected_value)
       end
     end
@@ -1771,8 +1872,8 @@ RSpec.describe Plurimath::Math::Formula do
           ),
         ])
       }
+      let(:expected_value) { "L=\\vec{F}\\cdot\\hat{L}\\qquadD=\\vec{F}\\cdot\\hat{D}" }
       it "returns formula" do
-        expected_value = "L=\\vec{F}\\cdot\\hat{L}\\qquadD=\\vec{F}\\cdot\\hat{D}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -1807,8 +1908,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "L=\\vec{F}\\cdot\\hat{e}_{\\eta}\\qquadD=\\vec{F}\\cdot\\hat{e}_{\\xi}" }
       it "returns formula" do
-        expected_value = "L=\\vec{F}\\cdot\\hat{e}_{\\eta}\\qquadD=\\vec{F}\\cdot\\hat{e}_{\\xi}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -1875,12 +1976,13 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new(".")
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           \\vec{M} = M_{\\xi} \\hat{e}_{\\xi} + M_{\\eta} \\hat{e}_{\\eta} + M_{\\zeta} \\hat{e}_{\\zeta} =
             \\int \\vec{r} - \\vec{r}_{0} \\times \\vec{f} ,dA.
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -2047,8 +2149,7 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           \\begin{split}
             C_{L} &= {L \\over {1\\over2} \\rho_{ref} q_{ref}^{2} S} \\\\ \\\\
@@ -2056,6 +2157,8 @@ RSpec.describe Plurimath::Math::Formula do
             \\vec{C}_{M} &= {\\beta \\vec{M} \\over {1\\over2} \\rho_{ref} q_{ref}^{2} c_{ref} S_{ref}},
           \\end{split}
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -2202,13 +2305,14 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new(",")
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           c_{l} = {L' \\over {1\\over2} \\rho_{ref} q_{ref}^{2} c_{ref}} \\qquad
           c_{d} = {D' \\over {1\\over2} \\rho_{ref} q_{ref}^{2} c_{ref}} \\qquad
           \\vec{c}_{m} = {\\vec{M}' \\over {1\\over2} \\rho_{ref} q_{ref}^{2} c_{ref}^{2}},
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -2273,8 +2377,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new(","),
         ])
       }
+      let(:expected_value) { "k=k_{ref}\\left(\\frac{T}{T_{ref}}\\right)^{3/2}\\frac{T_{ref}+T_{s}}{T+T_{s}}," }
       it "returns formula" do
-        expected_value = "k=k_{ref}\\left(\\frac{T}{T_{ref}}\\right)^{3/2}\\frac{T_{ref}+T_{s}}{T+T_{s}},"
         expect(formula).to eq(expected_value)
       end
     end
@@ -2343,8 +2447,8 @@ RSpec.describe Plurimath::Math::Formula do
           ]),
         ])
       }
+      let(:expected_value) { "-\\overline{u'_{i}u'_{j}}=\\nu_{t}\\left(\\frac{\\partialu_{i}}{\\partialx_{j}}+\\frac{\\partialu_{j}}{\\partialx_{i}}\\right)" }
       it "returns formula" do
-        expected_value = "-\\overline{u'_{i}u'_{j}}=\\nu_{t}\\left(\\frac{\\partialu_{i}}{\\partialx_{j}}+\\frac{\\partialu_{j}}{\\partialx_{i}}\\right)"
         expect(formula).to eq(expected_value)
       end
     end
@@ -2381,8 +2485,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("."),
         ])
       }
+      let(:expected_value) { "\\mu=\\mu_{ref}\\left(\\frac{T}{T_{ref}}\\right)^{n}." }
       it "returns formula" do
-        expected_value = "\\mu=\\mu_{ref}\\left(\\frac{T}{T_{ref}}\\right)^{n}."
         expect(formula).to eq(expected_value)
       end
     end
@@ -2447,8 +2551,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new(","),
         ])
       }
+      let(:expected_value) { "\\mu=\\mu_{ref}\\left(\\frac{T}{T_{ref}}\\right)^{3/2}\\frac{T_{ref}+T_{s}}{T+T_{s}}," }
       it "returns formula" do
-        expected_value = "\\mu=\\mu_{ref}\\left(\\frac{T}{T_{ref}}\\right)^{3/2}\\frac{T_{ref}+T_{s}}{T+T_{s}},"
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -2494,8 +2598,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("$"),
         ])
       }
+      let(:expected_value) { "$$f_{i}=\\sum_{j=1}^{2}s_{ij}n_{j};for;i=1,2$$" }
       it "returns formula" do
-        expected_value = "$$f_{i}=\\sum_{j=1}^{2}s_{ij}n_{j};for;i=1,2$$"
         expect(formula).to eq(expected_value)
       end
     end
@@ -2537,8 +2641,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Number.new("3"),
         ])
       }
+      let(:expected_value) { "f_{i}=\\sum_{j=1}^{3}s_{ij}n_{j};for;i=1,3" }
       it "returns formula" do
-        expected_value = "f_{i}=\\sum_{j=1}^{3}s_{ij}n_{j};for;i=1,3"
         expect(formula).to eq(expected_value)
       end
     end
@@ -2551,50 +2655,58 @@ RSpec.describe Plurimath::Math::Formula do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("s"),
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0"),
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0"),
-                  ]),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Symbol.new("s")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0"),
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("s"),
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0"),
-                  ]),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Symbol.new("s")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0"),
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0"),
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("s"),
-                  ]),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Symbol.new("s")],
+                    { columnalign: "center" }
+                  ),
                 ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("ccc")
-              ]
+              nil,
+              {}
             ),
             Plurimath::Math::Function::Right.new(")"),
-          ])
+          ]),
         ])
       }
+      let(:expected_value) { "\\left(\\begin{array}{ccc}s&0&0\\\\0&s&0\\\\0&0&s\\end{array}\\right)" }
       it "returns formula" do
-        expected_value = "\\left(\\begin{array}{ccc}s&0&0\\\\0&s&0\\\\0&0&s\\end{array}\\right)"
         expect(formula).to eq(expected_value)
       end
     end
@@ -2607,59 +2719,73 @@ RSpec.describe Plurimath::Math::Formula do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("s"),
-                      Plurimath::Math::Number.new("11"),
-                    ),
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0"),
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0"),
-                  ]),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("s"),
+                        Plurimath::Math::Number.new("11")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0"),
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("s"),
-                      Plurimath::Math::Number.new("22"),
-                    ),
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0"),
-                  ]),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("s"),
+                        Plurimath::Math::Number.new("22")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0"),
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0"),
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("s"),
-                      Plurimath::Math::Number.new("33"),
-                    ),
-                  ]),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("s"),
+                        Plurimath::Math::Number.new("33")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("ccc")
-              ]
+              nil,
+              {}
             ),
             Plurimath::Math::Function::Right.new(")"),
-          ])
+          ]),
         ])
       }
+      let(:expected_value) { "\\left(\\begin{array}{ccc}s_{11}&0&0\\\\0&s_{22}&0\\\\0&0&s_{33}\\end{array}\\right)" }
       it "returns formula" do
-        expected_value = "\\left(\\begin{array}{ccc}s_{11}&0&0\\\\0&s_{22}&0\\\\0&0&s_{33}\\end{array}\\right)"
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -2720,8 +2846,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Number.new("2"),
         ])
       }
+      let(:expected_value) { "s_{ij}=\\sum_{k=1}^{2}\\sum_{l=1}^{2}d_{ijkl}e_{kl};for;i=1,2;and;j=1,2" }
       it "returns formula" do
-        expected_value = "s_{ij}=\\sum_{k=1}^{2}\\sum_{l=1}^{2}d_{ijkl}e_{kl};for;i=1,2;and;j=1,2"
         expect(formula).to eq(expected_value)
       end
     end
@@ -2734,65 +2860,82 @@ RSpec.describe Plurimath::Math::Formula do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("s"),
-                      Plurimath::Math::Number.new("11"),
-                    ),
-                  ]),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("s"),
+                        Plurimath::Math::Number.new("11")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("s"),
-                      Plurimath::Math::Number.new("22"),
-                    ),
-                  ]),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("s"),
+                        Plurimath::Math::Number.new("22")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("s"),
-                      Plurimath::Math::Number.new("33"),
-                    ),
-                  ]),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("s"),
+                        Plurimath::Math::Number.new("33")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("s"),
-                      Plurimath::Math::Number.new("12"),
-                    ),
-                  ]),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("s"),
+                        Plurimath::Math::Number.new("12")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("s"),
-                      Plurimath::Math::Number.new("23"),
-                    ),
-                  ]),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("s"),
+                        Plurimath::Math::Number.new("23")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("s"),
-                      Plurimath::Math::Number.new("31"),
-                    ),
-                  ]),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("s"),
+                        Plurimath::Math::Number.new("31")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c")
-              ]
+              nil,
+              {}
             ),
             Plurimath::Math::Function::Right.new(")"),
           ]),
         ])
       }
+      let(:expected_value) { "\\left(\\begin{array}{c}s_{11}\\\\s_{22}\\\\s_{33}\\\\s_{12}\\\\s_{23}\\\\s_{31}\\end{array}\\right)" }
       it "returns formula" do
-        expected_value = "\\left(\\begin{array}{c}s_{11}\\\\s_{22}\\\\s_{33}\\\\s_{12}\\\\s_{23}\\\\s_{31}\\end{array}\\right)"
         expect(formula).to eq(expected_value)
       end
     end
@@ -2805,172 +2948,248 @@ RSpec.describe Plurimath::Math::Formula do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("1111")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("1122")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("1133")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("1112")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("1123")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("1131")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("1111")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("1122")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("1133")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("1112")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("1123")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("1131")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("2222")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("2233")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("2212")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("2223")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("2231")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("2222")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("2233")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("2212")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("2223")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("2231")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("3333")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("3312")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("3323")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("3331")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("3333")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("3312")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("3323")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("3331")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("1212")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("1223")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("1231")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("1212")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("1223")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("1231")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("\\mbox{symmetric}")
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("2323")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("2331")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Mbox.new(
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("s"),
+                          Plurimath::Math::Symbol.new("y"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("e"),
+                          Plurimath::Math::Symbol.new("t"),
+                          Plurimath::Math::Symbol.new("r"),
+                          Plurimath::Math::Symbol.new("i"),
+                          Plurimath::Math::Symbol.new("c"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("2323")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("2331")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("3131")
-                    )
-                  ])
-                ])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("3131")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("cccccc")
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           \\left(
             \\begin{array}{cccccc}
@@ -2999,6 +3218,8 @@ RSpec.describe Plurimath::Math::Formula do
             \\end{array}
           \\right)
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -3077,13 +3298,14 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Number.new("3"),
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           \\Delta \\sigma_{ij} =  \\sum_{k=1}^{3} \\sum_{l=1}^{3} d_{ijkl} \\Delta \\varepsilon_{kl} -
           \\alpha_{kl}\\Delta T - \\beta_{kl}\\Delta M  ;
           for ; i = 1,3 ; and ; j = 1,3
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -3109,8 +3331,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "G=\\frac{E}{21+\\nu}" }
       it "returns formula" do
-        expected_value = "G=\\frac{E}{21+\\nu}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -3123,8 +3345,8 @@ RSpec.describe Plurimath::Math::Formula do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Number.new("1"),
                         Plurimath::Math::Function::Base.new(
@@ -3132,50 +3354,54 @@ RSpec.describe Plurimath::Math::Formula do
                           Plurimath::Math::Number.new("11")
                         )
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("-"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("&#x3bd;"),
-                          Plurimath::Math::Number.new("12")
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("-"),
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("&#x3bd;"),
+                            Plurimath::Math::Number.new("12")
+                          ),
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("E"),
+                            Plurimath::Math::Number.new("22")
+                          )
                         ),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("E"),
-                          Plurimath::Math::Number.new("22")
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("-"),
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("&#x3bd;"),
+                            Plurimath::Math::Number.new("13")
+                          ),
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("E"),
+                            Plurimath::Math::Number.new("33")
+                          )
                         ),
-                      ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("-"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("&#x3bd;"),
-                          Plurimath::Math::Number.new("13")
-                        ),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("E"),
-                          Plurimath::Math::Number.new("33")
-                        )
-                      ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Function::Base.new(
                           Plurimath::Math::Symbol.new("&#x3bd;"),
                           Plurimath::Math::Formula.new([
                             Plurimath::Math::Number.new("1"),
                             Plurimath::Math::Symbol.new(","),
-                            Plurimath::Math::Number.new("12")
+                            Plurimath::Math::Number.new("12"),
                           ])
                         ),
                         Plurimath::Math::Function::Base.new(
@@ -3183,25 +3409,29 @@ RSpec.describe Plurimath::Math::Formula do
                           Plurimath::Math::Number.new("12")
                         )
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("mm")
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Number.new("1"),
                         Plurimath::Math::Function::Base.new(
@@ -3209,34 +3439,36 @@ RSpec.describe Plurimath::Math::Formula do
                           Plurimath::Math::Number.new("22")
                         )
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("-"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("&#x3bd;"),
-                          Plurimath::Math::Number.new("23")
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("-"),
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("&#x3bd;"),
+                            Plurimath::Math::Number.new("23")
+                          ),
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("E"),
+                            Plurimath::Math::Number.new("22")
+                          )
                         ),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("E"),
-                          Plurimath::Math::Number.new("22")
-                        )
-                      ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Function::Base.new(
                           Plurimath::Math::Symbol.new("&#x3bd;"),
                           Plurimath::Math::Formula.new([
                             Plurimath::Math::Number.new("2"),
                             Plurimath::Math::Symbol.new(","),
-                            Plurimath::Math::Number.new("12")
+                            Plurimath::Math::Number.new("12"),
                           ])
                         ),
                         Plurimath::Math::Function::Base.new(
@@ -3244,26 +3476,30 @@ RSpec.describe Plurimath::Math::Formula do
                           Plurimath::Math::Number.new("12")
                         )
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("mm")
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Number.new("1"),
                         Plurimath::Math::Function::Base.new(
@@ -3271,18 +3507,18 @@ RSpec.describe Plurimath::Math::Formula do
                           Plurimath::Math::Number.new("33")
                         )
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Function::Base.new(
                           Plurimath::Math::Symbol.new("&#x3bd;"),
                           Plurimath::Math::Formula.new([
                             Plurimath::Math::Number.new("3"),
                             Plurimath::Math::Symbol.new(","),
-                            Plurimath::Math::Number.new("12")
+                            Plurimath::Math::Number.new("12"),
                           ])
                         ),
                         Plurimath::Math::Function::Base.new(
@@ -3290,27 +3526,31 @@ RSpec.describe Plurimath::Math::Formula do
                           Plurimath::Math::Number.new("12")
                         )
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("mm")
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Number.new("1"),
                         Plurimath::Math::Function::Base.new(
@@ -3318,30 +3558,49 @@ RSpec.describe Plurimath::Math::Formula do
                           Plurimath::Math::Number.new("12")
                         )
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("mm")
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("\\mbox{symmetric}")
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Mbox.new(
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("s"),
+                          Plurimath::Math::Symbol.new("y"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("e"),
+                          Plurimath::Math::Symbol.new("t"),
+                          Plurimath::Math::Symbol.new("r"),
+                          Plurimath::Math::Symbol.new("i"),
+                          Plurimath::Math::Symbol.new("c"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Number.new("1"),
                         Plurimath::Math::Function::Base.new(
@@ -3349,18 +3608,18 @@ RSpec.describe Plurimath::Math::Formula do
                           Plurimath::Math::Number.new("23")
                         )
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Function::Base.new(
                           Plurimath::Math::Symbol.new("&#x3bd;"),
                           Plurimath::Math::Formula.new([
                             Plurimath::Math::Number.new("23"),
                             Plurimath::Math::Symbol.new(","),
-                            Plurimath::Math::Number.new("31")
+                            Plurimath::Math::Number.new("31"),
                           ])
                         ),
                         Plurimath::Math::Function::Base.new(
@@ -3368,23 +3627,25 @@ RSpec.describe Plurimath::Math::Formula do
                           Plurimath::Math::Number.new("31")
                         )
                       ),
-                      "displaystyle"
-                    )
-                  ])
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("mm")
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Number.new("1"),
                         Plurimath::Math::Function::Base.new(
@@ -3392,22 +3653,20 @@ RSpec.describe Plurimath::Math::Formula do
                           Plurimath::Math::Number.new("31")
                         )
                       ),
-                      "displaystyle"
-                    )
-                  ])
-                ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("cccccc")
-              ]
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
             \\left(
               \\begin{array}{cccccc}
@@ -3437,6 +3696,8 @@ RSpec.describe Plurimath::Math::Formula do
               \\end{array}
             \\right)
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -3449,8 +3710,8 @@ RSpec.describe Plurimath::Math::Formula do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Number.new("1"),
                         Plurimath::Math::Function::Base.new(
@@ -3458,60 +3719,69 @@ RSpec.describe Plurimath::Math::Formula do
                           Plurimath::Math::Number.new("11")
                         )
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("-"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("&#x3bd;"),
-                          Plurimath::Math::Number.new("12")
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("-"),
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("&#x3bd;"),
+                            Plurimath::Math::Number.new("12")
+                          ),
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("E"),
+                            Plurimath::Math::Number.new("22")
+                          )
                         ),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("E"),
-                          Plurimath::Math::Number.new("22")
-                        )
-                      ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("-"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("&#x3bd;"),
-                          Plurimath::Math::Number.new("13")
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("-"),
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("&#x3bd;"),
+                            Plurimath::Math::Number.new("13")
+                          ),
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("E"),
+                            Plurimath::Math::Number.new("33")
+                          )
                         ),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("E"),
-                          Plurimath::Math::Number.new("33")
-                        )
-                      ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("mm")
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Number.new("1"),
                         Plurimath::Math::Function::Base.new(
@@ -3519,45 +3789,52 @@ RSpec.describe Plurimath::Math::Formula do
                           Plurimath::Math::Number.new("22")
                         )
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("-"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("&#x3bd;"),
-                          Plurimath::Math::Number.new("23")
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("-"),
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("&#x3bd;"),
+                            Plurimath::Math::Number.new("23")
+                          ),
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("E"),
+                            Plurimath::Math::Number.new("33")
+                          )
                         ),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("E"),
-                          Plurimath::Math::Number.new("33")
-                        )
-                      ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("mm")
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Number.new("1"),
                         Plurimath::Math::Function::Base.new(
@@ -3565,30 +3842,35 @@ RSpec.describe Plurimath::Math::Formula do
                           Plurimath::Math::Number.new("33")
                         )
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("mm")
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Number.new("1"),
                         Plurimath::Math::Function::Base.new(
@@ -3596,30 +3878,45 @@ RSpec.describe Plurimath::Math::Formula do
                           Plurimath::Math::Number.new("12")
                         )
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("mm")
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("symmetric")
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("s"),
+                      Plurimath::Math::Symbol.new("y"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("e"),
+                      Plurimath::Math::Symbol.new("t"),
+                      Plurimath::Math::Symbol.new("r"),
+                      Plurimath::Math::Symbol.new("i"),
+                      Plurimath::Math::Symbol.new("c"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Number.new("1"),
                         Plurimath::Math::Function::Base.new(
@@ -3627,26 +3924,29 @@ RSpec.describe Plurimath::Math::Formula do
                           Plurimath::Math::Number.new("23")
                         )
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("mm")
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Number.new("1"),
                         Plurimath::Math::Function::Base.new(
@@ -3654,22 +3954,20 @@ RSpec.describe Plurimath::Math::Formula do
                           Plurimath::Math::Number.new("31")
                         )
                       ),
-                      "displaystyle"
-                    )
-                  ])
-                ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("cccccc")
-              ]
+              nil,
+              {}
             ),
             Plurimath::Math::Function::Right.new(")"),
-          ])
+          ]),
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           \\left(
             \\begin{array}{cccccc}
@@ -3703,6 +4001,8 @@ RSpec.describe Plurimath::Math::Formula do
             \\end{array}
           \\right)
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -3737,8 +4037,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "G_{tt}=\\frac{E_{tt}}{21+\\nu_{tt}}" }
       it "returns formula" do
-        expected_value = "G_{tt}=\\frac{E_{tt}}{21+\\nu_{tt}}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -3751,227 +4051,304 @@ RSpec.describe Plurimath::Math::Formula do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Number.new("1"),
                         Plurimath::Math::Function::Base.new(
                           Plurimath::Math::Symbol.new("E"),
-                          Plurimath::Math::Symbol.new("ll")
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("l"),
+                            Plurimath::Math::Symbol.new("l"),
+                          ])
                         )
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("-"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("&#x3bd;"),
-                          Plurimath::Math::Symbol.new("tl")
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("-"),
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("&#x3bd;"),
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("t"),
+                              Plurimath::Math::Symbol.new("l"),
+                            ])
+                          ),
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("E"),
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("t"),
+                              Plurimath::Math::Symbol.new("t"),
+                            ])
+                          )
                         ),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("E"),
-                          Plurimath::Math::Symbol.new("tt")
-                        )
-                      ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("-"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("&#x3bd;"),
-                          Plurimath::Math::Symbol.new("tl")
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("-"),
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("&#x3bd;"),
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("t"),
+                              Plurimath::Math::Symbol.new("l"),
+                            ])
+                          ),
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("E"),
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("t"),
+                              Plurimath::Math::Symbol.new("t"),
+                            ])
+                          )
                         ),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("E"),
-                          Plurimath::Math::Symbol.new("tt")
-                        )
-                      ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("mm")
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Number.new("1"),
                         Plurimath::Math::Function::Base.new(
                           Plurimath::Math::Symbol.new("E"),
-                          Plurimath::Math::Symbol.new("tt")
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("t"),
+                            Plurimath::Math::Symbol.new("t"),
+                          ])
                         )
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("-"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("&#x3bd;"),
-                          Plurimath::Math::Symbol.new("tt")
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("-"),
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("&#x3bd;"),
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("t"),
+                              Plurimath::Math::Symbol.new("t"),
+                            ])
+                          ),
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("E"),
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("t"),
+                              Plurimath::Math::Symbol.new("t"),
+                            ])
+                          )
                         ),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("E"),
-                          Plurimath::Math::Symbol.new("tt")
-                        )
-                      ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("mm")
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Number.new("1"),
                         Plurimath::Math::Function::Base.new(
                           Plurimath::Math::Symbol.new("E"),
-                          Plurimath::Math::Symbol.new("tt")
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("t"),
+                            Plurimath::Math::Symbol.new("t"),
+                          ])
                         )
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("mm")
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Number.new("1"),
                         Plurimath::Math::Function::Base.new(
                           Plurimath::Math::Symbol.new("G"),
-                          Plurimath::Math::Symbol.new("lt")
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("l"),
+                            Plurimath::Math::Symbol.new("t"),
+                          ])
                         )
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("mm")
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("\\mbox{symmetric}")
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Mbox.new(
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("s"),
+                          Plurimath::Math::Symbol.new("y"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("e"),
+                          Plurimath::Math::Symbol.new("t"),
+                          Plurimath::Math::Symbol.new("r"),
+                          Plurimath::Math::Symbol.new("i"),
+                          Plurimath::Math::Symbol.new("c"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Number.new("1"),
                         Plurimath::Math::Function::Base.new(
                           Plurimath::Math::Symbol.new("G"),
-                          Plurimath::Math::Symbol.new("tt")
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("t"),
+                            Plurimath::Math::Symbol.new("t"),
+                          ])
                         )
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("mm")
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Number.new("1"),
                         Plurimath::Math::Function::Base.new(
                           Plurimath::Math::Symbol.new("G"),
-                          Plurimath::Math::Symbol.new("lt")
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("l"),
+                            Plurimath::Math::Symbol.new("t"),
+                          ])
                         )
                       ),
-                      "displaystyle"
-                    )
-                  ])
-                ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("cccccc")
-              ]
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           \\left(
             \\begin{array}{cccccc}
@@ -4005,6 +4382,8 @@ RSpec.describe Plurimath::Math::Formula do
             \\end{array}
           \\right)
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -4017,227 +4396,304 @@ RSpec.describe Plurimath::Math::Formula do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Number.new("1"),
                         Plurimath::Math::Function::Base.new(
                           Plurimath::Math::Symbol.new("E"),
-                          Plurimath::Math::Symbol.new("ll")
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("l"),
+                            Plurimath::Math::Symbol.new("l"),
+                          ])
                         )
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("-"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("&#x3bd;"),
-                          Plurimath::Math::Symbol.new("tl")
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("-"),
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("&#x3bd;"),
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("t"),
+                              Plurimath::Math::Symbol.new("l"),
+                            ])
+                          ),
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("E"),
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("t"),
+                              Plurimath::Math::Symbol.new("t"),
+                            ])
+                          )
                         ),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("E"),
-                          Plurimath::Math::Symbol.new("tt")
-                        )
-                      ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("-"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("&#x3bd;"),
-                          Plurimath::Math::Symbol.new("tl")
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("-"),
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("&#x3bd;"),
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("t"),
+                              Plurimath::Math::Symbol.new("l"),
+                            ])
+                          ),
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("E"),
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("t"),
+                              Plurimath::Math::Symbol.new("t"),
+                            ])
+                          )
                         ),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("E"),
-                          Plurimath::Math::Symbol.new("tt")
-                        )
-                      ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("mm")
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Number.new("1"),
                         Plurimath::Math::Function::Base.new(
                           Plurimath::Math::Symbol.new("E"),
-                          Plurimath::Math::Symbol.new("tt")
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("t"),
+                            Plurimath::Math::Symbol.new("t"),
+                          ])
                         )
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("-"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("&#x3bd;"),
-                          Plurimath::Math::Symbol.new("tt")
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("-"),
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("&#x3bd;"),
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("t"),
+                              Plurimath::Math::Symbol.new("t"),
+                            ])
+                          ),
+                          Plurimath::Math::Function::Base.new(
+                            Plurimath::Math::Symbol.new("E"),
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("t"),
+                              Plurimath::Math::Symbol.new("t"),
+                            ])
+                          )
                         ),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("E"),
-                          Plurimath::Math::Symbol.new("tt")
-                        )
-                      ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("mm")
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Number.new("1"),
                         Plurimath::Math::Function::Base.new(
                           Plurimath::Math::Symbol.new("E"),
-                          Plurimath::Math::Symbol.new("tt")
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("t"),
+                            Plurimath::Math::Symbol.new("t"),
+                          ])
                         )
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("mm")
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Number.new("1"),
                         Plurimath::Math::Function::Base.new(
                           Plurimath::Math::Symbol.new("G"),
-                          Plurimath::Math::Symbol.new("lt")
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("l"),
+                            Plurimath::Math::Symbol.new("t"),
+                          ])
                         )
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("mm")
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("\\mbox{symmetric}")
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Mbox.new(
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("s"),
+                          Plurimath::Math::Symbol.new("y"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("e"),
+                          Plurimath::Math::Symbol.new("t"),
+                          Plurimath::Math::Symbol.new("r"),
+                          Plurimath::Math::Symbol.new("i"),
+                          Plurimath::Math::Symbol.new("c"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Number.new("1"),
                         Plurimath::Math::Function::Base.new(
                           Plurimath::Math::Symbol.new("G"),
-                          Plurimath::Math::Symbol.new("tt")
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("t"),
+                            Plurimath::Math::Symbol.new("t"),
+                          ])
                         )
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("mm")
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Number.new("1"),
                         Plurimath::Math::Function::Base.new(
                           Plurimath::Math::Symbol.new("G"),
-                          Plurimath::Math::Symbol.new("lt")
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("l"),
+                            Plurimath::Math::Symbol.new("t"),
+                          ])
                         )
                       ),
-                      "displaystyle"
-                    )
-                  ])
-                ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("cccccc")
-              ]
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           \\left(
             \\begin{array}{cccccc}
@@ -4271,6 +4727,8 @@ RSpec.describe Plurimath::Math::Formula do
             \\end{array}
           \\right)
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -4283,191 +4741,232 @@ RSpec.describe Plurimath::Math::Formula do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Number.new("1"),
                         Plurimath::Math::Symbol.new("E")
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("-"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Symbol.new("&#x3bd;"),
-                        Plurimath::Math::Symbol.new("E")
-                      ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("-"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Symbol.new("&#x3bd;"),
-                        Plurimath::Math::Symbol.new("E")
-                      ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("-"),
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Symbol.new("&#x3bd;"),
+                          Plurimath::Math::Symbol.new("E")
+                        ),
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("-"),
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Symbol.new("&#x3bd;"),
+                          Plurimath::Math::Symbol.new("E")
+                        ),
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("mm")
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Number.new("1"),
                         Plurimath::Math::Symbol.new("E")
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("-"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Symbol.new("&#x3bd;"),
-                        Plurimath::Math::Symbol.new("E")
-                      ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("-"),
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Symbol.new("&#x3bd;"),
+                          Plurimath::Math::Symbol.new("E")
+                        ),
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("mm")
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Number.new("1"),
                         Plurimath::Math::Symbol.new("E")
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("mm")
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Number.new("1"),
                         Plurimath::Math::Symbol.new("G")
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("mm")
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("\\mbox{symmetric}")
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Mbox.new(
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("s"),
+                          Plurimath::Math::Symbol.new("y"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("e"),
+                          Plurimath::Math::Symbol.new("t"),
+                          Plurimath::Math::Symbol.new("r"),
+                          Plurimath::Math::Symbol.new("i"),
+                          Plurimath::Math::Symbol.new("c"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Number.new("1"),
                         Plurimath::Math::Symbol.new("G")
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("mm")
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Number.new("1"),
                         Plurimath::Math::Symbol.new("G")
                       ),
-                      "displaystyle"
-                    )
-                  ])
-                ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("cccccc")
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           \\left(
             \\begin{array}{cccccc}
@@ -4500,6 +4999,8 @@ RSpec.describe Plurimath::Math::Formula do
             \\end{array}
           \\right)
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -4512,68 +5013,84 @@ RSpec.describe Plurimath::Math::Formula do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("&#x03b5;"),
-                      Plurimath::Math::Number.new("11")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("&#x03b5;"),
+                        Plurimath::Math::Number.new("11")
+                      )
+                    ],
+                    { columnalign: "center" }
+                  )
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("&#x03b5;"),
-                      Plurimath::Math::Number.new("22")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("&#x03b5;"),
+                        Plurimath::Math::Number.new("22")
+                      )
+                    ],
+                    { columnalign: "center" }
+                  )
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("&#x03b5;"),
-                      Plurimath::Math::Number.new("33")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("&#x03b5;"),
+                        Plurimath::Math::Number.new("33")
+                      )
+                    ],
+                    { columnalign: "center" }
+                  )
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("2"),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("&#x03b5;"),
-                      Plurimath::Math::Number.new("12")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Number.new("2"),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("&#x03b5;"),
+                        Plurimath::Math::Number.new("12")
+                      )
+                    ],
+                    { columnalign: "center" }
+                  )
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("2"),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("&#x03b5;"),
-                      Plurimath::Math::Number.new("23")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Number.new("2"),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("&#x03b5;"),
+                        Plurimath::Math::Number.new("23")
+                      )
+                    ],
+                    { columnalign: "center" }
+                  )
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("2"),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Number.new("2"),
                       Plurimath::Math::Function::Base.new(
                         Plurimath::Math::Symbol.new("&#x03b5;"),
                         Plurimath::Math::Number.new("31")
                       )
-                    ])
+                    ],
+                    { columnalign: "center" }
+                  )
                 ])
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c")
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")"),
+            Plurimath::Math::Function::Right.new(")")
           ])
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           \\left(
             \\begin{array}{c}
@@ -4586,6 +5103,8 @@ RSpec.describe Plurimath::Math::Formula do
             \\end{array}
           \\right)
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -4602,47 +5121,47 @@ RSpec.describe Plurimath::Math::Formula do
             Plurimath::Math::Formula.new([
               Plurimath::Math::Symbol.new("j"),
               Plurimath::Math::Symbol.new("="),
-              Plurimath::Math::Number.new("1")
+              Plurimath::Math::Number.new("1"),
             ]),
             Plurimath::Math::Number.new("6")
           ),
           Plurimath::Math::Function::Base.new(
             Plurimath::Math::Symbol.new("D"),
-            Plurimath::Math::Symbol.new("ij")
-          ),
-          Plurimath::Math::Formula.new([
-            Plurimath::Math::Function::Base.new(
-              Plurimath::Math::Symbol.new("E"),
-              Plurimath::Math::Symbol.new("j")
-            ),
-            Plurimath::Math::Symbol.new("-"),
-            Plurimath::Math::Function::PowerBase.new(
-              Plurimath::Math::Symbol.new("E"),
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Symbol.new("i"),
               Plurimath::Math::Symbol.new("j"),
-              Plurimath::Math::Symbol.new("T"),
-            ),
-            Plurimath::Math::Symbol.new("-"),
-            Plurimath::Math::Function::PowerBase.new(
-              Plurimath::Math::Symbol.new("E"),
-              Plurimath::Math::Symbol.new("j"),
-              Plurimath::Math::Symbol.new("M"),
-            )
-          ]),
-          Plurimath::Math::Symbol.new("&#x3b;"),
-          Plurimath::Math::Function::FontStyle.new(
-            Plurimath::Math::Symbol.new("for"),
-            "rm"
+            ])
           ),
-          Plurimath::Math::Symbol.new("&#x3b;"),
+          Plurimath::Math::Function::Base.new(
+            Plurimath::Math::Symbol.new("E"),
+            Plurimath::Math::Symbol.new("j")
+          ),
+          Plurimath::Math::Symbol.new("-"),
+          Plurimath::Math::Function::PowerBase.new(
+            Plurimath::Math::Symbol.new("E"),
+            Plurimath::Math::Symbol.new("j"),
+            Plurimath::Math::Symbol.new("T")
+          ),
+          Plurimath::Math::Symbol.new("-"),
+          Plurimath::Math::Function::PowerBase.new(
+            Plurimath::Math::Symbol.new("E"),
+            Plurimath::Math::Symbol.new("j"),
+            Plurimath::Math::Symbol.new("M")
+          ),
+          Plurimath::Math::Symbol.new(";"),
+          Plurimath::Math::Symbol.new("f"),
+          Plurimath::Math::Symbol.new("o"),
+          Plurimath::Math::Symbol.new("r"),
+          Plurimath::Math::Symbol.new(";"),
           Plurimath::Math::Symbol.new("i"),
           Plurimath::Math::Symbol.new("="),
           Plurimath::Math::Number.new("1"),
           Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Number.new("6")
-        ])
+          Plurimath::Math::Number.new("6"),
+        ]);
       }
+      let(:expected_value) { "S_{i}=\\sum_{j=1}^{6}D_{ij}E_{j}-E_{j}^{T}-E_{j}^{M};for;i=1,6" }
       it "returns formula" do
-        expected_value = "S_{i}=\\sum_{j=1}^{6}D_{ij}E_{j}-E_{j}^{T}-E_{j}^{M};for;i=1,6"
         expect(formula).to eq(expected_value)
       end
     end
@@ -4655,172 +5174,248 @@ RSpec.describe Plurimath::Math::Formula do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("1111")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("1122")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("1133")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("1112")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("1123")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("1131")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("1111")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("1122")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("1133")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("1112")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("1123")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("1131")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("2222")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("2233")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("2212")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("2223")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("2231")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("2222")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("2233")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("2212")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("2223")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("2231")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("3333")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("3312")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("3323")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("3331")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("3333")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("3312")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("3323")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("3331")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("1212")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("1223")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("1231")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("1212")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("1223")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("1231")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("\\mbox{symmetric}")
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("2323")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("2331")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Mbox.new(
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("s"),
+                          Plurimath::Math::Symbol.new("y"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("e"),
+                          Plurimath::Math::Symbol.new("t"),
+                          Plurimath::Math::Symbol.new("r"),
+                          Plurimath::Math::Symbol.new("i"),
+                          Plurimath::Math::Symbol.new("c"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("2323")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("2331")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("d"),
-                      Plurimath::Math::Number.new("3131")
-                    )
-                  ])
-                ])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("d"),
+                        Plurimath::Math::Number.new("3131")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("cccccc")
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           \\left(
             \\begin{array}{cccccc}
@@ -4849,6 +5444,8 @@ RSpec.describe Plurimath::Math::Formula do
             \\end{array}
           \\right)
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -4861,65 +5458,82 @@ RSpec.describe Plurimath::Math::Formula do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("s"),
-                      Plurimath::Math::Number.new("11")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("s"),
+                        Plurimath::Math::Number.new("11")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("s"),
-                      Plurimath::Math::Number.new("22")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("s"),
+                        Plurimath::Math::Number.new("22")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("s"),
-                      Plurimath::Math::Number.new("33")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("s"),
+                        Plurimath::Math::Number.new("33")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("s"),
-                      Plurimath::Math::Number.new("12")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("s"),
+                        Plurimath::Math::Number.new("12")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("s"),
-                      Plurimath::Math::Number.new("23")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("s"),
+                        Plurimath::Math::Number.new("23")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("s"),
-                      Plurimath::Math::Number.new("31")
-                    )
-                  ])
-                ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("s"),
+                        Plurimath::Math::Number.new("31")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c")
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
       }
+      let(:expected_value) { "\\left(\\begin{array}{c}s_{11} \\\\s_{22} \\\\s_{33} \\\\s_{12} \\\\s_{23} \\\\s_{31}\\end{array}\\right)" }
       it "returns formula" do
-        expected_value = "\\left(\\begin{array}{c}s_{11} \\\\s_{22} \\\\s_{33} \\\\s_{12} \\\\s_{23} \\\\s_{31}\\end{array}\\right)"
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -4980,12 +5594,13 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Number.new("3")
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           s_{ij} =  \\sum_{k=1}^{3} \\sum_{l=1}^{3} d_{ijkl} e_{kl} ;
           for ; i = 1,3 ; and ; j = 1,3
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -5046,8 +5661,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Number.new("2")
         ])
       }
+      let(:expected_value) { "s_{ij}=\\sum_{k=1}^{2}\\sum_{l=1}^{2}d_{ijkl}e_{kl};for;i=1,2;and;j=1,2" }
       it "returns formula" do
-        expected_value = "s_{ij}=\\sum_{k=1}^{2}\\sum_{l=1}^{2}d_{ijkl}e_{kl};for;i=1,2;and;j=1,2"
         expect(formula).to eq(expected_value)
       end
     end
@@ -5060,59 +5675,73 @@ RSpec.describe Plurimath::Math::Formula do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("s"),
-                      Plurimath::Math::Number.new("11")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("s"),
+                        Plurimath::Math::Number.new("11")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("s"),
-                      Plurimath::Math::Number.new("22")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("s"),
+                        Plurimath::Math::Number.new("22")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("s"),
-                      Plurimath::Math::Number.new("33")
-                    )
-                  ])
-                ])
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("s"),
+                        Plurimath::Math::Number.new("33")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("ccc")
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
       }
+      let(:expected_value) { "\\left(\\begin{array}{ccc}s_{11}&0&0\\\\0&s_{22}&0\\\\0&0&s_{33}\\end{array}\\right)" }
       it "returns formula" do
-        expected_value = "\\left(\\begin{array}{ccc}s_{11}&0&0\\\\0&s_{22}&0\\\\0&0&s_{33}\\end{array}\\right)"
         expect(formula).to eq(expected_value)
       end
     end
@@ -5132,8 +5761,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "-\\rho\\overline{w'w'}" }
       it "returns formula" do
-        expected_value = "-\\rho\\overline{w'w'}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -5156,8 +5785,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "{1\\over2}\\rhoq^{2}" }
       it "returns formula" do
-        expected_value = "{1\\over2}\\rhoq^{2}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -5168,75 +5797,90 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Function::Table::Array.new(
             [
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Tilde.new(
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Tilde.new(
+                      Plurimath::Math::Symbol.new("x")
+                    ),
+                    Plurimath::Math::Symbol.new("="),
                     Plurimath::Math::Symbol.new("x"),
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Symbol.new("x"),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("L"),
-                  Plurimath::Math::Symbol.new(",")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Tilde.new(
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Symbol.new("L"),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Tilde.new(
+                      Plurimath::Math::Symbol.new("u")
+                    ),
+                    Plurimath::Math::Symbol.new("="),
                     Plurimath::Math::Symbol.new("u"),
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Symbol.new("u"),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("c"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new(",")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Tilde.new(
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("c"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Tilde.new(
+                      Plurimath::Math::Symbol.new("&#x3c1;")
+                    ),
+                    Plurimath::Math::Symbol.new("="),
                     Plurimath::Math::Symbol.new("&#x3c1;"),
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Symbol.new("&#x3c1;"),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("&#x3c1;"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new(",")
-                ])
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("&#x3c1;"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
               ]),
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Tilde.new(
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Tilde.new(
+                      Plurimath::Math::Symbol.new("y")
+                    ),
+                    Plurimath::Math::Symbol.new("="),
                     Plurimath::Math::Symbol.new("y"),
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Symbol.new("y"),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("L"),
-                  Plurimath::Math::Symbol.new(",")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Tilde.new(
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Symbol.new("L"),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Tilde.new(
+                      Plurimath::Math::Symbol.new("v")
+                    ),
+                    Plurimath::Math::Symbol.new("="),
                     Plurimath::Math::Symbol.new("v"),
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Symbol.new("v"),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("c"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new(",")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Tilde.new(
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("c"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Tilde.new(
+                      Plurimath::Math::Symbol.new("p")
+                    ),
+                    Plurimath::Math::Symbol.new("="),
                     Plurimath::Math::Symbol.new("p"),
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Symbol.new("p"),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Formula.new([
+                    Plurimath::Math::Symbol.new("/"),
                     Plurimath::Math::Function::Base.new(
                       Plurimath::Math::Symbol.new("&#x3c1;"),
                       Plurimath::Math::Symbol.new("&#x221e;")
@@ -5244,62 +5888,70 @@ RSpec.describe Plurimath::Math::Formula do
                     Plurimath::Math::Function::PowerBase.new(
                       Plurimath::Math::Symbol.new("c"),
                       Plurimath::Math::Symbol.new("&#x221e;"),
-                      Plurimath::Math::Number.new("2"),
-                    )
-                  ]),
-                  Plurimath::Math::Symbol.new(",")
-                ])
+                      Plurimath::Math::Number.new("2")
+                    ),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
               ]),
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Tilde.new(
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Tilde.new(
+                      Plurimath::Math::Symbol.new("z")
+                    ),
+                    Plurimath::Math::Symbol.new("="),
                     Plurimath::Math::Symbol.new("z"),
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Symbol.new("z"),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("L"),
-                  Plurimath::Math::Symbol.new(","),
-                  Plurimath::Math::Symbol.new("&#x2001;")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Tilde.new(
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Symbol.new("L"),
+                    Plurimath::Math::Symbol.new(","),
+                    Plurimath::Math::Symbol.new("&#x2001;"),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Tilde.new(
+                      Plurimath::Math::Symbol.new("w")
+                    ),
+                    Plurimath::Math::Symbol.new("="),
                     Plurimath::Math::Symbol.new("w"),
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Symbol.new("w"),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("c"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new(","),
-                  Plurimath::Math::Symbol.new("&#x2001;")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Tilde.new(
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("c"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new(","),
+                    Plurimath::Math::Symbol.new("&#x2001;"),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Tilde.new(
+                      Plurimath::Math::Symbol.new("&#x3bc;")
+                    ),
+                    Plurimath::Math::Symbol.new("="),
                     Plurimath::Math::Symbol.new("&#x3bc;"),
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Symbol.new("&#x3bc;"),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("&#x3bc;"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new(",")
-                ])
-              ])
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("&#x3bc;"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+              ]),
             ],
             nil,
-            [
-              Plurimath::Math::Symbol.new("ccc")
-            ],
-          )
+            nil,
+            {}
+          ),
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           \\begin{array}{ccc}
             \\tilde{x} = x/L, &  \\tilde{u} = u/c_{\\infty}, & \\tilde{\\rho} = \\rho/\\rho_{\\infty}, \\\\
@@ -5307,6 +5959,8 @@ RSpec.describe Plurimath::Math::Formula do
             \\tilde{z} = z/L, \\quad & \\tilde{w} = w/c_{\\infty}, \\quad & \\tilde{\\mu} = \\mu/\\mu_{\\infty},
           \\end{array}
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -5419,13 +6073,14 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new(",")
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           x' = x/L, & u' = u/L/T, & \\rho' = \\rho/M/L^{3}, \\\\
           y' = y/L, & v' = v/L/T, & p' = p/M/L T^{2}, \\\\
           z' = z/L, \\quad & w' = w/L/T, \\quad & \\mu' = \\mu/M/L T,
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -5436,241 +6091,274 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Function::Table::Array.new(
             [
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("x"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("'"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Symbol.new("ref"),
-                      "textrm"
-                    )
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
+                Plurimath::Math::Function::Td.new(
+                  [
                     Plurimath::Math::Symbol.new("x"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Symbol.new("ref"),
-                      "textrm"
-                    )
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("L"),
-                  Plurimath::Math::Symbol.new(",")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("u"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("'"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Symbol.new("ref"),
-                      "textrm"
-                    )
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Unicode.new("&#x27;"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("r"),
+                        Plurimath::Math::Symbol.new("e"),
+                        Plurimath::Math::Symbol.new("f"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("x"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("r"),
+                        Plurimath::Math::Symbol.new("e"),
+                        Plurimath::Math::Symbol.new("f"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Symbol.new("L"),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
                     Plurimath::Math::Symbol.new("u"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Symbol.new("ref"),
-                      "textrm"
-                    )
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Formula.new([
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Unicode.new("&#x27;"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("r"),
+                        Plurimath::Math::Symbol.new("e"),
+                        Plurimath::Math::Symbol.new("f"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("u"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("r"),
+                        Plurimath::Math::Symbol.new("e"),
+                        Plurimath::Math::Symbol.new("f"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
                     Plurimath::Math::Symbol.new("L"),
                     Plurimath::Math::Symbol.new("/"),
-                    Plurimath::Math::Symbol.new("T")
-                  ]),
-                  Plurimath::Math::Symbol.new(",")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("&#x3c1;"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("'"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Symbol.new("ref"),
-                      "textrm"
-                    )
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
+                    Plurimath::Math::Symbol.new("T"),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
                     Plurimath::Math::Symbol.new("&#x3c1;"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Symbol.new("ref"),
-                      "textrm"
-                    )
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Formula.new([
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Unicode.new("&#x27;"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("r"),
+                        Plurimath::Math::Symbol.new("e"),
+                        Plurimath::Math::Symbol.new("f"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("&#x3c1;"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("r"),
+                        Plurimath::Math::Symbol.new("e"),
+                        Plurimath::Math::Symbol.new("f"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
                     Plurimath::Math::Symbol.new("M"),
                     Plurimath::Math::Symbol.new("/"),
                     Plurimath::Math::Function::Power.new(
                       Plurimath::Math::Symbol.new("L"),
                       Plurimath::Math::Number.new("3")
-                    )
-                  ]),
-                  Plurimath::Math::Symbol.new(",")
-                ])
+                    ),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
               ]),
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("y"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("'"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Symbol.new("ref"),
-                      "textrm"
-                    )
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
+                Plurimath::Math::Function::Td.new(
+                  [
                     Plurimath::Math::Symbol.new("y"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Symbol.new("ref"),
-                      "textrm"
-                    )
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("L"),
-                  Plurimath::Math::Symbol.new(",")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("v"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("'"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Symbol.new("ref"),
-                      "textrm"
-                    )
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Unicode.new("&#x27;"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("r"),
+                        Plurimath::Math::Symbol.new("e"),
+                        Plurimath::Math::Symbol.new("f"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("y"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("r"),
+                        Plurimath::Math::Symbol.new("e"),
+                        Plurimath::Math::Symbol.new("f"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Symbol.new("L"),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
                     Plurimath::Math::Symbol.new("v"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Symbol.new("ref"),
-                      "textrm"
-                    )
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Formula.new([
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Unicode.new("&#x27;"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("r"),
+                        Plurimath::Math::Symbol.new("e"),
+                        Plurimath::Math::Symbol.new("f"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("v"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("r"),
+                        Plurimath::Math::Symbol.new("e"),
+                        Plurimath::Math::Symbol.new("f"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
                     Plurimath::Math::Symbol.new("L"),
                     Plurimath::Math::Symbol.new("/"),
-                    Plurimath::Math::Symbol.new("T")
-                  ]),
-                  Plurimath::Math::Symbol.new(",")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("p"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("'"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Symbol.new("ref"),
-                      "textrm"
-                    )
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
+                    Plurimath::Math::Symbol.new("T"),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
                     Plurimath::Math::Symbol.new("p"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Symbol.new("ref"),
-                      "textrm"
-                    )
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Formula.new([
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Unicode.new("&#x27;"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("r"),
+                        Plurimath::Math::Symbol.new("e"),
+                        Plurimath::Math::Symbol.new("f"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("p"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("r"),
+                        Plurimath::Math::Symbol.new("e"),
+                        Plurimath::Math::Symbol.new("f"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
                     Plurimath::Math::Symbol.new("M"),
                     Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Symbol.new("L"),
                     Plurimath::Math::Function::Power.new(
-                      Plurimath::Math::Symbol.new("LT"),
+                      Plurimath::Math::Symbol.new("T"),
                       Plurimath::Math::Number.new("2")
-                    )
-                  ])
-                ])
+                    ),
+                  ],
+                  { columnalign: "center" }
+                ),
               ]),
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("z"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("'"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Symbol.new("ref"),
-                      "textrm"
-                    )
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
+                Plurimath::Math::Function::Td.new(
+                  [
                     Plurimath::Math::Symbol.new("z"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Symbol.new("ref"),
-                      "textrm"
-                    )
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("L"),
-                  Plurimath::Math::Symbol.new(","),
-                  Plurimath::Math::Symbol.new("&#x2001;")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("w"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("'"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Symbol.new("ref"),
-                      "textrm"
-                    )
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Unicode.new("&#x27;"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("r"),
+                        Plurimath::Math::Symbol.new("e"),
+                        Plurimath::Math::Symbol.new("f"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("z"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("r"),
+                        Plurimath::Math::Symbol.new("e"),
+                        Plurimath::Math::Symbol.new("f"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Symbol.new("L"),
+                    Plurimath::Math::Symbol.new(","),
+                    Plurimath::Math::Symbol.new("&#x2001;"),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
                     Plurimath::Math::Symbol.new("w"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Symbol.new("ref"),
-                      "textrm"
-                    )
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Formula.new([
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Unicode.new("&#x27;"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("r"),
+                        Plurimath::Math::Symbol.new("e"),
+                        Plurimath::Math::Symbol.new("f"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("w"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("r"),
+                        Plurimath::Math::Symbol.new("e"),
+                        Plurimath::Math::Symbol.new("f"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
                     Plurimath::Math::Symbol.new("L"),
                     Plurimath::Math::Symbol.new("/"),
-                    Plurimath::Math::Symbol.new("T")
-                  ]),
-                  Plurimath::Math::Symbol.new(","),
-                  Plurimath::Math::Symbol.new("&#x2001;")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Symbol.new("&#x3bc;"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("'"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Symbol.new("ref"),
-                      "textrm"
-                    )
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
+                    Plurimath::Math::Symbol.new("T"),
+                    Plurimath::Math::Symbol.new(","),
+                    Plurimath::Math::Symbol.new("&#x2001;"),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
                     Plurimath::Math::Symbol.new("&#x3bc;"),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Symbol.new("ref"),
-                      "textrm"
-                    )
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Formula.new([
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Unicode.new("&#x27;"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("r"),
+                        Plurimath::Math::Symbol.new("e"),
+                        Plurimath::Math::Symbol.new("f"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("&#x3bc;"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("r"),
+                        Plurimath::Math::Symbol.new("e"),
+                        Plurimath::Math::Symbol.new("f"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
                     Plurimath::Math::Symbol.new("M"),
                     Plurimath::Math::Symbol.new("/"),
-                    Plurimath::Math::Symbol.new("LT")
-                  ]),
-                  Plurimath::Math::Symbol.new(".")
-                ])
-              ])
+                    Plurimath::Math::Symbol.new("L"),
+                    Plurimath::Math::Symbol.new("T"),
+                    Plurimath::Math::Symbol.new("."),
+                  ],
+                  { columnalign: "center" }
+                ),
+              ]),
             ],
             nil,
-            [
-              Plurimath::Math::Symbol.new("ccc")
-            ],
-          )
+            nil,
+            {}
+          ),
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           \\begin{array}{ccc}
             x'_{ref} = x_{ref}/L, & u'_{ref} = u_{ref}/L/T, & \\rho'_{ref} = \\rho_{ref}/M/L^{3}, \\\\
@@ -5678,6 +6366,8 @@ RSpec.describe Plurimath::Math::Formula do
             z'_{ref} = z_{ref}/L, \\quad & w'_{ref} = w_{ref}/L/T, \\quad & \\mu'_{ref} = \\mu_{ref}/M/L T.
           \\end{array}
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -5846,8 +6536,7 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           \\begin{split}
             p''_{ijk} & \\equiv p_{ijk} / \\rho_{ref} c_{ref}^{2}.02in \\\\ \\\\
@@ -5855,6 +6544,8 @@ RSpec.describe Plurimath::Math::Formula do
             &= p'_{ijk} / \\rho'_{ref} c'_{ref}^{2}
           \\end{split}
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -5865,111 +6556,174 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Function::Table::Array.new(
             [
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Function::Tilde.new(
-                          Plurimath::Math::Symbol.new("x")
-                        ),
-                    Plurimath::Math::Symbol.new("ijk")
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("x"),
-                    Plurimath::Math::Symbol.new("ijk")
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("L"),
-                  Plurimath::Math::Symbol.new(",")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Function::Tilde.new(
-                      Plurimath::Math::Symbol.new("u")
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Function::Tilde.new(
+                        Plurimath::Math::Symbol.new("x")
+                      ),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("j"),
+                        Plurimath::Math::Symbol.new("k"),
+                      ])
                     ),
-                    Plurimath::Math::Symbol.new("ijk")
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("u"),
-                    Plurimath::Math::Symbol.new("ijk")
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("c"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new(",")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Function::Tilde.new(
-                      Plurimath::Math::Symbol.new("&#x3c1;")
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("x"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("j"),
+                        Plurimath::Math::Symbol.new("k"),
+                      ])
                     ),
-                    Plurimath::Math::Symbol.new("ijk")
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("&#x3c1;"),
-                    Plurimath::Math::Symbol.new("ijk")
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("&#x3c1;"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new(",")
-                ])
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Symbol.new("L"),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Function::Tilde.new(
+                        Plurimath::Math::Symbol.new("u")
+                      ),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("j"),
+                        Plurimath::Math::Symbol.new("k"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("u"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("j"),
+                        Plurimath::Math::Symbol.new("k"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("c"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Function::Tilde.new(
+                        Plurimath::Math::Symbol.new("&#x3c1;")
+                      ),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("j"),
+                        Plurimath::Math::Symbol.new("k"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("&#x3c1;"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("j"),
+                        Plurimath::Math::Symbol.new("k"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("&#x3c1;"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
               ]),
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Function::Tilde.new(
-                      Plurimath::Math::Symbol.new("y")
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Function::Tilde.new(
+                        Plurimath::Math::Symbol.new("y")
+                      ),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("j"),
+                        Plurimath::Math::Symbol.new("k"),
+                      ])
                     ),
-                    Plurimath::Math::Symbol.new("ijk")
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("y"),
-                    Plurimath::Math::Symbol.new("ijk")
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("L"),
-                  Plurimath::Math::Symbol.new(",")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Function::Tilde.new(
-                      Plurimath::Math::Symbol.new("v")
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("y"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("j"),
+                        Plurimath::Math::Symbol.new("k"),
+                      ])
                     ),
-                    Plurimath::Math::Symbol.new("ijk")
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("v"),
-                    Plurimath::Math::Symbol.new("ijk")
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("c"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new(",")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Function::Tilde.new(
-                      Plurimath::Math::Symbol.new("p")
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Symbol.new("L"),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Function::Tilde.new(
+                        Plurimath::Math::Symbol.new("v")
+                      ),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("j"),
+                        Plurimath::Math::Symbol.new("k"),
+                      ])
                     ),
-                    Plurimath::Math::Symbol.new("ijk")
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("p"),
-                    Plurimath::Math::Symbol.new("ijk")
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Formula.new([
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("v"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("j"),
+                        Plurimath::Math::Symbol.new("k"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("c"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Function::Tilde.new(
+                        Plurimath::Math::Symbol.new("p")
+                      ),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("j"),
+                        Plurimath::Math::Symbol.new("k"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("p"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("j"),
+                        Plurimath::Math::Symbol.new("k"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
                     Plurimath::Math::Function::Base.new(
                       Plurimath::Math::Symbol.new("&#x3c1;"),
                       Plurimath::Math::Symbol.new("&#x221e;")
@@ -5977,69 +6731,99 @@ RSpec.describe Plurimath::Math::Formula do
                     Plurimath::Math::Function::PowerBase.new(
                       Plurimath::Math::Symbol.new("c"),
                       Plurimath::Math::Symbol.new("&#x221e;"),
-                      Plurimath::Math::Number.new("2"),
-                    )
-                  ]),
-                  Plurimath::Math::Symbol.new(","),
-                  Plurimath::Math::Formula.new([
+                      Plurimath::Math::Number.new("2")
+                    ),
+                    Plurimath::Math::Symbol.new(","),
                     Plurimath::Math::Symbol.new("."),
                     Plurimath::Math::Number.new("02"),
-                    Plurimath::Math::Symbol.new("in")
-                  ])
-                ])
+                    Plurimath::Math::Symbol.new("i"),
+                    Plurimath::Math::Symbol.new("n"),
+                  ],
+                  { columnalign: "center" }
+                ),
               ]),
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Function::Tilde.new(
-                      Plurimath::Math::Symbol.new("z")
-                    ),
-                    Plurimath::Math::Symbol.new("ijk")
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("z"),
-                    Plurimath::Math::Symbol.new("ijk")
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("L"),
-                  Plurimath::Math::Symbol.new(",")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Function::Tilde.new(
-                      Plurimath::Math::Symbol.new("w")
-                    ),
-                    Plurimath::Math::Symbol.new("ijk")
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("w"),
-                    Plurimath::Math::Symbol.new("ijk")
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("c"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new(",")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Function::Tilde.new(
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
                       Plurimath::Math::Function::Tilde.new(
-                        Plurimath::Math::Symbol.new("&#x3bc;")
-                      )
+                        Plurimath::Math::Symbol.new("z")
+                      ),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("j"),
+                        Plurimath::Math::Symbol.new("k"),
+                      ])
                     ),
-                    Plurimath::Math::Symbol.new("ijk")
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("&#x3bc;"),
-                    Plurimath::Math::Symbol.new("ijk")
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Formula.new([
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("z"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("j"),
+                        Plurimath::Math::Symbol.new("k"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Symbol.new("L"),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Function::Tilde.new(
+                        Plurimath::Math::Symbol.new("w")
+                      ),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("j"),
+                        Plurimath::Math::Symbol.new("k"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("w"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("j"),
+                        Plurimath::Math::Symbol.new("k"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("c"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Function::Tilde.new(
+                        Plurimath::Math::Function::Tilde.new(
+                          Plurimath::Math::Symbol.new("&#x3bc;")
+                        )
+                      ),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("j"),
+                        Plurimath::Math::Symbol.new("k"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("&#x3bc;"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("j"),
+                        Plurimath::Math::Symbol.new("k"),
+                      ])
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
                     Plurimath::Math::Function::Base.new(
                       Plurimath::Math::Symbol.new("&#x3c1;"),
                       Plurimath::Math::Symbol.new("&#x221e;")
@@ -6048,21 +6832,20 @@ RSpec.describe Plurimath::Math::Formula do
                       Plurimath::Math::Symbol.new("c"),
                       Plurimath::Math::Symbol.new("&#x221e;")
                     ),
-                    Plurimath::Math::Symbol.new("L")
-                  ]),
-                  Plurimath::Math::Symbol.new(",")
-                ])
-              ])
+                    Plurimath::Math::Symbol.new("L"),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+              ]),
             ],
             nil,
-            [
-              Plurimath::Math::Symbol.new("ccc")
-            ],
-          )
+            nil,
+            {}
+          ),
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           \\begin{array}{ccc}
             \\tilde{x}_{ijk} = x_{ijk}/L, & \\tilde{u}_{ijk} = u_{ijk}/c_{\\infty}, & \\tilde{\\rho}_{ijk} = \\rho_{ijk}/\\rho_{\\infty}, \\\\
@@ -6070,6 +6853,8 @@ RSpec.describe Plurimath::Math::Formula do
             \\tilde{z}_{ijk} = z_{ijk}/L, & \\tilde{w}_{ijk} = w_{ijk}/c_{\\infty}, & \\tilde{\\tilde{\\mu}}_{ijk} = \\mu_{ijk} / \\rho_{\\infty} c_{\\infty} L,
           \\end{array}
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -6080,82 +6865,91 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Function::Table::Array.new(
             [
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Function::Tilde.new(
-                      Plurimath::Math::Symbol.new("u")
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Function::Tilde.new(
+                        Plurimath::Math::Symbol.new("u")
+                      ),
+                      Plurimath::Math::Symbol.new("&#x221e;")
                     ),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("u"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("c"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new(","),
-                  Plurimath::Math::Symbol.new("&#x2001;")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Function::Tilde.new(
-                      Plurimath::Math::Symbol.new("&#x3c1;")
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("u"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
                     ),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("&#x3c1;"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("&#x3c1;"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Number.new("1"),
-                  Plurimath::Math::Symbol.new(",")
-                ])
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("c"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new(","),
+                    Plurimath::Math::Symbol.new("&#x2001;"),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Function::Tilde.new(
+                        Plurimath::Math::Symbol.new("&#x3c1;")
+                      ),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("&#x3c1;"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("&#x3c1;"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Number.new("1"),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
               ]),
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Function::Tilde.new(
-                      Plurimath::Math::Symbol.new("v")
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Function::Tilde.new(
+                        Plurimath::Math::Symbol.new("v")
+                      ),
+                      Plurimath::Math::Symbol.new("&#x221e;")
                     ),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("v"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("c"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new(",")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Function::Tilde.new(
-                      Plurimath::Math::Symbol.new("p")
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("v"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
                     ),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("p"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Formula.new([
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("c"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Function::Tilde.new(
+                        Plurimath::Math::Symbol.new("p")
+                      ),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("p"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
                     Plurimath::Math::Function::Base.new(
                       Plurimath::Math::Symbol.new("&#x3c1;"),
                       Plurimath::Math::Symbol.new("&#x221e;")
@@ -6163,57 +6957,60 @@ RSpec.describe Plurimath::Math::Formula do
                     Plurimath::Math::Function::PowerBase.new(
                       Plurimath::Math::Symbol.new("c"),
                       Plurimath::Math::Symbol.new("&#x221e;"),
-                      Plurimath::Math::Number.new("2"),
-                    )
-                  ]),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Number.new("1"),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("&#x3b3;"),
-                  Plurimath::Math::Symbol.new(","),
-                  Plurimath::Math::Formula.new([
+                      Plurimath::Math::Number.new("2")
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Number.new("1"),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Symbol.new("&#x3b3;"),
+                    Plurimath::Math::Symbol.new(","),
                     Plurimath::Math::Symbol.new("."),
                     Plurimath::Math::Number.new("02"),
-                    Plurimath::Math::Symbol.new("in")
-                  ])
-                ])
+                    Plurimath::Math::Symbol.new("i"),
+                    Plurimath::Math::Symbol.new("n"),
+                  ],
+                  { columnalign: "center" }
+                ),
               ]),
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Function::Tilde.new(
-                      Plurimath::Math::Symbol.new("w")
-                    ),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("w"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("c"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new(",")
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Function::Tilde.new(
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
                       Plurimath::Math::Function::Tilde.new(
-                        Plurimath::Math::Symbol.new("&#x3bc;")
-                      )
+                        Plurimath::Math::Symbol.new("w")
+                      ),
+                      Plurimath::Math::Symbol.new("&#x221e;")
                     ),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new("="),
-                  Plurimath::Math::Function::Base.new(
-                    Plurimath::Math::Symbol.new("&#x3bc;"),
-                    Plurimath::Math::Symbol.new("&#x221e;")
-                  ),
-                  Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Formula.new([
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("w"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("c"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Function::Tilde.new(
+                        Plurimath::Math::Function::Tilde.new(
+                          Plurimath::Math::Symbol.new("&#x3bc;")
+                        )
+                      ),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new("="),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("&#x3bc;"),
+                      Plurimath::Math::Symbol.new("&#x221e;")
+                    ),
+                    Plurimath::Math::Symbol.new("/"),
                     Plurimath::Math::Function::Base.new(
                       Plurimath::Math::Symbol.new("&#x3c1;"),
                       Plurimath::Math::Symbol.new("&#x221e;")
@@ -6222,28 +7019,26 @@ RSpec.describe Plurimath::Math::Formula do
                       Plurimath::Math::Symbol.new("c"),
                       Plurimath::Math::Symbol.new("&#x221e;")
                     ),
-                    Plurimath::Math::Symbol.new("L")
-                  ]),
-                  Plurimath::Math::Symbol.new("&#x223c;"),
-                  Plurimath::Math::Symbol.new("O"),
-                  Plurimath::Math::Formula.new([
+                    Plurimath::Math::Symbol.new("L"),
+                    Plurimath::Math::Symbol.new("&#x223c;"),
+                    Plurimath::Math::Symbol.new("O"),
                     Plurimath::Math::Number.new("1"),
                     Plurimath::Math::Symbol.new("/"),
-                    Plurimath::Math::Symbol.new("Re")
-                  ]),
-                  Plurimath::Math::Symbol.new(",")
-                ])
-              ])
+                    Plurimath::Math::Symbol.new("R"),
+                    Plurimath::Math::Symbol.new("e"),
+                    Plurimath::Math::Symbol.new(","),
+                  ],
+                  { columnalign: "center" }
+                ),
+              ]),
             ],
             nil,
-            [
-              Plurimath::Math::Symbol.new("cc")
-            ],
-          )
+            nil,
+            {}
+          ),
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           \\begin{array}{cc}
             \\tilde{u}_{\\infty} = u_{\\infty}/c_{\\infty}, \\quad & \\tilde{\\rho}_{\\infty} = \\rho_{\\infty}/\\rho_{\\infty} = 1, \\\\
@@ -6251,6 +7046,8 @@ RSpec.describe Plurimath::Math::Formula do
             \\tilde{w}_{\\infty} = w_{\\infty}/c_{\\infty}, & \\tilde{\\tilde{\\mu}}_{\\infty} = \\mu_{\\infty} / \\rho_{\\infty} c_{\\infty} L \\sim O1/Re,
           \\end{array}
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -6304,8 +7101,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new(",")
         ])
       }
+      let(:expected_value) { "c_{p}={p-p_{ref}\\over{1\\over2}\\rho_{ref}q_{ref}^{2}}," }
       it "returns formula" do
-        expected_value = "c_{p}={p-p_{ref}\\over{1\\over2}\\rho_{ref}q_{ref}^{2}},"
         expect(formula).to eq(expected_value)
       end
     end
@@ -6355,8 +7152,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new(",")
         ])
       }
+      let(:expected_value) { "\\vec{c}_{f}={\\vec{\\tau}\\over{1\\over2}\\rho_{ref}q_{ref}^{2}}," }
       it "returns formula" do
-        expected_value = "\\vec{c}_{f}={\\vec{\\tau}\\over{1\\over2}\\rho_{ref}q_{ref}^{2}},"
         expect(formula).to eq(expected_value)
       end
     end
@@ -6403,8 +7200,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "{1\\over2}u^{2}+v^{2}+w^{2}={1\\over2}q^{2}" }
       it "returns formula" do
-        expected_value = "{1\\over2}u^{2}+v^{2}+w^{2}={1\\over2}q^{2}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -6464,8 +7261,8 @@ RSpec.describe Plurimath::Math::Formula do
           ])
         ])
       }
+      let(:expected_value) { "T=G:J:\\frac{\\partial\\theta}{\\partialx}-E:\\frac{\\partial^{2}}{\\partialx^{2}}C_{w}:\\frac{\\partial\\theta}{\\partialx}" }
       it "returns formula" do
-        expected_value = "T=G:J:\\frac{\\partial\\theta}{\\partialx}-E:\\frac{\\partial^{2}}{\\partialx^{2}}C_{w}:\\frac{\\partial\\theta}{\\partialx}"
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -6494,8 +7291,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\frac{\\Delta\\theta}{\\DeltaL}=\\frac{T}{J:G}" }
       it "returns formula" do
-        expected_value = "\\frac{\\Delta\\theta}{\\DeltaL}=\\frac{T}{J:G}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -6518,8 +7315,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "V=\\frac{1}{2}:k:d^{2}" }
       it "returns formula" do
-        expected_value = "V=\\frac{1}{2}:k:d^{2}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -6533,39 +7330,42 @@ RSpec.describe Plurimath::Math::Formula do
           ),
           Plurimath::Math::Symbol.new("="),
           Plurimath::Math::Symbol.new("G"),
-          Plurimath::Math::Symbol.new("&#x3a;"),
+          Plurimath::Math::Symbol.new(":"),
           Plurimath::Math::Formula.new([
             Plurimath::Math::Function::Left.new("("),
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("1")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("1")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("1")
-                  ])
-                ])
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("1")],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("cc")
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
       }
+      let(:expected_value) { "D_{s}=G:\\left(\\begin{array}{cc}1&0\\\\0&1\\end{array}\\right)" }
       it "returns formula" do
-        expected_value = "D_{s}=G:\\left(\\begin{array}{cc}1&0\\\\0&1\\end{array}\\right)"
         expect(formula).to eq(expected_value)
       end
     end
@@ -6578,72 +7378,87 @@ RSpec.describe Plurimath::Math::Formula do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("V"),
-                      Plurimath::Math::Symbol.new("x")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("V"),
+                        Plurimath::Math::Symbol.new("x")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("V"),
-                      Plurimath::Math::Symbol.new("y")
-                    )
-                  ])
-                ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("V"),
+                        Plurimath::Math::Symbol.new("y")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c")
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
+            Plurimath::Math::Function::Right.new(")"),
           ]),
           Plurimath::Math::Symbol.new("="),
           Plurimath::Math::Function::Base.new(
             Plurimath::Math::Symbol.new("h"),
             Plurimath::Math::Symbol.new("s")
           ),
-          Plurimath::Math::Symbol.new("&#x3a;"),
+          Plurimath::Math::Symbol.new(":"),
           Plurimath::Math::Function::Base.new(
             Plurimath::Math::Symbol.new("D"),
             Plurimath::Math::Symbol.new("s")
           ),
-          Plurimath::Math::Symbol.new("&#x3a;"),
+          Plurimath::Math::Symbol.new(":"),
           Plurimath::Math::Formula.new([
             Plurimath::Math::Function::Left.new("("),
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("&#x03b5;"),
-                      Plurimath::Math::Symbol.new("xz")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("&#x03b5;"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("x"),
+                          Plurimath::Math::Symbol.new("z"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("&#x03b5;"),
-                      Plurimath::Math::Symbol.new("yz")
-                    )
-                  ])
-                ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("&#x03b5;"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("y"),
+                          Plurimath::Math::Symbol.new("z"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c")
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           \\left(
             \\begin{array}{c}
@@ -6657,6 +7472,8 @@ RSpec.describe Plurimath::Math::Formula do
                                             \\end{array}
                                           \\right)
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -6665,102 +7482,116 @@ RSpec.describe Plurimath::Math::Formula do
       let(:exp) {
         Plurimath::Math::Formula.new([
           Plurimath::Math::Symbol.new("D"),
-          Plurimath::Math::Symbol.new("'"),
+          Plurimath::Math::Unicode.new("&#x27;"),
           Plurimath::Math::Symbol.new("="),
           Plurimath::Math::Formula.new([
             Plurimath::Math::Function::Left.new("("),
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("h"),
-                      Plurimath::Math::Symbol.new("m")
-                    ),
-                    Plurimath::Math::Symbol.new("&#x2c;"),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("D"),
-                      Plurimath::Math::Symbol.new("mm")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("h"),
-                      Plurimath::Math::Symbol.new("b")
-                    ),
-                    Plurimath::Math::Symbol.new("&#x2c;"),
-                    Plurimath::Math::Symbol.new("p"),
-                    Plurimath::Math::Symbol.new("&#x2c;"),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("D"),
-                      Plurimath::Math::Symbol.new("mc")
-                    )
-                  ])
-                ]),
-                Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Number.new("2"),
-                      Plurimath::Math::Symbol.new("mm")
-                    ]),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("h"),
-                      Plurimath::Math::Symbol.new("b")
-                    ),
-                    Plurimath::Math::Symbol.new("&#x2c;"),
-                    Plurimath::Math::Symbol.new("p"),
-                    Plurimath::Math::Symbol.new("&#x2c;"),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("D"),
-                      Plurimath::Math::Symbol.new("mc")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::FontStyle.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Function::Frac.new(
-                            Plurimath::Math::Number.new("1"),
-                            Plurimath::Math::Number.new("12")
-                          ),
-                          Plurimath::Math::Function::PowerBase.new(
-                            Plurimath::Math::Symbol.new("h"),
-                            Plurimath::Math::Symbol.new("b"),
-                            Plurimath::Math::Number.new("3"),
-                          ),
-                          Plurimath::Math::Symbol.new("+"),
-                          Plurimath::Math::Function::Base.new(
-                            Plurimath::Math::Symbol.new("h"),
-                            Plurimath::Math::Symbol.new("b")
-                          ),
-                          Plurimath::Math::Symbol.new("&#x2c;"),
-                          Plurimath::Math::Function::Power.new(
-                            Plurimath::Math::Symbol.new("p"),
-                            Plurimath::Math::Number.new("2")
-                          )
-                        ]),
-                        "displaystyle"
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("h"),
+                        Plurimath::Math::Symbol.new("m")
                       ),
-                      Plurimath::Math::Symbol.new("&#x2c;"),
+                      Plurimath::Math::Symbol.new(","),
                       Plurimath::Math::Function::Base.new(
                         Plurimath::Math::Symbol.new("D"),
-                        Plurimath::Math::Symbol.new("mb")
-                      )
-                    ])
-                  ])
-                ])
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("h"),
+                        Plurimath::Math::Symbol.new("b")
+                      ),
+                      Plurimath::Math::Symbol.new(","),
+                      Plurimath::Math::Symbol.new("p"),
+                      Plurimath::Math::Symbol.new(","),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("D"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("c"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
+                Plurimath::Math::Function::Tr.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Number.new("2"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("h"),
+                        Plurimath::Math::Symbol.new("b")
+                      ),
+                      Plurimath::Math::Symbol.new(","),
+                      Plurimath::Math::Symbol.new("p"),
+                      Plurimath::Math::Symbol.new(","),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("D"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("c"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Frac.new(
+                        Plurimath::Math::Number.new("1"),
+                        Plurimath::Math::Number.new("12")
+                      ),
+                      Plurimath::Math::Function::PowerBase.new(
+                        Plurimath::Math::Symbol.new("h"),
+                        Plurimath::Math::Symbol.new("b"),
+                        Plurimath::Math::Number.new("3")
+                      ),
+                      Plurimath::Math::Symbol.new("+"),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("h"),
+                        Plurimath::Math::Symbol.new("b")
+                      ),
+                      Plurimath::Math::Symbol.new(","),
+                      Plurimath::Math::Function::Power.new(
+                        Plurimath::Math::Symbol.new("p"),
+                        Plurimath::Math::Number.new("2")
+                      ),
+                      Plurimath::Math::Symbol.new(","),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("D"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("b"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("cc")
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           D' =  \\left(
                   \\begin{array} {cc}
@@ -6771,6 +7602,8 @@ RSpec.describe Plurimath::Math::Formula do
                   \\end{array}
                 \\right)
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -6791,77 +7624,85 @@ RSpec.describe Plurimath::Math::Formula do
               Plurimath::Math::Function::Power.new(
                 Plurimath::Math::Symbol.new("&#x3bd;"),
                 Plurimath::Math::Number.new("2")
-              )
+              ),
             ])
           ),
-          Plurimath::Math::Symbol.new("&#x3a;"),
+          Plurimath::Math::Symbol.new(":"),
           Plurimath::Math::Formula.new([
             Plurimath::Math::Function::Left.new("("),
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("1")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("&#x3bd;")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("1")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Symbol.new("&#x3bd;")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Number.new("2"),
-                      Plurimath::Math::Symbol.new("mm")
-                    ]),
-                    Plurimath::Math::Symbol.new("&#x3bd;")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("1")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ])
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("&#x3bd;"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("1")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Number.new("2"),
-                      Plurimath::Math::Symbol.new("mm")
-                    ]),
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Number.new("0")
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Number.new("0"),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [Plurimath::Math::Number.new("0")],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Formula.new([
                           Plurimath::Math::Number.new("1"),
                           Plurimath::Math::Symbol.new("-"),
-                          Plurimath::Math::Symbol.new("&#x3bd;")
+                          Plurimath::Math::Symbol.new("&#x3bd;"),
                         ]),
                         Plurimath::Math::Number.new("2")
                       ),
-                      "displaystyle"
-                    )
-                  ])
-                ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("ccc")
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           D_{m} = \\frac{E}{1 - \\nu^{2}} :
           \\left(
@@ -6878,6 +7719,8 @@ RSpec.describe Plurimath::Math::Formula do
             \\end{array}
           \\right)
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -6886,89 +7729,91 @@ RSpec.describe Plurimath::Math::Formula do
       let(:exp) {
         Plurimath::Math::Formula.new([
           Plurimath::Math::Symbol.new("D"),
-          Plurimath::Math::Symbol.new("'"),
+          Plurimath::Math::Unicode.new("&#x27;"),
           Plurimath::Math::Symbol.new("="),
           Plurimath::Math::Formula.new([
             Plurimath::Math::Function::Left.new("("),
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("h"),
-                    Plurimath::Math::Symbol.new("&#x2c;"),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("D"),
-                      Plurimath::Math::Symbol.new("m")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Symbol.new("h"),
-                    Plurimath::Math::Symbol.new("&#x2c;"),
-                    Plurimath::Math::Symbol.new("p"),
-                    Plurimath::Math::Symbol.new("&#x2c;"),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("D"),
-                      Plurimath::Math::Symbol.new("m")
-                    )
-                  ])
-                ]),
-                Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Number.new("2"),
-                      Plurimath::Math::Symbol.new("mm")
-                    ]),
-                    Plurimath::Math::Symbol.new("h"),
-                    Plurimath::Math::Symbol.new("&#x2c;"),
-                    Plurimath::Math::Symbol.new("p"),
-                    Plurimath::Math::Symbol.new("&#x2c;"),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("D"),
-                      Plurimath::Math::Symbol.new("m")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::FontStyle.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Function::Frac.new(
-                            Plurimath::Math::Number.new("1"),
-                            Plurimath::Math::Number.new("12")
-                          ),
-                          Plurimath::Math::Function::Power.new(
-                            Plurimath::Math::Symbol.new("h"),
-                            Plurimath::Math::Number.new("3")
-                          ),
-                          Plurimath::Math::Symbol.new("+"),
-                          Plurimath::Math::Symbol.new("h"),
-                          Plurimath::Math::Symbol.new("&#x2c;"),
-                          Plurimath::Math::Function::Power.new(
-                            Plurimath::Math::Symbol.new("p"),
-                            Plurimath::Math::Number.new("2")
-                          )
-                        ]),
-                        "displaystyle"
-                      ),
-                      Plurimath::Math::Symbol.new("&#x2c;"),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("h"),
+                      Plurimath::Math::Symbol.new(","),
                       Plurimath::Math::Function::Base.new(
                         Plurimath::Math::Symbol.new("D"),
                         Plurimath::Math::Symbol.new("m")
-                      )
-                    ])
-                  ])
-                ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("h"),
+                      Plurimath::Math::Symbol.new(","),
+                      Plurimath::Math::Symbol.new("p"),
+                      Plurimath::Math::Symbol.new(","),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("D"),
+                        Plurimath::Math::Symbol.new("m")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
+                Plurimath::Math::Function::Tr.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Number.new("2"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("h"),
+                      Plurimath::Math::Symbol.new(","),
+                      Plurimath::Math::Symbol.new("p"),
+                      Plurimath::Math::Symbol.new(","),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("D"),
+                        Plurimath::Math::Symbol.new("m")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Frac.new(
+                        Plurimath::Math::Number.new("1"),
+                        Plurimath::Math::Number.new("12")
+                      ),
+                      Plurimath::Math::Function::Power.new(
+                        Plurimath::Math::Symbol.new("h"),
+                        Plurimath::Math::Number.new("3")
+                      ),
+                      Plurimath::Math::Symbol.new("+"),
+                      Plurimath::Math::Symbol.new("h"),
+                      Plurimath::Math::Symbol.new(","),
+                      Plurimath::Math::Function::Power.new(
+                        Plurimath::Math::Symbol.new("p"),
+                        Plurimath::Math::Number.new("2")
+                      ),
+                      Plurimath::Math::Symbol.new(","),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("D"),
+                        Plurimath::Math::Symbol.new("m")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("cc")
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           D' =  \\left(
                   \\begin{array}{cc}
@@ -6979,6 +7824,8 @@ RSpec.describe Plurimath::Math::Formula do
                   \\end{array}
                 \\right)
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -6991,65 +7838,99 @@ RSpec.describe Plurimath::Math::Formula do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("&#x03b5;"),
-                      Plurimath::Math::Symbol.new("xx")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("&#x03b5;"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("x"),
+                          Plurimath::Math::Symbol.new("x"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("&#x03b5;"),
-                      Plurimath::Math::Symbol.new("yy")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("&#x03b5;"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("y"),
+                          Plurimath::Math::Symbol.new("y"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("&#x3b3;"),
-                      Plurimath::Math::Symbol.new("xy")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("&#x3b3;"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("x"),
+                          Plurimath::Math::Symbol.new("y"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("&#x3c7;"),
-                      Plurimath::Math::Symbol.new("xx")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("&#x3c7;"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("x"),
+                          Plurimath::Math::Symbol.new("x"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("&#x3c7;"),
-                      Plurimath::Math::Symbol.new("yy")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("&#x3c7;"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("y"),
+                          Plurimath::Math::Symbol.new("y"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("&#x3c4;"),
-                      Plurimath::Math::Symbol.new("xy")
-                    )
-                  ])
-                ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("&#x3c4;"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("x"),
+                          Plurimath::Math::Symbol.new("y"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c")
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           \\left(
             \\begin{array}{c}
@@ -7062,6 +7943,8 @@ RSpec.describe Plurimath::Math::Formula do
             \\end{array}
           \\right)
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -7074,65 +7957,100 @@ RSpec.describe Plurimath::Math::Formula do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("N"),
-                      Plurimath::Math::Symbol.new("yy")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("N"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("y"),
+                          Plurimath::Math::Symbol.new("y"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("N"),
-                      Plurimath::Math::Symbol.new("xx")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("N"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("x"),
+                          Plurimath::Math::Symbol.new("x"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("N"),
-                      Plurimath::Math::Symbol.new("xy")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("N"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("x"),
+                          Plurimath::Math::Symbol.new("y"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("M"),
-                      Plurimath::Math::Symbol.new("xx")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("M"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("x"),
+                          Plurimath::Math::Symbol.new("x"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("M"),
-                      Plurimath::Math::Symbol.new("yy")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("M"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("y"),
+                          Plurimath::Math::Symbol.new("y"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("M"),
-                      Plurimath::Math::Symbol.new("xy")
-                    )
-                  ])
-                ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("M"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("x"),
+                          Plurimath::Math::Symbol.new("y"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c")
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
       }
+      let(:expected_value) { "\\left(\\begin{array}{c}N_{yy}\\\\N_{xx}\\\\N_{xy}\\\\M_{xx}\\\\M_{yy}\\\\M_{xy}\\end{array}\\right)" }
       it "returns formula" do
-        expected_value = "\\left(\\begin{array}{c}N_{yy}\\\\N_{xx}\\\\N_{xy}\\\\M_{xx}\\\\M_{yy}\\\\M_{xy}\\end{array}\\right)"
         expect(formula).to eq(expected_value)
       end
     end
@@ -7150,8 +8068,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("'")
         ])
       }
+      let(:expected_value) { "\\sigma'=D':\\varepsilon'" }
       it "returns formula" do
-        expected_value = "\\sigma'=D':\\varepsilon'"
         expect(formula).to eq(expected_value)
       end
     end
@@ -7171,8 +8089,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\varepsilon'=B':u" }
       it "returns formula" do
-        expected_value = "\\varepsilon'=B':u"
         expect(formula).to eq(expected_value)
       end
     end
@@ -7224,8 +8142,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "V=\\frac{1}{2}:u^{t}:\\int_{surface}:B'^{t}:D':B':ds;u" }
       it "returns formula" do
-        expected_value = "V=\\frac{1}{2}:u^{t}:\\int_{surface}:B'^{t}:D':B':ds;u"
         expect(formula).to eq(expected_value)
       end
     end
@@ -7240,8 +8158,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("&#x03b5;")
         ])
       }
+      let(:expected_value) { "\\sigma=D:\\varepsilon" }
       it "returns formula" do
-        expected_value = "\\sigma=D:\\varepsilon"
         expect(formula).to eq(expected_value)
       end
     end
@@ -7259,8 +8177,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\varepsilon=B:u" }
       it "returns formula" do
-        expected_value = "\\varepsilon=B:u"
         expect(formula).to eq(expected_value)
       end
     end
@@ -7314,8 +8232,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "V=\\frac{1}{2}:u^{t}:\\int_{surface}:\\int_{thickness}:B^{t}:D:B:dt:ds;u" }
       it "returns formula" do
-        expected_value = "V=\\frac{1}{2}:u^{t}:\\int_{surface}:\\int_{thickness}:B^{t}:D:B:dt:ds;u"
         expect(formula).to eq(expected_value)
       end
     end
@@ -7328,81 +8246,74 @@ RSpec.describe Plurimath::Math::Formula do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::FontStyle.new(
-                        Plurimath::Math::Function::Frac.new(
-                          Plurimath::Math::Formula.new([
-                            Plurimath::Math::Symbol.new("&#x2202;"),
-                            Plurimath::Math::Symbol.new("w")
-                          ]),
-                          Plurimath::Math::Formula.new([
-                            Plurimath::Math::Symbol.new("&#x2202;"),
-                            Plurimath::Math::Symbol.new("x")
-                          ])
-                        ),
-                        "displaystyle"
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Frac.new(
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("&#x2202;"),
+                          Plurimath::Math::Symbol.new("w"),
+                        ]),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("&#x2202;"),
+                          Plurimath::Math::Symbol.new("x"),
+                        ])
                       ),
                       Plurimath::Math::Symbol.new("+"),
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Formula.new([
                           Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("u")
+                          Plurimath::Math::Symbol.new("u"),
                         ]),
                         Plurimath::Math::Formula.new([
                           Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("z")
+                          Plurimath::Math::Symbol.new("z"),
                         ])
-                      )
-                    ])
-                  ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("mm")
-                    ]),
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::FontStyle.new(
-                        Plurimath::Math::Function::Frac.new(
-                          Plurimath::Math::Formula.new([
-                            Plurimath::Math::Symbol.new("&#x2202;"),
-                            Plurimath::Math::Symbol.new("w")
-                          ]),
-                          Plurimath::Math::Formula.new([
-                            Plurimath::Math::Symbol.new("&#x2202;"),
-                            Plurimath::Math::Symbol.new("y")
-                          ])
-                        ),
-                        "displaystyle"
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Function::Frac.new(
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("&#x2202;"),
+                          Plurimath::Math::Symbol.new("w"),
+                        ]),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("&#x2202;"),
+                          Plurimath::Math::Symbol.new("y"),
+                        ])
                       ),
                       Plurimath::Math::Symbol.new("+"),
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Formula.new([
                           Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("v")
+                          Plurimath::Math::Symbol.new("v"),
                         ]),
                         Plurimath::Math::Formula.new([
                           Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("z")
+                          Plurimath::Math::Symbol.new("z"),
                         ])
-                      )
-                    ])
-                  ])
-                ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c")
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           \\left(
             \\begin{array}{c}
@@ -7411,6 +8322,8 @@ RSpec.describe Plurimath::Math::Formula do
             \\end{array}
           \\right)
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -7444,8 +8357,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\DeltaF_{i}=\\sum_{j=1}^{2}s_{ij}:\\Delta\\varepsilon_{j}" }
       it "returns formula" do
-        expected_value = "\\DeltaF_{i}=\\sum_{j=1}^{2}s_{ij}:\\Delta\\varepsilon_{j}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -7487,8 +8400,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\DeltaN_{ij}=\\sum_{k=1}^{2}\\sum_{l=1}^{2}d_{ijkl}:\\Deltac_{kl}" }
       it "returns formula" do
-        expected_value = "\\DeltaN_{ij}=\\sum_{k=1}^{2}\\sum_{l=1}^{2}d_{ijkl}:\\Deltac_{kl}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -7501,119 +8414,114 @@ RSpec.describe Plurimath::Math::Formula do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::FontStyle.new(
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
                         Plurimath::Math::Symbol.new("-"),
-                        "displaystyle"
-                      ),
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Function::Power.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Function::Power.new(
+                              Plurimath::Math::Symbol.new("&#x2202;"),
+                              Plurimath::Math::Number.new("2")
+                            ),
+                            Plurimath::Math::Symbol.new("w"),
+                          ]),
+                          Plurimath::Math::Formula.new([
                             Plurimath::Math::Symbol.new("&#x2202;"),
-                            Plurimath::Math::Number.new("2")
-                          ),
-                          Plurimath::Math::Symbol.new("w")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Function::Power.new(
+                            Plurimath::Math::Function::Power.new(
+                              Plurimath::Math::Symbol.new("x"),
+                              Plurimath::Math::Number.new("2")
+                            ),
+                          ])
+                        ),
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("-"),
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Function::Power.new(
+                              Plurimath::Math::Symbol.new("&#x2202;"),
+                              Plurimath::Math::Number.new("2")
+                            ),
+                            Plurimath::Math::Symbol.new("w"),
+                          ]),
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("&#x2202;"),
                             Plurimath::Math::Symbol.new("x"),
-                            Plurimath::Math::Number.new("2")
-                          )
-                        ])
-                      )
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::FontStyle.new(
-                        Plurimath::Math::Symbol.new("-"),
-                        "displaystyle"
-                      ),
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Function::Power.new(
                             Plurimath::Math::Symbol.new("&#x2202;"),
-                            Plurimath::Math::Number.new("2")
-                          ),
-                          Plurimath::Math::Symbol.new("w")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("x"),
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("y")
-                        ])
-                      )
-                    ])
-                  ])
+                            Plurimath::Math::Symbol.new("y"),
+                          ])
+                        ),
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("mm")
-                    ]),
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::FontStyle.new(
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Formula.new([
                         Plurimath::Math::Symbol.new("-"),
-                        "displaystyle"
-                      ),
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Function::Power.new(
+                              Plurimath::Math::Symbol.new("&#x2202;"),
+                              Plurimath::Math::Number.new("2")
+                            ),
+                            Plurimath::Math::Symbol.new("w"),
+                          ]),
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("&#x2202;"),
+                            Plurimath::Math::Symbol.new("x"),
+                            Plurimath::Math::Symbol.new("&#x2202;"),
+                            Plurimath::Math::Symbol.new("y"),
+                          ])
+                        ),
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("-"),
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Formula.new([
                           Plurimath::Math::Function::Power.new(
                             Plurimath::Math::Symbol.new("&#x2202;"),
                             Plurimath::Math::Number.new("2")
                           ),
-                          Plurimath::Math::Symbol.new("w")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("x"),
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("y")
-                        ])
-                      )
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::FontStyle.new(
-                        Plurimath::Math::Symbol.new("-"),
-                        "displaystyle"
-                      ),
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Function::Power.new(
-                            Plurimath::Math::Symbol.new("&#x2202;"),
-                            Plurimath::Math::Number.new("2")
-                          ),
-                          Plurimath::Math::Symbol.new("w")
+                          Plurimath::Math::Symbol.new("w"),
                         ]),
                         Plurimath::Math::Formula.new([
                           Plurimath::Math::Symbol.new("&#x2202;"),
                           Plurimath::Math::Function::Power.new(
                             Plurimath::Math::Symbol.new("y"),
                             Plurimath::Math::Number.new("2")
-                          )
+                          ),
                         ])
-                      )
-                    ])
-                  ])
-                ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("cc")
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           \\left(
             \\begin{array}{cc}
@@ -7624,6 +8532,8 @@ RSpec.describe Plurimath::Math::Formula do
             \\end{array}
           \\right)
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -7665,8 +8575,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\DeltaD_{ij}=\\sum_{k=1}^{2}\\sum_{l=1}^{2}d_{ijkl}:\\Deltac_{kl}" }
       it "returns formula" do
-        expected_value = "\\DeltaD_{ij}=\\sum_{k=1}^{2}\\sum_{l=1}^{2}d_{ijkl}:\\Deltac_{kl}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -7681,85 +8591,82 @@ RSpec.describe Plurimath::Math::Formula do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Formula.new([
                           Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("u")
+                          Plurimath::Math::Symbol.new("u"),
                         ]),
                         Plurimath::Math::Formula.new([
                           Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("x")
+                          Plurimath::Math::Symbol.new("x"),
                         ])
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Formula.new([
                           Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("v")
+                          Plurimath::Math::Symbol.new("v"),
                         ]),
                         Plurimath::Math::Formula.new([
                           Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("x")
+                          Plurimath::Math::Symbol.new("x"),
                         ])
                       ),
-                      "displaystyle"
-                    )
-                  ])
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("mm")
-                    ]),
-                    Plurimath::Math::Function::FontStyle.new(
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Formula.new([
                           Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("u")
+                          Plurimath::Math::Symbol.new("u"),
                         ]),
                         Plurimath::Math::Formula.new([
                           Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("y")
+                          Plurimath::Math::Symbol.new("y"),
                         ])
                       ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Formula.new([
                           Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("v")
+                          Plurimath::Math::Symbol.new("v"),
                         ]),
                         Plurimath::Math::Formula.new([
                           Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("y")
+                          Plurimath::Math::Symbol.new("y"),
                         ])
                       ),
-                      "displaystyle"
-                    )
-                  ])
-                ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("cc")
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           J = \\left(
                 \\begin{array}{cc}
@@ -7770,6 +8677,8 @@ RSpec.describe Plurimath::Math::Formula do
                 \\end{array}
               \\right)
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -7793,8 +8702,8 @@ RSpec.describe Plurimath::Math::Formula do
           ])
         ])
       }
+      let(:expected_value) { "\\varepsilon=\\frac{1}{2}J+J^{t}" }
       it "returns formula" do
-        expected_value = "\\varepsilon=\\frac{1}{2}J+J^{t}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -7836,8 +8745,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\DeltaN_{ij}=\\sum_{k=1}^{2}\\sum_{l=1}^{2}d_{ijkl}:\\Delta\\varepsilon_{kl}" }
       it "returns formula" do
-        expected_value = "\\DeltaN_{ij}=\\sum_{k=1}^{2}\\sum_{l=1}^{2}d_{ijkl}:\\Delta\\varepsilon_{kl}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -7861,8 +8770,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("M")
         ])
       }
+      let(:expected_value) { "\\Delta\\varepsilon_{ij}=\\beta_{ij}M:\\DeltaM" }
       it "returns formula" do
-        expected_value = "\\Delta\\varepsilon_{ij}=\\beta_{ij}M:\\DeltaM"
         expect(formula).to eq(expected_value)
       end
     end
@@ -7892,8 +8801,8 @@ RSpec.describe Plurimath::Math::Formula do
           ])
         ])
       }
+      let(:expected_value) { "\\varepsilon_{ij}=\\alpha_{ij}:T:-:T_{o}" }
       it "returns formula" do
-        expected_value = "\\varepsilon_{ij}=\\alpha_{ij}:T:-:T_{o}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -7917,8 +8826,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("T")
         ])
       }
+      let(:expected_value) { "\\Delta\\varepsilon_{ij}=\\alpha_{ij}T:\\DeltaT" }
       it "returns formula" do
-        expected_value = "\\Delta\\varepsilon_{ij}=\\alpha_{ij}T:\\DeltaT"
         expect(formula).to eq(expected_value)
       end
     end
@@ -7960,8 +8869,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\Delta\\sigma_{ij}=\\sum_{k=1}^{3}\\sum_{l=1}^{3}d_{ijkl}:\\Delta\\varepsilon_{kl}" }
       it "returns formula" do
-        expected_value = "\\Delta\\sigma_{ij}=\\sum_{k=1}^{3}\\sum_{l=1}^{3}d_{ijkl}:\\Delta\\varepsilon_{kl}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -8001,8 +8910,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "Q_{i}^{s}=\\sum_{j=1}^{m}:s_{ji}:w_{j}^{s}:q_{ji}" }
       it "returns formula" do
-        expected_value = "Q_{i}^{s}=\\sum_{j=1}^{m}:s_{ji}:w_{j}^{s}:q_{ji}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -8039,8 +8948,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "Q=\\sum_{i=1}^{n}:j_{i}:w_{i}^{f}:Q_{i}^{s}" }
       it "returns formula" do
-        expected_value = "Q=\\sum_{i=1}^{n}:j_{i}:w_{i}^{f}:Q_{i}^{s}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -8075,8 +8984,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "Q_{i}^{s}=\\sum_{j=1}^{m}:w_{j}^{s}:q_{ji}" }
       it "returns formula" do
-        expected_value = "Q_{i}^{s}=\\sum_{j=1}^{m}:w_{j}^{s}:q_{ji}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -8111,8 +9020,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "Q=\\sum_{i=1}^{n}:s_{i}:w_{i}:q_{i}" }
       it "returns formula" do
-        expected_value = "Q=\\sum_{i=1}^{n}:s_{i}:w_{i}:q_{i}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -8152,8 +9061,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "Q=\\sum_{i=1}^{n}:s_{i}:j_{i}:w_{i}:q_{i}" }
       it "returns formula" do
-        expected_value = "Q=\\sum_{i=1}^{n}:s_{i}:j_{i}:w_{i}:q_{i}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -8188,8 +9097,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "Q=\\sum_{i=1}^{n}:j_{i}:w_{i}:q_{i}" }
       it "returns formula" do
-        expected_value = "Q=\\sum_{i=1}^{n}:j_{i}:w_{i}:q_{i}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -8227,8 +9136,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("|")
         ])
       }
+      let(:expected_value) { "y\\cdotd>tolerance,|y|,|d|" }
       it "returns formula" do
-        expected_value = "y\\cdotd>tolerance,|y|,|d|"
         expect(formula).to eq(expected_value)
       end
     end
@@ -8254,8 +9163,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("&#x27e9;")
         ])
       }
+      let(:expected_value) { "z=\\langlex\\timesd\\rangle" }
       it "returns formula" do
-        expected_value = "z=\\langlex\\timesd\\rangle"
         expect(formula).to eq(expected_value)
       end
     end
@@ -8293,8 +9202,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("|")
         ])
       }
+      let(:expected_value) { "x\\cdotX>tolerance,|x|,|X|" }
       it "returns formula" do
-        expected_value = "x\\cdotX>tolerance,|x|,|X|"
         expect(formula).to eq(expected_value)
       end
     end
@@ -8311,8 +9220,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new(">")
         ])
       }
+      let(:expected_value) { "z=<<xxxY>>" }
       it "returns formula" do
-        expected_value = "z=<<xxxY>>"
         expect(formula).to eq(expected_value)
       end
     end
@@ -8327,8 +9236,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Number.new("0")
         ])
       }
+      let(:expected_value) { "x*X>0" }
       it "returns formula" do
-        expected_value = "x*X>0"
         expect(formula).to eq(expected_value)
       end
     end
@@ -8343,8 +9252,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Number.new("0")
         ])
       }
+      let(:expected_value) { "x*X>0" }
       it "returns formula" do
-        expected_value = "x*X>0"
         expect(formula).to eq(expected_value)
       end
     end
@@ -8359,8 +9268,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Number.new("0")
         ])
       }
+      let(:expected_value) { "x*X>0" }
       it "returns formula" do
-        expected_value = "x*X>0"
         expect(formula).to eq(expected_value)
       end
     end
@@ -8381,8 +9290,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("|")
         ])
       }
+      let(:expected_value) { "d*x>\"tolerance\"|d||x|" }
       it "returns formula" do
-        expected_value = "d*x>\"tolerance\"|d||x|"
         expect(formula).to eq(expected_value)
       end
     end
@@ -8397,8 +9306,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Number.new("0")
         ])
       }
+      let(:expected_value) { "z*d>0" }
       it "returns formula" do
-        expected_value = "z*d>0"
         expect(formula).to eq(expected_value)
       end
     end
@@ -8419,8 +9328,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("|")
         ])
       }
+      let(:expected_value) { "z*Z>\"tolerance\"|z||Z|" }
       it "returns formula" do
-        expected_value = "z*Z>\"tolerance\"|z||Z|"
         expect(formula).to eq(expected_value)
       end
     end
@@ -8437,8 +9346,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new(">")
         ])
       }
+      let(:expected_value) { "y=<<zxxX>>" }
       it "returns formula" do
-        expected_value = "y=<<zxxX>>"
         expect(formula).to eq(expected_value)
       end
     end
@@ -8453,8 +9362,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Number.new("0")
         ])
       }
+      let(:expected_value) { "z*Z>0" }
       it "returns formula" do
-        expected_value = "z*Z>0"
         expect(formula).to eq(expected_value)
       end
     end
@@ -8483,8 +9392,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("&#x27e9;")
         ])
       }
+      let(:expected_value) { "x^{\\prime}=\\langle\\eta\\times\\zeta\\rangle" }
       it "returns formula" do
-        expected_value = "x^{\\prime}=\\langle\\eta\\times\\zeta\\rangle"
         expect(formula).to eq(expected_value)
       end
     end
@@ -8506,8 +9415,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "z^{\\prime}=\\zeta" }
       it "returns formula" do
-        expected_value = "z^{\\prime}=\\zeta"
         expect(formula).to eq(expected_value)
       end
     end
@@ -8536,8 +9445,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("&#x27e9;")
         ])
       }
+      let(:expected_value) { "z^{\\prime}=\\langle\\xi\\times\\eta\\rangle" }
       it "returns formula" do
-        expected_value = "z^{\\prime}=\\langle\\xi\\times\\eta\\rangle"
         expect(formula).to eq(expected_value)
       end
     end
@@ -8559,8 +9468,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "y^{\\prime}=\\eta" }
       it "returns formula" do
-        expected_value = "y^{\\prime}=\\eta"
         expect(formula).to eq(expected_value)
       end
     end
@@ -8589,8 +9498,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("&#x27e9;")
         ])
       }
+      let(:expected_value) { "y^{\\prime}=\\langle\\zeta\\times\\xi\\rangle" }
       it "returns formula" do
-        expected_value = "y^{\\prime}=\\langle\\zeta\\times\\xi\\rangle"
         expect(formula).to eq(expected_value)
       end
     end
@@ -8612,8 +9521,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "x^{\\prime}=\\xi" }
       it "returns formula" do
-        expected_value = "x^{\\prime}=\\xi"
         expect(formula).to eq(expected_value)
       end
     end
@@ -8624,207 +9533,479 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Function::Table::Array.new(
             [
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Formula.new([
-                    Plurimath::Math::Function::Left.new("("),
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Formula.new([
+                      Plurimath::Math::Function::Left.new("("),
+                      Plurimath::Math::Function::Table::Array.new(
+                        [
+                          Plurimath::Math::Function::Tr.new([
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                          ]),
+                          Plurimath::Math::Function::Tr.new([
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new(
+                              [
+                                Plurimath::Math::Symbol.new("+"),
+                                Plurimath::Math::Symbol.new("k"),
+                              ],
+                              { columnalign: "center" }
+                            ),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new(
+                              [
+                                Plurimath::Math::Formula.new([
+                                  Plurimath::Math::Symbol.new("-"),
+                                  Plurimath::Math::Symbol.new("k"),
+                                ]),
+                              ],
+                              { columnalign: "center" }
+                            ),
+                          ]),
+                          Plurimath::Math::Function::Tr.new([
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                          ]),
+                          Plurimath::Math::Function::Tr.new([
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                          ]),
+                          Plurimath::Math::Function::Tr.new([
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                          ]),
+                          Plurimath::Math::Function::Tr.new([
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new(
+                              [
+                                Plurimath::Math::Formula.new([
+                                  Plurimath::Math::Symbol.new("-"),
+                                  Plurimath::Math::Symbol.new("k"),
+                                ]),
+                              ],
+                              { columnalign: "center" }
+                            ),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new([], {
+                              columnalign: "center",
+                            }),
+                            Plurimath::Math::Function::Td.new(
+                              [
+                                Plurimath::Math::Symbol.new("+"),
+                                Plurimath::Math::Symbol.new("k"),
+                              ],
+                              { columnalign: "center" }
+                            ),
+                          ]),
+                        ],
+                        nil,
+                        nil,
+                        {}
+                      ),
+                      Plurimath::Math::Function::Right.new(")"),
+                    ]),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new(
+                  [
                     Plurimath::Math::Function::Table::Array.new(
                       [
                         Plurimath::Math::Function::Tr.new([
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([])
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
                         ]),
                         Plurimath::Math::Function::Tr.new([
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([
-                            Plurimath::Math::Symbol.new("+"),
-                            Plurimath::Math::Symbol.new("k")
-                          ]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([
-                            Plurimath::Math::Symbol.new("-"),
-                            Plurimath::Math::Symbol.new("k")
-                          ])
+                          Plurimath::Math::Function::Td.new(
+                            [Plurimath::Math::Symbol.new("&#x22ef;")],
+                            { columnalign: "center" }
+                          ),
+                          Plurimath::Math::Function::Td.new(
+                            [
+                              Plurimath::Math::Function::Mbox.new(
+                                Plurimath::Math::Formula.new([
+                                  Plurimath::Math::Symbol.new("d"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("g"),
+                                  Plurimath::Math::Symbol.new("r"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("o"),
+                                  Plurimath::Math::Symbol.new("f"),
+                                  Plurimath::Math::Symbol.new("f"),
+                                  Plurimath::Math::Symbol.new("r"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("d"),
+                                  Plurimath::Math::Symbol.new("o"),
+                                  Plurimath::Math::Symbol.new("m"),
+                                  Plurimath::Math::Number.new("1"),
+                                  Plurimath::Math::Symbol.new(","),
+                                  Plurimath::Math::Symbol.new("n"),
+                                  Plurimath::Math::Symbol.new("o"),
+                                  Plurimath::Math::Symbol.new("d"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Number.new("1"),
+                                ])
+                              ),
+                            ],
+                            { columnalign: "center" }
+                          ),
                         ]),
                         Plurimath::Math::Function::Tr.new([
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([])
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
                         ]),
                         Plurimath::Math::Function::Tr.new([
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([])
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
                         ]),
                         Plurimath::Math::Function::Tr.new([
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([])
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
                         ]),
                         Plurimath::Math::Function::Tr.new([
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([
-                            Plurimath::Math::Symbol.new("-"),
-                            Plurimath::Math::Symbol.new("k")
-                          ]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([]),
-                          Plurimath::Math::Function::Td.new([
-                            Plurimath::Math::Symbol.new("+"),
-                            Plurimath::Math::Symbol.new("k")
-                          ])
-                        ])
+                          Plurimath::Math::Function::Td.new(
+                            [Plurimath::Math::Symbol.new("&#x22ef;")],
+                            { columnalign: "center" }
+                          ),
+                          Plurimath::Math::Function::Td.new(
+                            [
+                              Plurimath::Math::Function::Mbox.new(
+                                Plurimath::Math::Formula.new([
+                                  Plurimath::Math::Symbol.new("d"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("g"),
+                                  Plurimath::Math::Symbol.new("r"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("o"),
+                                  Plurimath::Math::Symbol.new("f"),
+                                  Plurimath::Math::Symbol.new("f"),
+                                  Plurimath::Math::Symbol.new("r"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("d"),
+                                  Plurimath::Math::Symbol.new("o"),
+                                  Plurimath::Math::Symbol.new("m"),
+                                  Plurimath::Math::Number.new("2"),
+                                  Plurimath::Math::Symbol.new(","),
+                                  Plurimath::Math::Symbol.new("n"),
+                                  Plurimath::Math::Symbol.new("o"),
+                                  Plurimath::Math::Symbol.new("d"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Number.new("2"),
+                                ])
+                              ),
+                            ],
+                            { columnalign: "center" }
+                          ),
+                        ]),
                       ],
                       nil,
-                      [
-                        Plurimath::Math::Symbol.new("ccccccc")
-                      ],
+                      nil,
+                      {}
                     ),
-                    Plurimath::Math::Function::Right.new(")")
-                  ])
-                ]),
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Table::Array.new(
-                    [
-                      Plurimath::Math::Function::Tr.new([
-                        Plurimath::Math::Function::Td.new([]),
-                        Plurimath::Math::Function::Td.new([])
-                      ]),
-                      Plurimath::Math::Function::Tr.new([
-                        Plurimath::Math::Function::Td.new([
-                          Plurimath::Math::Symbol.new("&#x22ef;")
-                        ]),
-                        Plurimath::Math::Function::Td.new([
-                          Plurimath::Math::Symbol.new("\\mbox{degreeoffreedom1,node1}")
-                        ])
-                      ]),
-                      Plurimath::Math::Function::Tr.new([
-                        Plurimath::Math::Function::Td.new([]),
-                        Plurimath::Math::Function::Td.new([])
-                      ]),
-                      Plurimath::Math::Function::Tr.new([
-                        Plurimath::Math::Function::Td.new([]),
-                        Plurimath::Math::Function::Td.new([])
-                      ]),
-                      Plurimath::Math::Function::Tr.new([
-                        Plurimath::Math::Function::Td.new([]),
-                        Plurimath::Math::Function::Td.new([])
-                      ]),
-                      Plurimath::Math::Function::Tr.new([
-                        Plurimath::Math::Function::Td.new([
-                          Plurimath::Math::Symbol.new("&#x22ef;")
-                        ]),
-                        Plurimath::Math::Function::Td.new([
-                          Plurimath::Math::Symbol.new("\\mbox{degreeoffreedom2,node2}")
-                        ])
-                      ])
-                    ],
-                    nil,
-                    [
-                      Plurimath::Math::Symbol.new("cc")
-                    ],
-                  )
-                ])
+                  ],
+                  { columnalign: "center" }
+                ),
               ]),
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([]),
-                Plurimath::Math::Function::Td.new([])
+                Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
               ]),
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Table::Array.new(
-                    [
-                      Plurimath::Math::Function::Tr.new([
-                        Plurimath::Math::Function::Td.new([
-                          Plurimath::Math::Symbol.new("&#x22ee;")
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Table::Array.new(
+                      [
+                        Plurimath::Math::Function::Tr.new([
+                          Plurimath::Math::Function::Td.new(
+                            [Plurimath::Math::Symbol.new("&#x22ee;")],
+                            { columnalign: "center" }
+                          ),
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
+                          Plurimath::Math::Function::Td.new(
+                            [Plurimath::Math::Symbol.new("&#x22ee;")],
+                            { columnalign: "center" }
+                          ),
                         ]),
-                        Plurimath::Math::Function::Td.new([]),
-                        Plurimath::Math::Function::Td.new([]),
-                        Plurimath::Math::Function::Td.new([]),
-                        Plurimath::Math::Function::Td.new([]),
-                        Plurimath::Math::Function::Td.new([
-                          Plurimath::Math::Symbol.new("&#x22ee;")
-                        ])
-                      ])
-                    ],
-                    nil,
-                    [
-                      Plurimath::Math::Symbol.new("cccccc")
-                    ],
-                  )
-                ]),
-                Plurimath::Math::Function::Td.new([])
+                      ],
+                      nil,
+                      nil,
+                      {}
+                    ),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
               ]),
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([
-                  Plurimath::Math::Function::Table::Array.new(
-                    [
-                      Plurimath::Math::Function::Tr.new([
-                        Plurimath::Math::Function::Td.new([]),
-                        Plurimath::Math::Function::Td.new([
-                          Plurimath::Math::Symbol.new("\\mbox{degreeof}")
+                Plurimath::Math::Function::Td.new(
+                  [
+                    Plurimath::Math::Function::Table::Array.new(
+                      [
+                        Plurimath::Math::Function::Tr.new([
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
+                          Plurimath::Math::Function::Td.new(
+                            [
+                              Plurimath::Math::Function::Mbox.new(
+                                Plurimath::Math::Formula.new([
+                                  Plurimath::Math::Symbol.new("d"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("g"),
+                                  Plurimath::Math::Symbol.new("r"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("o"),
+                                  Plurimath::Math::Symbol.new("f"),
+                                ])
+                              ),
+                            ],
+                            { columnalign: "center" }
+                          ),
+                          Plurimath::Math::Function::Td.new(
+                            [
+                              Plurimath::Math::Function::Mbox.new(
+                                Plurimath::Math::Formula.new([
+                                  Plurimath::Math::Symbol.new("d"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("g"),
+                                  Plurimath::Math::Symbol.new("r"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("o"),
+                                  Plurimath::Math::Symbol.new("f"),
+                                ])
+                              ),
+                            ],
+                            { columnalign: "center" }
+                          ),
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
                         ]),
-                        Plurimath::Math::Function::Td.new([
-                          Plurimath::Math::Symbol.new("\\mbox{degreeof}")
+                        Plurimath::Math::Function::Tr.new([
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
+                          Plurimath::Math::Function::Td.new(
+                            [
+                              Plurimath::Math::Function::Mbox.new(
+                                Plurimath::Math::Formula.new([
+                                  Plurimath::Math::Symbol.new("f"),
+                                  Plurimath::Math::Symbol.new("r"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("d"),
+                                  Plurimath::Math::Symbol.new("o"),
+                                  Plurimath::Math::Symbol.new("m"),
+                                  Plurimath::Math::Number.new("1"),
+                                  Plurimath::Math::Symbol.new(","),
+                                ])
+                              ),
+                            ],
+                            { columnalign: "center" }
+                          ),
+                          Plurimath::Math::Function::Td.new(
+                            [
+                              Plurimath::Math::Function::Mbox.new(
+                                Plurimath::Math::Formula.new([
+                                  Plurimath::Math::Symbol.new("f"),
+                                  Plurimath::Math::Symbol.new("r"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Symbol.new("d"),
+                                  Plurimath::Math::Symbol.new("o"),
+                                  Plurimath::Math::Symbol.new("m"),
+                                  Plurimath::Math::Number.new("2"),
+                                  Plurimath::Math::Symbol.new(","),
+                                ])
+                              ),
+                            ],
+                            { columnalign: "center" }
+                          ),
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
                         ]),
-                        Plurimath::Math::Function::Td.new([])
-                      ]),
-                      Plurimath::Math::Function::Tr.new([
-                        Plurimath::Math::Function::Td.new([]),
-                        Plurimath::Math::Function::Td.new([
-                          Plurimath::Math::Symbol.new("\\mbox{freedom1,}")
+                        Plurimath::Math::Function::Tr.new([
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
+                          Plurimath::Math::Function::Td.new(
+                            [
+                              Plurimath::Math::Function::Mbox.new(
+                                Plurimath::Math::Formula.new([
+                                  Plurimath::Math::Symbol.new("n"),
+                                  Plurimath::Math::Symbol.new("o"),
+                                  Plurimath::Math::Symbol.new("d"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Number.new("1"),
+                                ])
+                              ),
+                            ],
+                            { columnalign: "center" }
+                          ),
+                          Plurimath::Math::Function::Td.new(
+                            [
+                              Plurimath::Math::Function::Mbox.new(
+                                Plurimath::Math::Formula.new([
+                                  Plurimath::Math::Symbol.new("n"),
+                                  Plurimath::Math::Symbol.new("o"),
+                                  Plurimath::Math::Symbol.new("d"),
+                                  Plurimath::Math::Symbol.new("e"),
+                                  Plurimath::Math::Number.new("2"),
+                                ])
+                              ),
+                            ],
+                            { columnalign: "center" }
+                          ),
+                          Plurimath::Math::Function::Td.new([], {
+                            columnalign: "center",
+                          }),
                         ]),
-                        Plurimath::Math::Function::Td.new([
-                          Plurimath::Math::Symbol.new("\\mbox{freedom2,}")
-                        ]),
-                        Plurimath::Math::Function::Td.new([])
-                      ]),
-                      Plurimath::Math::Function::Tr.new([
-                        Plurimath::Math::Function::Td.new([]),
-                        Plurimath::Math::Function::Td.new([
-                          Plurimath::Math::Symbol.new("\\mbox{node1}")
-                        ]),
-                        Plurimath::Math::Function::Td.new([
-                          Plurimath::Math::Symbol.new("\\mbox{node2}")
-                        ]),
-                        Plurimath::Math::Function::Td.new([])
-                      ])
-                    ],
-                    nil,
-                    [
-                      Plurimath::Math::Symbol.new("cccc")
-                    ],
-                  )
-                ]),
-                Plurimath::Math::Function::Td.new([])
-              ])
+                      ],
+                      nil,
+                      nil,
+                      {}
+                    ),
+                  ],
+                  { columnalign: "center" }
+                ),
+                Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+              ]),
             ],
             nil,
-            [Plurimath::Math::Symbol.new("cc")],
-          )
+            nil,
+            {}
+          ),
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           \\begin{array}{cc}
             \\left(
@@ -8862,6 +10043,8 @@ RSpec.describe Plurimath::Math::Formula do
             \\end{array} &
           \\end{array}
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -8874,95 +10057,117 @@ RSpec.describe Plurimath::Math::Formula do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("dt"),
-                      Plurimath::Math::Symbol.new("x")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("d"),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("t"),
+                        Plurimath::Math::Symbol.new("x")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("dt"),
-                      Plurimath::Math::Symbol.new("y")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("d"),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("t"),
+                        Plurimath::Math::Symbol.new("y")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("dt"),
-                      Plurimath::Math::Symbol.new("z")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("d"),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("t"),
+                        Plurimath::Math::Symbol.new("z")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("dr"),
-                      Plurimath::Math::Symbol.new("x")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("d"),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("r"),
+                        Plurimath::Math::Symbol.new("x")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("dr"),
-                      Plurimath::Math::Symbol.new("y")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("d"),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("r"),
+                        Plurimath::Math::Symbol.new("y")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("dr"),
-                      Plurimath::Math::Symbol.new("z")
-                    )
-                  ])
-                ])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("d"),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("r"),
+                        Plurimath::Math::Symbol.new("z")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("cccccc")
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           \\left(
              \\begin{array}{cccccc}
@@ -8975,6 +10180,8 @@ RSpec.describe Plurimath::Math::Formula do
              \\end{array}
           \\right)
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -8987,95 +10194,117 @@ RSpec.describe Plurimath::Math::Formula do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("kt"),
-                      Plurimath::Math::Symbol.new("x")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("k"),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("t"),
+                        Plurimath::Math::Symbol.new("x")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("kt"),
-                      Plurimath::Math::Symbol.new("y")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("k"),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("t"),
+                        Plurimath::Math::Symbol.new("y")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("kt"),
-                      Plurimath::Math::Symbol.new("z")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("k"),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("t"),
+                        Plurimath::Math::Symbol.new("z")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("kr"),
-                      Plurimath::Math::Symbol.new("x")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("k"),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("r"),
+                        Plurimath::Math::Symbol.new("x")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("kr"),
-                      Plurimath::Math::Symbol.new("y")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("k"),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("r"),
+                        Plurimath::Math::Symbol.new("y")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("kr"),
-                      Plurimath::Math::Symbol.new("z")
-                    )
-                  ])
-                ])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Symbol.new("k"),
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("r"),
+                        Plurimath::Math::Symbol.new("z")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("cccccc")
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           \\left(
             \\begin{array}{cccccc}
@@ -9088,6 +10317,8 @@ RSpec.describe Plurimath::Math::Formula do
             \\end{array}
           \\right)
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -9100,125 +10331,186 @@ RSpec.describe Plurimath::Math::Formula do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("x")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("m"),
+                        Plurimath::Math::Symbol.new("x")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("y")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("m"),
+                        Plurimath::Math::Symbol.new("y")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("z")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("m"),
+                        Plurimath::Math::Symbol.new("z")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("i"),
-                      Plurimath::Math::Symbol.new("xx")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("i"),
-                      Plurimath::Math::Symbol.new("xy")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("i"),
-                      Plurimath::Math::Symbol.new("xz")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("x"),
+                          Plurimath::Math::Symbol.new("x"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("x"),
+                          Plurimath::Math::Symbol.new("y"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("x"),
+                          Plurimath::Math::Symbol.new("z"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("i"),
-                      Plurimath::Math::Symbol.new("xy")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("i"),
-                      Plurimath::Math::Symbol.new("yy")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("i"),
-                      Plurimath::Math::Symbol.new("yz")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("x"),
+                          Plurimath::Math::Symbol.new("y"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("y"),
+                          Plurimath::Math::Symbol.new("y"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("y"),
+                          Plurimath::Math::Symbol.new("z"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("i"),
-                      Plurimath::Math::Symbol.new("xz")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("i"),
-                      Plurimath::Math::Symbol.new("yz")
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("i"),
-                      Plurimath::Math::Symbol.new("zz")
-                    )
-                  ])
-                ])
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new([], { columnalign: "center" }),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("x"),
+                          Plurimath::Math::Symbol.new("z"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("y"),
+                          Plurimath::Math::Symbol.new("z"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Formula.new([
+                          Plurimath::Math::Symbol.new("z"),
+                          Plurimath::Math::Symbol.new("z"),
+                        ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("cccccc")
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
-        }
-      it "returns formula" do
-        expected_value =
+      }
+      let(:expected_value) do
         <<~LATEX
           \\left(
             \\begin{array}{cccccc}
@@ -9237,6 +10529,8 @@ RSpec.describe Plurimath::Math::Formula do
             \\end{array}
           \\right)
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -9249,8 +10543,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("Mbba")
         ])
       }
+      let(:expected_value) { "bbf=Mbba" }
       it "returns formula" do
-        expected_value = "bbf=Mbba"
         expect(formula).to eq(expected_value)
       end
     end
@@ -9263,8 +10557,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("Dbbv")
         ])
       }
+      let(:expected_value) { "bbf=Dbbv" }
       it "returns formula" do
-        expected_value = "bbf=Dbbv"
         expect(formula).to eq(expected_value)
       end
     end
@@ -9277,8 +10571,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("Kbbd")
         ])
       }
+      let(:expected_value) { "bbf=Kbbd" }
       it "returns formula" do
-        expected_value = "bbf=Kbbd"
         expect(formula).to eq(expected_value)
       end
     end
@@ -9331,8 +10625,8 @@ RSpec.describe Plurimath::Math::Formula do
           ])
         ])
       }
+      let(:expected_value) { "1,,,,,,2,,0,,,,,3,,,0,,ddots,,,,,,n" }
       it "returns formula" do
-        expected_value = "1,,,,,,2,,0,,,,,3,,,0,,ddots,,,,,,n"
         expect(formula).to eq(expected_value)
       end
     end
@@ -9457,8 +10751,8 @@ RSpec.describe Plurimath::Math::Formula do
           ])
         ])
       }
+      let(:expected_value) { "1,,,,,,\"symetric\",2,n+1,,,,,,3,n+2,2n,,,,,*,*,*,3n-2,,,,*,*,*,*,*,,,*,*,*,*,*,*,,n,2n-1,3n-3,*,*,*,nn+1//2" }
       it "returns formula" do
-        expected_value = "1,,,,,,\"symetric\",2,n+1,,,,,,3,n+2,2n,,,,,*,*,*,3n-2,,,,*,*,*,*,*,,,*,*,*,*,*,*,,n,2n-1,3n-3,*,*,*,nn+1//2"
         expect(formula).to eq(expected_value)
       end
     end
@@ -9479,8 +10773,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\tilde{s}=p/\\rho^{\\gamma}" }
       it "returns formula" do
-        expected_value = "\\tilde{s}=p/\\rho^{\\gamma}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -9517,8 +10811,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\vec{q}=u\\hat{e}_{x}+v\\hat{e}_{y}+w\\hat{e}_{z}" }
       it "returns formula" do
-        expected_value = "\\vec{q}=u\\hat{e}_{x}+v\\hat{e}_{y}+w\\hat{e}_{z}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -9541,8 +10835,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "q=\\sqrt{\\vec{q}\\cdot\\vec{q}}" }
       it "returns formula" do
-        expected_value = "q=\\sqrt{\\vec{q}\\cdot\\vec{q}}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -9583,8 +10877,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\rho\\vec{q}=\\rhou\\hat{e}_{x}+\\rhov\\hat{e}_{y}+\\rhow\\hat{e}_{z}" }
       it "returns formula" do
-        expected_value = "\\rho\\vec{q}=\\rhou\\hat{e}_{x}+\\rhov\\hat{e}_{y}+\\rhow\\hat{e}_{z}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -9599,8 +10893,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\rhoe_{0}" }
       it "returns formula" do
-        expected_value = "\\rhoe_{0}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -9611,8 +10905,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("&#x3bc;")
         ])
       }
+      let(:expected_value) { "\\mu" }
       it "returns formula" do
-        expected_value = "\\mu"
         expect(formula).to eq(expected_value)
       end
     end
@@ -9623,8 +10917,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("&#x3bd;")
         ])
       }
+      let(:expected_value) { "\\nu" }
       it "returns formula" do
-        expected_value = "\\nu"
         expect(formula).to eq(expected_value)
       end
     end
@@ -9639,8 +10933,8 @@ RSpec.describe Plurimath::Math::Formula do
           ),
         ])
       }
+      let(:expected_value) { "\\overline{\\overline{S}}" }
       it "returns formula" do
-        expected_value = "\\overline{\\overline{S}}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -9655,8 +10949,8 @@ RSpec.describe Plurimath::Math::Formula do
           ),
         ])
       }
+      let(:expected_value) { "\\overline{\\overline{\\tau}}" }
       it "returns formula" do
-        expected_value = "\\overline{\\overline{\\tau}}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -9690,8 +10984,8 @@ RSpec.describe Plurimath::Math::Formula do
           ])
         ])
       }
+      let(:expected_value) { "x_{1},x_{2},x_{3}=x,y,z" }
       it "returns formula" do
-        expected_value = "x_{1},x_{2},x_{3}=x,y,z"
         expect(formula).to eq(expected_value)
       end
     end
@@ -9725,8 +11019,8 @@ RSpec.describe Plurimath::Math::Formula do
           ])
         ])
       }
+      let(:expected_value) { "u_{1},u_{2},u_{3}=u,v,w" }
       it "returns formula" do
-        expected_value = "u_{1},u_{2},u_{3}=u,v,w"
         expect(formula).to eq(expected_value)
       end
     end
@@ -9743,8 +11037,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("&#x3bc;")
         ])
       }
+      let(:expected_value) { "\\lambda=-2/3\\mu" }
       it "returns formula" do
-        expected_value = "\\lambda=-2/3\\mu"
         expect(formula).to eq(expected_value)
       end
     end
@@ -9764,8 +11058,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "-\\rho\\overline{u'e'}" }
       it "returns formula" do
-        expected_value = "-\\rho\\overline{u'e'}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -9815,8 +11109,8 @@ RSpec.describe Plurimath::Math::Formula do
           ])
         ])
       }
+      let(:expected_value) { "\\overline{u'v'}=\\nu_{t}\\left(\\frac{\\partialu}{\\partialy}+\\frac{\\partialv}{\\partialx}\\right)" }
       it "returns formula" do
-        expected_value = "\\overline{u'v'}=\\nu_{t}\\left(\\frac{\\partialu}{\\partialy}+\\frac{\\partialv}{\\partialx}\\right)"
         expect(formula).to eq(expected_value)
       end
     end
@@ -9830,8 +11124,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\nu_{t}" }
       it "returns formula" do
-        expected_value = "\\nu_{t}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -9842,8 +11136,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("&#x3f5;")
         ])
       }
+      let(:expected_value) { "\\epsilon" }
       it "returns formula" do
-        expected_value = "\\epsilon"
         expect(formula).to eq(expected_value)
       end
     end
@@ -9891,8 +11185,8 @@ RSpec.describe Plurimath::Math::Formula do
           ])
         ])
       }
+      let(:expected_value) { "k={1\\over2}\\overline{u'u'}+\\overline{v'v'}+\\overline{w'w'}" }
       it "returns formula" do
-        expected_value = "k={1\\over2}\\overline{u'u'}+\\overline{v'v'}+\\overline{w'w'}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -9908,8 +11202,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\nabla\\phi=\\vec{q}" }
       it "returns formula" do
-        expected_value = "\\nabla\\phi=\\vec{q}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -9926,8 +11220,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\nabla\\times\\psi=\\vec{q}" }
       it "returns formula" do
-        expected_value = "\\nabla\\times\\psi=\\vec{q}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -9941,8 +11235,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\rho_{0}" }
       it "returns formula" do
-        expected_value = "\\rho_{0}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -9964,8 +11258,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "u=\\vec{q}\\cdot\\hat{e}_{x}" }
       it "returns formula" do
-        expected_value = "u=\\vec{q}\\cdot\\hat{e}_{x}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -9987,8 +11281,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "v=\\vec{q}\\cdot\\hat{e}_{y}" }
       it "returns formula" do
-        expected_value = "v=\\vec{q}\\cdot\\hat{e}_{y}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -10010,8 +11304,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "w=\\vec{q}\\cdot\\hat{e}_{z}" }
       it "returns formula" do
-        expected_value = "w=\\vec{q}\\cdot\\hat{e}_{z}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -10031,8 +11325,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\vec{q}\\cdot\\hat{e}_{r}" }
       it "returns formula" do
-        expected_value = "\\vec{q}\\cdot\\hat{e}_{r}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -10043,8 +11337,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("&#x3b8;")
         ])
       }
+      let(:expected_value) { "\\theta" }
       it "returns formula" do
-        expected_value = "\\theta"
         expect(formula).to eq(expected_value)
       end
     end
@@ -10064,8 +11358,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\vec{q}\\cdot\\hat{e}_{\\theta}" }
       it "returns formula" do
-        expected_value = "\\vec{q}\\cdot\\hat{e}_{\\theta}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -10076,8 +11370,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("&#x3d5;")
         ])
       }
+      let(:expected_value) { "\\phi" }
       it "returns formula" do
-        expected_value = "\\phi"
         expect(formula).to eq(expected_value)
       end
     end
@@ -10097,8 +11391,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\vec{q}\\cdot\\hat{e}_{\\phi}" }
       it "returns formula" do
-        expected_value = "\\vec{q}\\cdot\\hat{e}_{\\phi}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -10115,8 +11409,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\vec{q}\\cdot\\hat{n}" }
       it "returns formula" do
-        expected_value = "\\vec{q}\\cdot\\hat{n}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -10128,8 +11422,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("u")
         ])
       }
+      let(:expected_value) { "\\rhou" }
       it "returns formula" do
-        expected_value = "\\rhou"
         expect(formula).to eq(expected_value)
       end
     end
@@ -10153,8 +11447,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("q")
         ])
       }
+      let(:expected_value) { "\\vec{q}\\cdot\\hat{e}_{x}/q" }
       it "returns formula" do
-        expected_value = "\\vec{q}\\cdot\\hat{e}_{x}/q"
         expect(formula).to eq(expected_value)
       end
     end
@@ -10178,8 +11472,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("q")
         ])
       }
+      let(:expected_value) { "\\vec{q}\\cdot\\hat{e}_{y}/q" }
       it "returns formula" do
-        expected_value = "\\vec{q}\\cdot\\hat{e}_{y}/q"
         expect(formula).to eq(expected_value)
       end
     end
@@ -10203,8 +11497,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("q")
         ])
       }
+      let(:expected_value) { "\\vec{q}\\cdot\\hat{e}_{z}/q" }
       it "returns formula" do
-        expected_value = "\\vec{q}\\cdot\\hat{e}_{z}/q"
         expect(formula).to eq(expected_value)
       end
     end
@@ -10222,8 +11516,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\rho\\vec{q}\\cdot\\hat{n}" }
       it "returns formula" do
-        expected_value = "\\rho\\vec{q}\\cdot\\hat{n}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -10238,8 +11532,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("&#x3c1;")
         ])
       }
+      let(:expected_value) { "\\nu=\\mu/\\rho" }
       it "returns formula" do
-        expected_value = "\\nu=\\mu/\\rho"
         expect(formula).to eq(expected_value)
       end
     end
@@ -10260,8 +11554,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "R=c_{p}-c_{v}" }
       it "returns formula" do
-        expected_value = "R=c_{p}-c_{v}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -10280,8 +11574,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\rho\\overline{u'u'}" }
       it "returns formula" do
-        expected_value = "\\rho\\overline{u'u'}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -10370,8 +11664,7 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new(",")
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           \\begin{pmatrix}
             \\hat{e}_{\\xi} \\\\ \\hat{e}_{\\eta} \\\\ \\hat{e}_{\\zeta}
@@ -10381,6 +11674,8 @@ RSpec.describe Plurimath::Math::Formula do
             \\hat{e}_{x} \\\\ \\hat{e}_{y} \\\\ \\hat{e}_{z}
           \\end{pmatrix},
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -10403,8 +11698,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\varepsilon=\\frac{\\partialu}{\\partialx}" }
       it "returns formula" do
-        expected_value = "\\varepsilon=\\frac{\\partialu}{\\partialx}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -10426,8 +11721,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\phi=\\frac{\\partial\\theta}{\\partialx}" }
       it "returns formula" do
-        expected_value = "\\phi=\\frac{\\partial\\theta}{\\partialx}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -10447,8 +11742,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\frac{\\partial\\theta}{\\partialz}" }
       it "returns formula" do
-        expected_value = "\\frac{\\partial\\theta}{\\partialz}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -10459,47 +11754,47 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("f"),
           Plurimath::Math::Symbol.new("="),
           Plurimath::Math::Function::Power.new(
-            Plurimath::Math::Formula.new([
-              Plurimath::Math::Function::FontStyle.new(
-                Plurimath::Math::Symbol.new("F"),
-                "bf",
-              )
-            ]),
+            Plurimath::Math::Symbol.new("F"),
             Plurimath::Math::Symbol.new("t")
           ),
-          Plurimath::Math::Symbol.new("&#x3a;"),
+          Plurimath::Math::Symbol.new(":"),
           Plurimath::Math::Formula.new([
             Plurimath::Math::Function::Left.new("("),
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("n"),
-                      Plurimath::Math::Symbol.new("y")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("n"),
+                        Plurimath::Math::Symbol.new("y")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("n"),
-                      Plurimath::Math::Symbol.new("z")
-                    )
-                  ])
-                ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("n"),
+                        Plurimath::Math::Symbol.new("z")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c")
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
       }
+      let(:expected_value) { "f=F^{t}:\\left(\\begin{array}{c}n_{y}\\\\n_{z}\\end{array}\\right)" }
       it "returns formula" do
-        expected_value = "f=F^{t}:\\left(\\begin{array}{c}n_{y}\\\\n_{z}\\end{array}\\right)"
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -10510,47 +11805,47 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("m"),
           Plurimath::Math::Symbol.new("="),
           Plurimath::Math::Function::Power.new(
-            Plurimath::Math::Formula.new([
-              Plurimath::Math::Function::FontStyle.new(
-                Plurimath::Math::Symbol.new("M"),
-                "bf"
-              )
-            ]),
+            Plurimath::Math::Symbol.new("M"),
             Plurimath::Math::Symbol.new("t")
           ),
-          Plurimath::Math::Symbol.new("&#x3a;"),
+          Plurimath::Math::Symbol.new(":"),
           Plurimath::Math::Formula.new([
             Plurimath::Math::Function::Left.new("("),
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("n"),
-                      Plurimath::Math::Symbol.new("y")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("n"),
+                        Plurimath::Math::Symbol.new("y")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("n"),
-                      Plurimath::Math::Symbol.new("z")
-                    )
-                  ])
-                ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("n"),
+                        Plurimath::Math::Symbol.new("z")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c")
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
       }
+      let(:expected_value) { "m=M^{t}:\\left(\\begin{array}{c}n_{y}\\\\n_{z}\\end{array}\\right)" }
       it "returns formula" do
-        expected_value = "m=M^{t}:\\left(\\begin{array}{c}n_{y}\\\\n_{z}\\end{array}\\right)"
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -10558,83 +11853,75 @@ RSpec.describe Plurimath::Math::Formula do
     context "contains latex equation #149" do
       let(:exp) {
         Plurimath::Math::Formula.new([
-          Plurimath::Math::Function::FontStyle.new(
-            Plurimath::Math::Symbol.new("c"),
-            "bf"
-          ),
+          Plurimath::Math::Symbol.new("c"),
           Plurimath::Math::Symbol.new("="),
           Plurimath::Math::Formula.new([
             Plurimath::Math::Function::Left.new("("),
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::FontStyle.new(
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
                         Plurimath::Math::Symbol.new("-"),
-                        "displaystyle"
-                      ),
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Function::Power.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Function::Power.new(
+                              Plurimath::Math::Symbol.new("&#x2202;"),
+                              Plurimath::Math::Number.new("2")
+                            ),
+                            Plurimath::Math::Symbol.new("v"),
+                          ]),
+                          Plurimath::Math::Formula.new([
                             Plurimath::Math::Symbol.new("&#x2202;"),
-                            Plurimath::Math::Number.new("2")
-                          ),
-                          Plurimath::Math::Symbol.new("v")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Function::Power.new(
-                            Plurimath::Math::Symbol.new("x"),
-                            Plurimath::Math::Number.new("2")
-                          )
-                        ])
-                      )
-                    ])
-                  ])
+                            Plurimath::Math::Function::Power.new(
+                              Plurimath::Math::Symbol.new("x"),
+                              Plurimath::Math::Number.new("2")
+                            ),
+                          ])
+                        ),
+                      ]),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Number.new("2"),
-                      Plurimath::Math::Symbol.new("mm")
-                    ]),
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::FontStyle.new(
-                        Plurimath::Math::Symbol.new("-"),
-                        "displaystyle"
-                      ),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("-"),
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Formula.new([
                           Plurimath::Math::Function::Power.new(
                             Plurimath::Math::Symbol.new("&#x2202;"),
                             Plurimath::Math::Number.new("2")
                           ),
-                          Plurimath::Math::Symbol.new("w")
+                          Plurimath::Math::Symbol.new("w"),
                         ]),
                         Plurimath::Math::Formula.new([
                           Plurimath::Math::Symbol.new("&#x2202;"),
                           Plurimath::Math::Function::Power.new(
                             Plurimath::Math::Symbol.new("x"),
                             Plurimath::Math::Number.new("2")
-                          )
+                          ),
                         ])
-                      )
-                    ])
-                  ])
-                ])
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c")
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           c =  \\left(
                         \\begin{array}{c}
@@ -10644,6 +11931,8 @@ RSpec.describe Plurimath::Math::Formula do
                       \\right)
 
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -10656,55 +11945,52 @@ RSpec.describe Plurimath::Math::Formula do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Formula.new([
                           Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("&#x3b8;")
+                          Plurimath::Math::Symbol.new("&#x3b8;"),
                         ]),
                         Plurimath::Math::Formula.new([
                           Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("y")
+                          Plurimath::Math::Symbol.new("y"),
                         ])
                       ),
-                      "displaystyle"
-                    )
-                  ])
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
+                  Plurimath::Math::Function::Td.new(
+                    [
                       Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("mm")
-                    ]),
-                    Plurimath::Math::Function::FontStyle.new(
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("m"),
                       Plurimath::Math::Function::Frac.new(
                         Plurimath::Math::Formula.new([
                           Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("&#x3b8;")
+                          Plurimath::Math::Symbol.new("&#x3b8;"),
                         ]),
                         Plurimath::Math::Formula.new([
                           Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("z")
+                          Plurimath::Math::Symbol.new("z"),
                         ])
                       ),
-                      "displaystyle"
-                    )
-                  ])
-                ])
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c")
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           \\left(
             \\begin{array}{c}
@@ -10713,6 +11999,8 @@ RSpec.describe Plurimath::Math::Formula do
             \\end{array}
           \\right)
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -10723,47 +12011,47 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("f"),
           Plurimath::Math::Symbol.new("="),
           Plurimath::Math::Function::Power.new(
-            Plurimath::Math::Formula.new([
-              Plurimath::Math::Function::FontStyle.new(
-                Plurimath::Math::Symbol.new("F"),
-                "bf"
-              )
-            ]),
+            Plurimath::Math::Symbol.new("F"),
             Plurimath::Math::Symbol.new("t")
           ),
-          Plurimath::Math::Symbol.new("&#x3a;"),
+          Plurimath::Math::Symbol.new(":"),
           Plurimath::Math::Formula.new([
             Plurimath::Math::Function::Left.new("("),
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("n"),
-                      Plurimath::Math::Symbol.new("x")
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("n"),
+                        Plurimath::Math::Symbol.new("x")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("n"),
-                      Plurimath::Math::Symbol.new("y")
-                    )
-                  ])
-                ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::Base.new(
+                        Plurimath::Math::Symbol.new("n"),
+                        Plurimath::Math::Symbol.new("y")
+                      ),
+                    ],
+                    { columnalign: "center" }
+                  ),
+                ]),
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("c")
-              ],
+              nil,
+              {}
             ),
-            Plurimath::Math::Function::Right.new(")")
-          ])
+            Plurimath::Math::Function::Right.new(")"),
+          ]),
         ])
       }
+      let(:expected_value) { "f=F^{t}:\\left(\\begin{array}{c}n_{x}\\\\n_{y}\\end{array}\\right)" }
       it "returns formula" do
-        expected_value = "f=F^{t}:\\left(\\begin{array}{c}n_{x}\\\\n_{y}\\end{array}\\right)"
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -10778,81 +12066,84 @@ RSpec.describe Plurimath::Math::Formula do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::FontStyle.new(
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Function::FontStyle.new(
+                          Plurimath::Math::Function::Frac.new(
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("&#x2202;"),
+                              Plurimath::Math::Symbol.new("w")
+                            ]),
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("&#x2202;"),
+                              Plurimath::Math::Symbol.new("x")
+                            ])
+                          ),
+                          "displaystyle"
+                        ),
+                        Plurimath::Math::Symbol.new("+"),
                         Plurimath::Math::Function::Frac.new(
                           Plurimath::Math::Formula.new([
                             Plurimath::Math::Symbol.new("&#x2202;"),
-                            Plurimath::Math::Symbol.new("w")
+                            Plurimath::Math::Symbol.new("u")
                           ]),
                           Plurimath::Math::Formula.new([
                             Plurimath::Math::Symbol.new("&#x2202;"),
-                            Plurimath::Math::Symbol.new("x")
+                            Plurimath::Math::Symbol.new("z")
                           ])
-                        ),
-                        "displaystyle"
-                      ),
-                      Plurimath::Math::Symbol.new("+"),
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("u")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("z")
-                        ])
-                      )
-                    ])
-                  ])
+                        )
+                      ])
+                    ],
+                    { columnalign: "center" },
+                  )
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Number.new("2"),
-                      Plurimath::Math::Symbol.new("mm")
-                    ]),
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::FontStyle.new(
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Number.new("2"),
+                        Plurimath::Math::Symbol.new("mm")
+                      ]),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Function::FontStyle.new(
+                          Plurimath::Math::Function::Frac.new(
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("&#x2202;"),
+                              Plurimath::Math::Symbol.new("w")
+                            ]),
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("&#x2202;"),
+                              Plurimath::Math::Symbol.new("y")
+                            ])
+                          ),
+                          "displaystyle"
+                        ),
+                        Plurimath::Math::Symbol.new("+"),
                         Plurimath::Math::Function::Frac.new(
                           Plurimath::Math::Formula.new([
                             Plurimath::Math::Symbol.new("&#x2202;"),
-                            Plurimath::Math::Symbol.new("w")
+                            Plurimath::Math::Symbol.new("v")
                           ]),
                           Plurimath::Math::Formula.new([
                             Plurimath::Math::Symbol.new("&#x2202;"),
-                            Plurimath::Math::Symbol.new("y")
+                            Plurimath::Math::Symbol.new("z")
                           ])
-                        ),
-                        "displaystyle"
-                      ),
-                      Plurimath::Math::Symbol.new("+"),
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("v")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("z")
-                        ])
-                      )
-                    ])
-                  ])
+                        )
+                      ])
+                    ],
+                    { columnalign: "center" },
+                  )
                 ])
               ],
               nil,
-              [
-                  Plurimath::Math::Symbol.new("c")
-                ],
+              nil,
             ),
             Plurimath::Math::Function::Right.new(")")
           ])
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           \\varepsilon =  \\left(
                             \\begin{array}{c}
@@ -10863,6 +12154,8 @@ RSpec.describe Plurimath::Math::Formula do
                             \\end{array}
                           \\right)
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -10877,85 +12170,94 @@ RSpec.describe Plurimath::Math::Formula do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("u")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("x")
-                        ])
-                      ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("u")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("y")
-                        ])
-                      ),
-                      "displaystyle"
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("&#x2202;"),
+                            Plurimath::Math::Symbol.new("u")
+                          ]),
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("&#x2202;"),
+                            Plurimath::Math::Symbol.new("x")
+                          ])
+                        ),
+                        "displaystyle"
+                      )
+                    ],
+                    { columnalign: "center" },
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("&#x2202;"),
+                            Plurimath::Math::Symbol.new("u")
+                          ]),
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("&#x2202;"),
+                            Plurimath::Math::Symbol.new("y")
+                          ])
+                        ),
+                        "displaystyle"
+                      )
+                    ],
+                    { columnalign: "center" },
+                  )
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Number.new("2"),
-                      Plurimath::Math::Symbol.new("mm")
-                    ]),
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("v")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("x")
-                        ])
-                      ),
-                      "displaystyle"
-                    )
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Function::FontStyle.new(
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("v")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("y")
-                        ])
-                      ),
-                      "displaystyle"
-                    )
-                  ])
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Number.new("2"),
+                        Plurimath::Math::Symbol.new("mm")
+                      ]),
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("&#x2202;"),
+                            Plurimath::Math::Symbol.new("v")
+                          ]),
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("&#x2202;"),
+                            Plurimath::Math::Symbol.new("x")
+                          ])
+                        ),
+                        "displaystyle"
+                      )
+                    ],
+                    { columnalign: "center" },
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Function::FontStyle.new(
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("&#x2202;"),
+                            Plurimath::Math::Symbol.new("v")
+                          ]),
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("&#x2202;"),
+                            Plurimath::Math::Symbol.new("y")
+                          ])
+                        ),
+                        "displaystyle"
+                      )
+                    ],
+                    { columnalign: "center" },
+                  )
                 ])
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("cc")
-              ],
+              nil,
             ),
             Plurimath::Math::Function::Right.new(")")
           ])
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           \\varepsilon =  \\left(
                             \\begin{array}{cc}
@@ -10966,6 +12268,8 @@ RSpec.describe Plurimath::Math::Formula do
                             \\end{array}
                           \\right)
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -10980,119 +12284,129 @@ RSpec.describe Plurimath::Math::Formula do
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::FontStyle.new(
-                        Plurimath::Math::Symbol.new("-"),
-                        "displaystyle"
-                      ),
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Function::Power.new(
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Function::FontStyle.new(
+                          Plurimath::Math::Symbol.new("-"),
+                          "displaystyle"
+                        ),
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Function::Power.new(
+                              Plurimath::Math::Symbol.new("&#x2202;"),
+                              Plurimath::Math::Number.new("2")
+                            ),
+                            Plurimath::Math::Symbol.new("w")
+                          ]),
+                          Plurimath::Math::Formula.new([
                             Plurimath::Math::Symbol.new("&#x2202;"),
-                            Plurimath::Math::Number.new("2")
-                          ),
-                          Plurimath::Math::Symbol.new("w")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Function::Power.new(
+                            Plurimath::Math::Function::Power.new(
+                              Plurimath::Math::Symbol.new("x"),
+                              Plurimath::Math::Number.new("2")
+                            )
+                          ])
+                        )
+                      ])
+                    ],
+                    { columnalign: "center" },
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Function::FontStyle.new(
+                          Plurimath::Math::Symbol.new("-"),
+                          "displaystyle"
+                        ),
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Function::Power.new(
+                              Plurimath::Math::Symbol.new("&#x2202;"),
+                              Plurimath::Math::Number.new("2")
+                            ),
+                            Plurimath::Math::Symbol.new("w")
+                          ]),
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("&#x2202;"),
                             Plurimath::Math::Symbol.new("x"),
-                            Plurimath::Math::Number.new("2")
-                          )
-                        ])
-                      )
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::FontStyle.new(
-                        Plurimath::Math::Symbol.new("-"),
-                        "displaystyle"
-                      ),
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Function::Power.new(
                             Plurimath::Math::Symbol.new("&#x2202;"),
-                            Plurimath::Math::Number.new("2")
-                          ),
-                          Plurimath::Math::Symbol.new("w")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("x"),
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("y")
-                        ])
-                      )
-                    ])
-                  ])
+                            Plurimath::Math::Symbol.new("y")
+                          ])
+                        )
+                      ])
+                    ],
+                    { columnalign: "center" },
+                  )
                 ]),
                 Plurimath::Math::Function::Tr.new([
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Number.new("2"),
-                      Plurimath::Math::Symbol.new("mm")
-                    ]),
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::FontStyle.new(
-                        Plurimath::Math::Symbol.new("-"),
-                        "displaystyle"
-                      ),
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Function::Power.new(
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Number.new("2"),
+                        Plurimath::Math::Symbol.new("mm")
+                      ]),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Function::FontStyle.new(
+                          Plurimath::Math::Symbol.new("-"),
+                          "displaystyle"
+                        ),
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Function::Power.new(
+                              Plurimath::Math::Symbol.new("&#x2202;"),
+                              Plurimath::Math::Number.new("2")
+                            ),
+                            Plurimath::Math::Symbol.new("w")
+                          ]),
+                          Plurimath::Math::Formula.new([
                             Plurimath::Math::Symbol.new("&#x2202;"),
-                            Plurimath::Math::Number.new("2")
-                          ),
-                          Plurimath::Math::Symbol.new("w")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("x"),
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Symbol.new("y")
-                        ])
-                      )
-                    ])
-                  ]),
-                  Plurimath::Math::Function::Td.new([
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Function::FontStyle.new(
-                        Plurimath::Math::Symbol.new("-"),
-                        "displaystyle"
-                      ),
-                      Plurimath::Math::Function::Frac.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Function::Power.new(
+                            Plurimath::Math::Symbol.new("x"),
                             Plurimath::Math::Symbol.new("&#x2202;"),
-                            Plurimath::Math::Number.new("2")
-                          ),
-                          Plurimath::Math::Symbol.new("w")
-                        ]),
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("&#x2202;"),
-                          Plurimath::Math::Function::Power.new(
-                            Plurimath::Math::Symbol.new("y"),
-                            Plurimath::Math::Number.new("2")
-                          )
-                        ])
-                      )
-                    ])
-                  ])
+                            Plurimath::Math::Symbol.new("y")
+                          ])
+                        )
+                      ])
+                    ],
+                    { columnalign: "center" },
+                  ),
+                  Plurimath::Math::Function::Td.new(
+                    [
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Function::FontStyle.new(
+                          Plurimath::Math::Symbol.new("-"),
+                          "displaystyle"
+                        ),
+                        Plurimath::Math::Function::Frac.new(
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Function::Power.new(
+                              Plurimath::Math::Symbol.new("&#x2202;"),
+                              Plurimath::Math::Number.new("2")
+                            ),
+                            Plurimath::Math::Symbol.new("w")
+                          ]),
+                          Plurimath::Math::Formula.new([
+                            Plurimath::Math::Symbol.new("&#x2202;"),
+                            Plurimath::Math::Function::Power.new(
+                              Plurimath::Math::Symbol.new("y"),
+                              Plurimath::Math::Number.new("2")
+                            )
+                          ])
+                        )
+                      ])
+                    ],
+                    { columnalign: "center" },
+                  )
                 ])
               ],
               nil,
-              [
-                Plurimath::Math::Symbol.new("cc")
-              ],
+              nil,
+              {},
             ),
             Plurimath::Math::Function::Right.new(")")
           ])
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           c = \\left(
                 \\begin{array}{cc}
@@ -11103,6 +12417,8 @@ RSpec.describe Plurimath::Math::Formula do
                 \\end{array}
               \\right)
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -11160,8 +12476,7 @@ RSpec.describe Plurimath::Math::Formula do
           ])
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           \\varepsilon_{ij}^{E} = 1/2
           \\left(
@@ -11169,6 +12484,8 @@ RSpec.describe Plurimath::Math::Formula do
             \\frac{\\partial v_{j}}{\\partial x_{i}}
           \\right)
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -11196,8 +12513,8 @@ RSpec.describe Plurimath::Math::Formula do
           ])
         ])
       }
+      let(:expected_value) { "\\varepsilon_{ij}^{T}=\\alpha_{ij}T-T_{0}" }
       it "returns formula" do
-        expected_value = "\\varepsilon_{ij}^{T}=\\alpha_{ij}T-T_{0}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -11223,8 +12540,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\varepsilon_{ij}=\\varepsilon_{ij}^{E}+\\varepsilon_{ij}^{T}" }
       it "returns formula" do
-        expected_value = "\\varepsilon_{ij}=\\varepsilon_{ij}^{E}+\\varepsilon_{ij}^{T}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -11254,8 +12571,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "\\Deltav=\\sum_{i}\\sum_{j}\\sigma_{ij}\\Delta\\varepsilon_{ij}" }
       it "returns formula" do
-        expected_value = "\\Deltav=\\sum_{i}\\sum_{j}\\sigma_{ij}\\Delta\\varepsilon_{ij}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -11279,8 +12596,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "a_{i}\\cdotx_{i}=b_{i}" }
       it "returns formula" do
-        expected_value = "a_{i}\\cdotx_{i}=b_{i}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -11315,8 +12632,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new("b")
         ])
       }
+      let(:expected_value) { "\\sum_{i=1}^{n}\\left(a_{i}\\cdotx_{i}\\right)=b" }
       it "returns formula" do
-        expected_value = "\\sum_{i=1}^{n}\\left(a_{i}\\cdotx_{i}\\right)=b"
         expect(formula).to eq(expected_value)
       end
     end
@@ -11377,8 +12694,7 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Symbol.new(".")
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           \\left[
             \\frac{\\partial}{\\partial t} + u \\pm c \\frac{\\partial}{\\partial x}
@@ -11387,6 +12703,8 @@ RSpec.describe Plurimath::Math::Formula do
             u \\pm {2\\over\\gamma-1} c
           \\right) = 0.
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -11399,8 +12717,8 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Number.new("0")
         ])
       }
+      let(:expected_value) { "vecqxxhats=0" }
       it "returns formula" do
-        expected_value = "vecqxxhats=0"
         expect(formula).to eq(expected_value)
       end
     end
@@ -11414,8 +12732,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "{\\color{blue}something}" }
       it "returns formula" do
-        expected_value = "{\\color{blue}something}"
         expect(formula).to eq(expected_value)
       end
     end
@@ -11539,8 +12857,7 @@ RSpec.describe Plurimath::Math::Formula do
           ])
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           c = \\left[
                 \\begin{multline}
@@ -11551,6 +12868,8 @@ RSpec.describe Plurimath::Math::Formula do
                 \\end{multline}
               \\right]
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -11674,8 +12993,7 @@ RSpec.describe Plurimath::Math::Formula do
           ])
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           c = \\left[
                 \\begin{align}
@@ -11686,6 +13004,8 @@ RSpec.describe Plurimath::Math::Formula do
                 \\end{align}
               \\right]
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -11809,8 +13129,7 @@ RSpec.describe Plurimath::Math::Formula do
           ])
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           c = \\left[
                 \\begin{matrix}
@@ -11821,6 +13140,8 @@ RSpec.describe Plurimath::Math::Formula do
                 \\end{matrix}
               \\right]
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -11940,8 +13261,7 @@ RSpec.describe Plurimath::Math::Formula do
           ])
         ])
       }
-      it "returns formula" do
-        expected_value =
+      let(:expected_value) do
         <<~LATEX
           c = \\left[
                 \\begin{vmatrix}
@@ -11952,6 +13272,8 @@ RSpec.describe Plurimath::Math::Formula do
                 \\end{vmatrix}
               \\right]
         LATEX
+      end
+      it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end
@@ -11979,8 +13301,8 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
+      let(:expected_value) { "a_{\\left\\{\\left.\\begin{matrix}{a}11\\end{matrix}\\right.\\right\\}}^{4terms}" }
       it "returns formula" do
-        expected_value = "a_{\\left\\{\\left.\\begin{matrix}{a}11\\end{matrix}\\right.\\right\\}}^{4terms}"
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end
     end

--- a/spec/plurimath/math/formula/mathml_spec.rb
+++ b/spec/plurimath/math/formula/mathml_spec.rb
@@ -124,12 +124,12 @@ RSpec.describe Plurimath::Math::Formula do
         <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
             <mstyle displaystyle="true">
-              <msub>
+              <munder>
                 <mrow>
                   <mi>sin</mi>
                 </mrow>
                 <mo>&#x2211;</mo>
-              </msub>
+              </munder>
             </mstyle>
           </math>
         MATHML
@@ -654,7 +654,8 @@ RSpec.describe Plurimath::Math::Formula do
             <mstyle displaystyle="true">
               <msubsup>
                 <mi>a</mi>
-                <mfenced open="[" close="">
+                <mrow>
+                  <mo>[</mo>
                   <mtable>
                     <mtr>
                       <mtd>
@@ -662,7 +663,8 @@ RSpec.describe Plurimath::Math::Formula do
                       </mtd>
                     </mtr>
                   </mtable>
-                </mfenced>
+                  <mo></mo>
+                </mrow>
                 <mtext>4terms</mtext>
               </msubsup>
             </mstyle>

--- a/spec/plurimath/math/function/log_spec.rb
+++ b/spec/plurimath/math/function/log_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Plurimath::Math::Function::Log do
             <mrow>
               <munderover>
                 <mo>&#x220f;</mo>
-                <mo>&#x26;</mo>
+                <mo>&amp;</mo>
                 <mtext>so</mtext>
               </munderover>
             </mrow>
@@ -146,14 +146,14 @@ RSpec.describe Plurimath::Math::Function::Log do
             <mrow>
               <munderover>
                 <mo>&#x2211;</mo>
-                <mo>&#x26;</mo>
+                <mo>&amp;</mo>
                 <mtext>so</mtext>
               </munderover>
             </mrow>
             <mrow>
               <munderover>
                 <mo>&#x220f;</mo>
-                <mo>&#x26;</mo>
+                <mo>&amp;</mo>
                 <mtext>so</mtext>
               </munderover>
             </mrow>

--- a/spec/plurimath/math/function/table_spec.rb
+++ b/spec/plurimath/math/function/table_spec.rb
@@ -13,9 +13,10 @@ RSpec.describe Plurimath::Math::Function::Table do
       end
 
       it 'initializes Table object' do
-        expect(table.parameter_one).to eql(['70'])
-        expect(table.parameter_two).to eql('{')
-        expect(table.parameter_three).to eql('}')
+        expect(table.value).to eql(['70'])
+        expect(table.open_paren).to eql('{')
+        expect(table.close_paren).to eql('}')
+        expect(table.options).to eql({})
       end
     end
   end

--- a/spec/plurimath/math/function/tr_spec.rb
+++ b/spec/plurimath/math/function/tr_spec.rb
@@ -78,12 +78,18 @@ RSpec.describe Plurimath::Math::Function::Tr do
     end
 
     context "contains Symbol as value" do
-      let(:first_value) { Plurimath::Math::Symbol.new("n") }
+      let(:first_value) do
+        Plurimath::Math::Function::Td.new([
+          Plurimath::Math::Symbol.new("n")
+        ])
+      end
 
       it "returns mathml string" do
         expected_value = <<~MATHML
           <mtr>
-            <mi>n</mi>
+            <mtd>
+              <mi>n</mi>
+            </mtd>
           </mtr>
         MATHML
         expect(formula).to be_equivalent_to(expected_value)
@@ -91,12 +97,18 @@ RSpec.describe Plurimath::Math::Function::Tr do
     end
 
     context "contains Number as value" do
-      let(:first_value) { Plurimath::Math::Number.new("70") }
+      let(:first_value) do
+        Plurimath::Math::Function::Td.new([
+          Plurimath::Math::Number.new("70")
+        ])
+      end
 
       it "returns mathml string" do
         expected_value = <<~MATHML
           <mtr>
-            <mn>70</mn>
+            <mtd>
+              <mn>70</mn>
+            </mtd>
           </mtr>
         MATHML
         expect(formula).to be_equivalent_to(expected_value)
@@ -105,23 +117,27 @@ RSpec.describe Plurimath::Math::Function::Tr do
 
     context "contains Formula as value" do
       let(:first_value) do
-        Plurimath::Math::Formula.new([
-          Plurimath::Math::Function::Sum.new(
-            Plurimath::Math::Symbol.new("&"),
-            Plurimath::Math::Function::Text.new("so"),
-          )
+        Plurimath::Math::Function::Td.new([
+          Plurimath::Math::Formula.new([
+            Plurimath::Math::Function::Sum.new(
+              Plurimath::Math::Symbol.new("&"),
+              Plurimath::Math::Function::Text.new("so"),
+            )
+          ])
         ])
       end
       it "returns mathml string" do
         expected_value = <<~MATHML
           <mtr>
-            <mrow>
-              <munderover>
-                <mo>&#x2211;</mo>
-                <mo>&#x26;</mo>
-                <mtext>so</mtext>
-              </munderover>
-            </mrow>
+            <mtd>
+              <mrow>
+                <munderover>
+                  <mo>&#x2211;</mo>
+                  <mo>&#x26;</mo>
+                  <mtext>so</mtext>
+                </munderover>
+              </mrow>
+            </mtd>
           </mtr>
         MATHML
         expect(formula).to be_equivalent_to(expected_value)

--- a/spec/plurimath/omml/parser_spec.rb
+++ b/spec/plurimath/omml/parser_spec.rb
@@ -1,6 +1,5 @@
-require_relative "../../../lib/plurimath/math"
+require_relative "../../spec_helper"
 require_relative "../fixtures/expected_values.rb"
-require_relative "../../../lib/plurimath/omml/parser"
 
 RSpec.describe Plurimath::Omml::Parser do
 


### PR DESCRIPTION
This Pull Request _adds and updates_ specs, conversion methods, and all the necessary changes required for **Latex** to **MathML** conversion.

The **Latex** to **MathML** conversions are validated by comparing the output of [**Latexmath** gem](https://github.com/plurimath/latexmath)'s **MathML** output.

closes #87 