### PR TITLE
AsciiMath transformation rules and utility method

### DIFF
--- a/lib/plurimath/asciimath/transform.rb
+++ b/lib/plurimath/asciimath/transform.rb
@@ -352,7 +352,7 @@ module Plurimath
           font_style.to_s,
         )
         Math::Function::Base.new(
-          Utility.unfenced_value(font_object),
+          font_object,
           Utility.unfenced_value(base),
         )
       end
@@ -460,7 +460,7 @@ module Plurimath
       rule(power_base: simple(:power_base),
            base: simple(:base)) do
         Math::Function::Base.new(
-          Utility.unfenced_value(power_base),
+          power_base,
           Utility.unfenced_value(base),
         )
       end
@@ -469,7 +469,7 @@ module Plurimath
            base: simple(:base),
            expr: sequence(:expr)) do
         base_object = Math::Function::Base.new(
-          Utility.unfenced_value(power_base),
+          power_base,
           Utility.unfenced_value(base),
         )
         Math::Formula.new(
@@ -481,7 +481,7 @@ module Plurimath
            base: simple(:base),
            expr: simple(:expr)) do
         base_object = Math::Function::Base.new(
-          Utility.unfenced_value(power_base),
+          power_base,
           Utility.unfenced_value(base),
         )
         formula_array = [base_object]
@@ -494,7 +494,7 @@ module Plurimath
            base_value: simple(:base_value),
            power_value: simple(:power_value)) do
         Math::Function::PowerBase.new(
-          Utility.unfenced_value(power_base),
+          power_base,
           Utility.unfenced_value(base_value),
           Utility.unfenced_value(power_value),
         )
@@ -506,7 +506,7 @@ module Plurimath
         first_value = power_value
         first_value = power_value.shift if Utility.frac_values(power_value)
         power_base_object = Math::Function::PowerBase.new(
-          Utility.unfenced_value(power_base),
+          power_base,
           Utility.unfenced_value(base_value),
           Utility.filter_values(first_value),
         )
@@ -527,7 +527,7 @@ module Plurimath
            power_value: simple(:power_value),
            expr: sequence(:expr)) do
         power_base_object = Math::Function::PowerBase.new(
-          Utility.unfenced_value(power_base),
+          power_base,
           Utility.unfenced_value(base_value),
           Utility.unfenced_value(power_value),
         )
@@ -649,7 +649,7 @@ module Plurimath
       rule(intermediate_exp: simple(:int_exp),
            base: simple(:base)) do
         Math::Function::Base.new(
-          Utility.unfenced_value(int_exp),
+          int_exp,
           Utility.unfenced_value(base),
         )
       end

--- a/lib/plurimath/math/symbol.rb
+++ b/lib/plurimath/math/symbol.rb
@@ -31,7 +31,7 @@ module Plurimath
 
         unicodes = Mathml::Constants::UNICODE_SYMBOLS
         unicode = unicodes.invert[value]
-        if operator?(unicode) || unicode
+        if operator?(unicode) || unicode || explicit_checks(unicode)
           mo_value = (unicodes[value] || unicode || value).to_s
           return Utility.ox_element("mo") << mo_value
         end
@@ -68,6 +68,10 @@ module Plurimath
         Mathml::Constants::OPERATORS.any? do |d|
           [unicode.to_s, value.strip].include?(d)
         end
+      end
+
+      def explicit_checks(unicode)
+        return true if [unicode, value].any?{|v| ["∣", "|"].include?(v) }
       end
 
       def specific_values

--- a/lib/plurimath/utility.rb
+++ b/lib/plurimath/utility.rb
@@ -364,8 +364,7 @@ module Plurimath
       def unfenced_value(object)
         case object
         when Math::Function::Fenced
-          value = filter_values(object.parameter_two)
-          unfenced_value(value)
+          filter_values(object.parameter_two)
         when Array
           filter_values(object)
         else

