### PR TITLE
Added Plurimath error message support

### DIFF
--- a/lib/plurimath/math.rb
+++ b/lib/plurimath/math.rb
@@ -41,6 +41,14 @@ module Plurimath
 
       klass = VALID_TYPES[type.to_sym]
       klass.new(text).to_formula
+    rescue => ee
+      message = <<~MESSAGE
+        An error occurred while processing the input. Please check your input to ensure it is valid or open an issue on Github If you believe the input is correct.
+        ---- INPUT START ----
+          #{text}
+        ---- INPUT END ----
+      MESSAGE
+      raise Math::Error.new(message), cause: nil
     end
 
     private

--- a/spec/plurimath/asciimath_spec.rb
+++ b/spec/plurimath/asciimath_spec.rb
@@ -3855,5 +3855,38 @@ RSpec.describe Plurimath::Asciimath do
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
+
+    context "contains example #68" do
+      let(:string) { 'bb(ii(A)) + bb(ii(B)) = bb(ii()' }
+
+      it 'returns parsed Asciimath to Formula' do
+        latex = "\\mathbf{\\mathit{A}} + \\mathbf{\\mathit{B}} = \\mathbf{\\mathit{}}"
+        asciimath = 'mathbf(ii(A)) + mathbf(ii(B)) = mathbf(ii())'
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mstyle mathvariant="bold">
+                <mstyle mathvariant="italic">
+                  <mi>A</mi>
+                </mstyle>
+              </mstyle>
+              <mo>+</mo>
+              <mstyle mathvariant="bold">
+                <mstyle mathvariant="italic">
+                  <mi>B</mi>
+                </mstyle>
+              </mstyle>
+              <mo>=</mo>
+              <mstyle mathvariant="bold">
+                <mstyle mathvariant="italic"/>
+              </mstyle>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
+      end
+    end
   end
 end

--- a/spec/plurimath/math_spec.rb
+++ b/spec/plurimath/math_spec.rb
@@ -1,8 +1,28 @@
 require_relative '../../lib/plurimath/math'
 
 RSpec.describe Plurimath::Math do
+  describe ".initialize" do
+    subject(:formula) { Plurimath::Math.parse(input, type: type) }
 
-  it "raises error on wrong type" do
-    expect{Plurimath::Math.parse("asdf", type: 'wrong_type')}.to raise_error(Plurimath::Math::Error)
+    context "contains incorrect type with parseable input of asciimath" do
+      let(:input) { "sin(d)" }
+      let(:type) { "wrong_type" }
+
+      it "raises error on wrong type" do
+        expect{formula}.to raise_error(Plurimath::Math::Error)
+      end
+    end
+
+    context "contains correct type with incomplete input of latex" do
+      let(:input) { "{\\sin{d}" }
+      let(:type) { "latex" }
+
+      it "raises error on wrong text input" do
+        error_message = "An error occurred while processing the input. "\
+                        "Please check your input to ensure it is valid "\
+                        "or open an issue on Github If you believe the input is correct."
+        expect{formula}.to raise_error(Plurimath::Math::Error, Regexp.compile(error_message))
+      end
+    end
   end
 end


### PR DESCRIPTION
Updated the code to catch **Parslet**'s exception on parsing or conversion failure for **Plurimath**, and instead of raising the exception, added a **Plurimath** exception.

![image](https://user-images.githubusercontent.com/96812483/232776940-7bfd1455-b3b7-46d3-9f04-cae38b9e052e.png)
