### PR TITLE
Fixed missing closing double quote crash

### DIFF
--- a/lib/plurimath/asciimath/parse.rb
+++ b/lib/plurimath/asciimath/parse.rb
@@ -58,7 +58,8 @@ module Plurimath
       end
 
       rule(:quoted_text) do
-        str('"') >> match("[^\"]").repeat.as(:text) >> str('"')
+        str('"') >> match("[^\"]").repeat.as(:text) >> str('"') |
+          str('"') >> str("").as(:text)
       end
 
       rule(:symbol_text_or_integer) do

--- a/lib/plurimath/latex/constants.rb
+++ b/lib/plurimath/latex/constants.rb
@@ -3561,6 +3561,7 @@ module Plurimath
         cosh: :unary,
         ddot: :unary,
         mbox: :unary,
+        text: :unary,
         '"': :symbols,
         sum: :power_base,
         inf: :power_base,

--- a/spec/plurimath/asciimath_spec.rb
+++ b/spec/plurimath/asciimath_spec.rb
@@ -3771,5 +3771,26 @@ RSpec.describe Plurimath::Asciimath do
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
+
+    context "contains example #65" do
+      let(:string) { "y\"a" }
+
+      it 'returns parsed Asciimath to Formula' do
+        latex = "y \\text{} a"
+        asciimath = "y \"\" a"
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mi>y</mi>
+              <mtext></mtext>
+              <mi>a</mi>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
+      end
+    end
   end
 end


### PR DESCRIPTION
Resolved an issue with parsing **AsciiMath** where the presence of a **single double quote** caused a crash.

closes #121 