--- a/spec/plurimath/asciimath/asciidoctor_examples_spec.rb
+++ b/spec/plurimath/asciimath/asciidoctor_examples_spec.rb
@@ -308,16 +308,20 @@ RSpec.describe Plurimath::Asciimath::Parser do
           ]),
           Plurimath::Math::Symbol.new("="),
           Plurimath::Math::Function::PowerBase.new(
-            Plurimath::Math::Formula.new([
-              Plurimath::Math::Symbol.new("F"),
-              Plurimath::Math::Function::Fenced.new(
-                Plurimath::Math::Symbol.new("("),
-                [
-                  Plurimath::Math::Symbol.new("x")
-                ],
-                Plurimath::Math::Symbol.new(")")
-              )
-            ]),
+            Plurimath::Math::Function::Fenced.new(
+              Plurimath::Math::Symbol.new("["),
+              [
+                Plurimath::Math::Symbol.new("F"),
+                Plurimath::Math::Function::Fenced.new(
+                  Plurimath::Math::Symbol.new("("),
+                  [
+                    Plurimath::Math::Symbol.new("x")
+                  ],
+                  Plurimath::Math::Symbol.new(")")
+                ),
+              ],
+              Plurimath::Math::Symbol.new("]"),
+            ),
             Plurimath::Math::Symbol.new("a"),
             Plurimath::Math::Symbol.new("b")
           ),

--- a/spec/plurimath/asciimath/metanorma/mn_samples_bipm_spec.rb
+++ b/spec/plurimath/asciimath/metanorma/mn_samples_bipm_spec.rb
@@ -674,31 +674,39 @@ RSpec.describe Plurimath::Asciimath::Parser do
           ),
           Plurimath::Math::Symbol.new("="),
           Plurimath::Math::Function::Frac.new(
-            Plurimath::Math::Formula.new([
-              Plurimath::Math::Function::FontStyle::Italic.new(
-                Plurimath::Math::Symbol.new("W"),
-                "ii"
-              ),
-              Plurimath::Math::Symbol.new("-"),
-              Plurimath::Math::Function::Base.new(
+            Plurimath::Math::Function::Fenced.new(
+              Plurimath::Math::Symbol.new("("),
+              [
                 Plurimath::Math::Function::FontStyle::Italic.new(
                   Plurimath::Math::Symbol.new("W"),
                   "ii"
                 ),
-                Plurimath::Math::Function::Text.new("Ga")
-              )
-            ]),
-            Plurimath::Math::Formula.new([
-              Plurimath::Math::Number.new("1"),
-              Plurimath::Math::Symbol.new("-"),
-              Plurimath::Math::Function::Base.new(
-                Plurimath::Math::Function::FontStyle::Italic.new(
-                  Plurimath::Math::Symbol.new("W"),
-                  "ii"
+                Plurimath::Math::Symbol.new("-"),
+                Plurimath::Math::Function::Base.new(
+                  Plurimath::Math::Function::FontStyle::Italic.new(
+                    Plurimath::Math::Symbol.new("W"),
+                    "ii"
+                  ),
+                  Plurimath::Math::Function::Text.new("Ga")
                 ),
-                Plurimath::Math::Function::Text.new("Ga")
-              )
-            ])
+              ],
+              Plurimath::Math::Symbol.new(")"),
+            ),
+            Plurimath::Math::Function::Fenced.new(
+              Plurimath::Math::Symbol.new("("),
+              [
+                Plurimath::Math::Number.new("1"),
+                Plurimath::Math::Symbol.new("-"),
+                Plurimath::Math::Function::Base.new(
+                  Plurimath::Math::Function::FontStyle::Italic.new(
+                    Plurimath::Math::Symbol.new("W"),
+                    "ii"
+                  ),
+                  Plurimath::Math::Function::Text.new("Ga")
+                )
+              ],
+              Plurimath::Math::Symbol.new(")"),
+            )
           )
         ])
         expect(formula).to eq(expected_value)

