### PR TITLE
AsciiMath text parenthesis and msub/munder use fix

### DIFF
--- a/lib/plurimath/asciimath/parse.rb
+++ b/lib/plurimath/asciimath/parse.rb
@@ -109,7 +109,7 @@ module Plurimath
 
       rule(:sequence) do
         (lparen.as(:lparen) >> space.maybe >> expression.maybe.as(:expr) >> space.maybe >> rparen.maybe.as(:rparen)).as(:intermediate_exp) |
-          (str("text") >> lparen.capture(:paren).as(:lparen) >> read_text.as(:text) >> rparen.maybe.as(:rparen)).as(:intermediate_exp) |
+          (str("text") >> lparen.capture(:paren) >> read_text.as(:text) >> rparen.maybe).as(:intermediate_exp) |
           symbol_text_or_integer
       end
 

--- a/lib/plurimath/asciimath/transform.rb
+++ b/lib/plurimath/asciimath/transform.rb
@@ -1089,15 +1089,11 @@ module Plurimath
                         [expr]
                       end
         right_paren = rparen.to_s.empty? ? "" : rparen
-        if expr.is_a?(Math::Function::Text)
-          expr
-        else
-          Math::Function::Fenced.new(
-            Utility.symbol_object(lparen),
-            form_value&.flatten&.compact,
-            Utility.symbol_object(right_paren),
-          )
-        end
+        Math::Function::Fenced.new(
+          Utility.symbol_object(lparen),
+          form_value&.flatten&.compact,
+          Utility.symbol_object(right_paren),
+        )
       end
 
       rule(lparen: simple(:lparen),

--- a/lib/plurimath/math/function/base.rb
+++ b/lib/plurimath/math/function/base.rb
@@ -13,8 +13,7 @@ module Plurimath
         end
 
         def to_mathml_without_math_tag
-          under_classes = ["ubrace", "obrace"] + Utility::UNARY_CLASSES
-          tag_name = (under_classes.include?(parameter_one&.class_name) ? "under" : "sub")
+          tag_name = (Utility::MUNDER_CLASSES.include?(parameter_one&.class_name) ? "under" : "sub")
           sub_tag = Utility.ox_element("m#{tag_name}")
           mathml_value = []
           mathml_value << parameter_one&.to_mathml_without_math_tag

--- a/lib/plurimath/utility.rb
+++ b/lib/plurimath/utility.rb
@@ -67,6 +67,13 @@ module Plurimath
       f
       g
     ].freeze
+    MUNDER_CLASSES = %w[
+      ubrace
+      obrace
+      right
+      max
+      min
+    ].freeze
 
     class << self
       def organize_table(array, column_align: nil, options: nil)

--- a/spec/plurimath/asciimath/parser_spec.rb
+++ b/spec/plurimath/asciimath/parser_spec.rb
@@ -370,7 +370,11 @@ RSpec.describe Plurimath::Asciimath::Parser do
               Plurimath::Math::Symbol.new("l"),
               Plurimath::Math::Symbol.new("o"),
               Plurimath::Math::Symbol.new("r"),
-              Plurimath::Math::Function::Text.new("blue"),
+              Plurimath::Math::Function::Fenced.new(
+                Plurimath::Math::Symbol.new("{"),
+                [Plurimath::Math::Function::Text.new("blue")],
+                Plurimath::Math::Symbol.new("}"),
+              )
             ]),
             Plurimath::Math::Number.new("33")
           )

