### PR TITLE
Tilde MathML representation fix

### DIFF
--- a/lib/plurimath/math/function/tilde.rb
+++ b/lib/plurimath/math/function/tilde.rb
@@ -6,6 +6,12 @@ module Plurimath
   module Math
     module Function
       class Tilde < UnaryFunction
+        def to_mathml_without_math_tag
+          mover = Utility.ox_element("mover")
+          first_value = (Utility.ox_element("mo") << "~")
+          second_value = parameter_one.to_mathml_without_math_tag if parameter_one
+          Utility.update_nodes(mover, [second_value, first_value])
+        end
       end
     end
   end

--- a/spec/plurimath/asciimath_spec.rb
+++ b/spec/plurimath/asciimath_spec.rb
@@ -4197,5 +4197,27 @@ RSpec.describe Plurimath::Asciimath do
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
+
+    context "contains example #79" do
+      let(:string) { 'tilde(x)' }
+
+      it 'returns parsed Asciimath to Formula' do
+        latex = '\tilde{x}'
+        asciimath = 'tilde(x)'
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mover>
+                <mi>x</mi>
+                <mo>~</mo>
+              </mover>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
+      end
+    end
   end
 end

--- a/spec/plurimath/math/function/tilde_spec.rb
+++ b/spec/plurimath/math/function/tilde_spec.rb
@@ -62,11 +62,10 @@ RSpec.describe Plurimath::Math::Function::Tilde do
 
       it "returns mathml string" do
         expected_value = <<~MATHML
-
-          <mrow>
-            <mo>tilde</mo>
+          <mover>
             <mi>n</mi>
-          </mrow>
+            <mo>~</mo>
+          </mover>
         MATHML
         expect(formula).to be_equivalent_to(expected_value)
       end
@@ -77,10 +76,10 @@ RSpec.describe Plurimath::Math::Function::Tilde do
 
       it "returns mathml string" do
         expected_value = <<~MATHML
-          <mrow>
-            <mo>tilde</mo>
+          <mover>
             <mn>70</mn>
-          </mrow>
+            <mo>~</mo>
+          </mover>
         MATHML
         expect(formula).to be_equivalent_to(expected_value)
       end
@@ -97,16 +96,16 @@ RSpec.describe Plurimath::Math::Function::Tilde do
       end
       it "returns mathml string" do
         expected_value = <<~MATHML
-          <mrow>
-            <mo>tilde</mo>
+          <mover>
             <mrow>
               <munderover>
                 <mo>&#x2211;</mo>
-                <mo>&#x26;</mo>
+                <mo>&amp;</mo>
                 <mtext>so</mtext>
               </munderover>
             </mrow>
-          </mrow>
+            <mo>~</mo>
+          </mover>
         MATHML
         expect(formula).to be_equivalent_to(expected_value)
       end


### PR DESCRIPTION
This pull request addresses an issue with the `tilde(x)` example representation in the **AsciiMath** to **MathML** conversion.

closes #150 