--- a/spec/plurimath/asciimath_spec.rb
+++ b/spec/plurimath/asciimath_spec.rb
@@ -4139,5 +4139,63 @@ RSpec.describe Plurimath::Asciimath do
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
+
+    context "contains example #77" do
+      let(:string) { '"H"_nu^((1))(z)' }
+
+      it 'returns parsed Asciimath to Formula' do
+        latex = '\text{H}_{\nu}^{ \left ( 1 \right ) }  \left ( z \right ) '
+        asciimath = '"H"_(nu)^((1)) (z)'
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <msubsup>
+                <mtext>H</mtext>
+                <mi>&#x3bd;</mi>
+                <mrow>
+                  <mo>(</mo>
+                  <mn>1</mn>
+                  <mo>)</mo>
+                </mrow>
+              </msubsup>
+              <mrow>
+                <mo>(</mo>
+                <mi>z</mi>
+                <mo>)</mo>
+              </mrow>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
+      end
+    end
+
+    context "contains example #78" do
+      let(:string) { '(a)_n' }
+
+      it 'returns parsed Asciimath to Formula' do
+        latex = ' \left ( a \right ) _{n}'
+        asciimath = '(a)_(n)'
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <msub>
+                <mrow>
+                  <mo>(</mo>
+                  <mi>a</mi>
+                  <mo>)</mo>
+                </mrow>
+                <mi>n</mi>
+              </msub>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
+      end
+    end
   end
 end

--- a/spec/plurimath/asciimath_spec.rb
+++ b/spec/plurimath/asciimath_spec.rb
@@ -4016,5 +4016,128 @@ RSpec.describe Plurimath::Asciimath do
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
+
+    context "contains example #72" do
+      let(:string) { 'g @ f' }
+
+      it 'returns parsed Asciimath to Formula' do
+        latex = 'g\circ f'
+        asciimath = 'g@ f'
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mrow>
+                <mi>g</mi>
+                <mi>&#x2218;</mi>
+              </mrow>
+              <mrow>
+                <mi>f</mi>
+              </mrow>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
+      end
+    end
+
+    context "contains example #73" do
+      let(:string) { 'abs(A)' }
+
+      it 'returns parsed Asciimath to Formula' do
+        latex = '\abs{A}'
+        asciimath = 'abs(A)'
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mrow>
+                <mo>|</mo>
+                <mi>A</mi>
+                <mo>|</mo>
+              </mrow>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
+      end
+    end
+
+    context "contains example #74" do
+      let(:string) { 'ceil(x)' }
+
+      it 'returns parsed Asciimath to Formula' do
+        latex = '{\lceil x \rceil}'
+        asciimath = 'ceil(x)'
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mrow>
+                <mo>&#x2308;</mo>
+                <mi>x</mi>
+                <mo>&#x2309;</mo>
+              </mrow>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
+      end
+    end
+
+    context "contains example #75" do
+      let(:string) { 'ddot x' }
+
+      it 'returns parsed Asciimath to Formula' do
+        latex = '\ddot{x}'
+        asciimath = 'ddot(x)'
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mover accent="true">
+                <mi>x</mi>
+                <mo>..</mo>
+              </mover>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
+      end
+    end
+
+    context "contains example #76" do
+      let(:string) { '{x_i | i in I}' }
+
+      it 'returns parsed Asciimath to Formula' do
+        latex = ' \left \{ x_{i} | i \in I \right \} '
+        asciimath = '{x_(i) | i in I}'
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mrow>
+                <mo>{</mo>
+                <msub>
+                  <mi>x</mi>
+                  <mi>i</mi>
+                </msub>
+                <mo>&#x7c;</mo>
+                <mi>i</mi>
+                <mo>&#x2208;</mo>
+                <mi>I</mi>
+                <mo>}</mo>
+              </mrow>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
+      end
+    end
   end
 end


### PR DESCRIPTION
1. Updated vertical bar MathML conversion.
a. closes #144 
2. Added support for explicitly provided parenthesis and exponent expression parenthesis.
a. closes #143 
b. closes #146