--- a/spec/plurimath/asciimath_spec.rb
+++ b/spec/plurimath/asciimath_spec.rb
@@ -3888,5 +3888,101 @@ RSpec.describe Plurimath::Asciimath do
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
+
+    context "contains example #69" do
+      let(:string) { 'f_(199"Hg") = 1128575290808154.8 "unitsml(Hz)"' }
+
+      it 'returns parsed Asciimath to Formula' do
+        latex = 'f_{199 \\text{Hg}} = 1128575290808154.8 \\text{unitsml(Hz)}'
+        asciimath = 'f_(199 "Hg") = 1128575290808154.8 "unitsml(Hz)"'
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <msub>
+                <mrow>
+                  <mi>f</mi>
+                </mrow>
+                <mrow>
+                  <mn>199</mn>
+                  <mtext>Hg</mtext>
+                </mrow>
+              </msub>
+              <mo>=</mo>
+              <mn>1128575290808154.8</mn>
+              <mtext>unitsml(Hz)</mtext>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
+      end
+    end
+
+    context "contains example #70" do
+      let(:string) { 'n_"S"("X") = m_"S" // ii(M)("X"), " and " ii(M)(""X"") = ii(A)_"r"("X") "unitsml(g/mol)"' }
+
+      it 'returns parsed Asciimath to Formula' do
+        latex = 'n_{\text{S}}  \left ( \text{X} \right )  = m_{\text{S}} / \mathit{M}  \left ( \text{X} \right )  ,  \text{ and } \mathit{M}  \left ( \text{} X \text{} \right )  = \mathit{A}_{\text{r}}  \left ( \text{X} \right )  \text{unitsml(g/mol)}'
+        asciimath = 'n_("S") ("X") = m_("S") // ii(M) ("X") ,  " and " ii(M) ("" X "") = ii(A)_("r") ("X") "unitsml(g/mol)"'
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <msub>
+                <mi>n</mi>
+                <mtext>S</mtext>
+              </msub>
+              <mrow>
+                <mo>(</mo>
+                <mtext>X</mtext>
+                <mo>)</mo>
+              </mrow>
+              <mo>=</mo>
+              <msub>
+                <mi>m</mi>
+                <mtext>S</mtext>
+              </msub>
+              <mo>/</mo>
+              <mstyle mathvariant="italic">
+                <mi>M</mi>
+              </mstyle>
+              <mrow>
+                <mo>(</mo>
+                <mtext>X</mtext>
+                <mo>)</mo>
+              </mrow>
+              <mo>, </mo>
+              <mtext> and </mtext>
+              <mstyle mathvariant="italic">
+                <mi>M</mi>
+              </mstyle>
+              <mrow>
+                <mo>(</mo>
+                <mtext></mtext>
+                <mi>X</mi>
+                <mtext></mtext>
+                <mo>)</mo>
+              </mrow>
+              <mo>=</mo>
+              <msub>
+                <mstyle mathvariant="italic">
+                  <mi>A</mi>
+                </mstyle>
+                <mtext>r</mtext>
+              </msub>
+              <mrow>
+                <mo>(</mo>
+                <mtext>X</mtext>
+                <mo>)</mo>
+              </mrow>
+              <mtext>unitsml(g/mol)</mtext>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
+      end
+    end
   end
 end

--- a/spec/plurimath/math/formula/mathml_spec.rb
+++ b/spec/plurimath/math/formula/mathml_spec.rb
@@ -124,12 +124,12 @@ RSpec.describe Plurimath::Math::Formula do
         <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
             <mstyle displaystyle="true">
-              <munder>
+              <msub>
                 <mrow>
                   <mi>sin</mi>
                 </mrow>
                 <mo>&#x2211;</mo>
-              </munder>
+              </msub>
             </mstyle>
           </math>
         MATHML

--- a/spec/plurimath/math/formula_spec.rb
+++ b/spec/plurimath/math/formula_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe Plurimath::Math::Formula do
       let(:exp) { "sum_(i=color{text(blue)})^33" }
 
       it 'converts formula back to Asciimath string for color function' do
-        expect(formula).to eql("sum_(i = c o l o r \"blue\")^(33)")
+        expect(formula).to eql("sum_(i = c o l o r {\"blue\"})^(33)")
       end
     end
 
@@ -154,7 +154,7 @@ RSpec.describe Plurimath::Math::Formula do
       let(:exp) { "sum_(i=color{\"blue\"})^33" }
 
       it 'converts formula back to Asciimath string for color function' do
-        expect(formula).to eql('sum_(i = c o l o r "blue")^(33)')
+        expect(formula).to eql('sum_(i = c o l o r {"blue"})^(33)')
       end
     end
 


### PR DESCRIPTION
Fixed **AsciiMath** **Text** method missing parenthesis.
Fixed munder/msub use for **AsciiMath** to **MathML** conversion.

closes #135 
closes #133 