### PR TITLE
Added left right delimiters and latex parser/transformation rules

### DIFF
--- a/lib/plurimath/latex/constants.rb
+++ b/lib/plurimath/latex/constants.rb
@@ -3715,6 +3715,8 @@ module Plurimath
       PARENTHESIS = {
         "[" => "]",
         "(" => ")",
+        "\\(" => "\\)",
+        "\\[" => "\\]",
         "\\{" => "\\}",
       }.freeze
       MATRICES_PARENTHESIS = {
@@ -3783,6 +3785,50 @@ module Plurimath
         bmod
         pmod
       ].freeze
+      LEFT_RIGHT_PARENTHESIS = {
+        "\\backslash": "&#x5c;",
+        "\\langle": "&#x27e8;",
+        "\\rangle": "&#x27e9;",
+        "\\lfloor": "&#x230a;",
+        "\\rfloor": "&#x230b;",
+        "\\lceil": "&#x2308;",
+        "\\rceil": "&#x2309;",
+        "\\lbrace": "&#x7b;",
+        "\\rbrace": "&#x7d;",
+        "\\lbrack": "&#x5b;",
+        "\\rbrack": "&#x5d;",
+        "\\Vert": "&#x2016;",
+        "\\vert": "&#x7c;",
+        "\\|": "&#x2016;",
+        "\\}": "}",
+        "\\{": "{",
+        "(": "(",
+        ")": ")",
+        "<": "<",
+        ">": ">",
+        "/": "/",
+        "|": "|",
+        "[": "[",
+        "]": "]",
+      }.freeze
+      SLASHED_SYMBOLS = %w[
+        backslash
+        langle
+        rangle
+        lfloor
+        rfloor
+        lbrace
+        rbrace
+        lbrack
+        rbrack
+        lceil
+        rceil
+        Vert
+        vert
+        |
+        }
+        {
+      ]
     end
   end
 end

--- a/lib/plurimath/latex/transform.rb
+++ b/lib/plurimath/latex/transform.rb
@@ -24,6 +24,8 @@ module Plurimath
       rule(power_base: simple(:power_base)) { power_base }
       rule(table_data: simple(:table_data)) { table_data }
 
+      rule(intermediate_exp: simple(:int_exp)) { int_exp }
+
       rule(numeric_values: simple(:value)) do
         Math::Symbol.new(value)
       end
@@ -72,57 +74,107 @@ module Plurimath
       end
 
       rule(left: simple(:left),
-           lparen: simple(:lparen),
+           left_paren: simple(:lparen),
            expression: sequence(:expr),
            right: simple(:right),
-           rparen: simple(:rparen)) do
+           right_paren: simple(:rparen)) do
         Math::Formula.new(
           [
-            Math::Function::Left.new(lparen),
+            Utility.left_right_objects(lparen, "left"),
             Math::Formula.new(expr),
-            Math::Function::Right.new(rparen),
+            Utility.left_right_objects(rparen, "right"),
           ],
         )
       end
 
       rule(left: simple(:left),
-           lparen: simple(:lparen),
+           left_paren: simple(:lparen),
+           expression: sequence(:expr),
            right: simple(:right)) do
         Math::Formula.new(
           [
-            Math::Function::Left.new(lparen),
+            Utility.left_right_objects(lparen, "left"),
+            Math::Formula.new(expr),
             Math::Function::Right.new,
           ],
         )
       end
 
       rule(left: simple(:left),
-           lparen: simple(:lparen),
-           right: simple(:right),
-           rparen: simple(:rparen)) do
+           left_paren: simple(:lparen),
+           expression: simple(:expr),
+           right: simple(:right)) do
         Math::Formula.new(
           [
-            Math::Function::Left.new(lparen),
-            Math::Function::Right.new(rparen),
+            Utility.left_right_objects(lparen, "left"),
+            expr,
+            Math::Function::Right.new,
           ],
         )
       end
 
       rule(left: simple(:left),
-           lparen: simple(:lparen)) do
-        Math::Function::Left.new(lparen)
+           left_paren: simple(:lparen),
+           right: simple(:right)) do
+        Math::Formula.new(
+          [
+            Utility.left_right_objects(lparen, "left"),
+            Math::Function::Right.new,
+          ],
+        )
       end
 
       rule(left: simple(:left),
-           lparen: simple(:lparen),
-           expression: simple(:expr),
+           left_paren: simple(:lparen),
            right: simple(:right),
-           rparen: simple(:rparen)) do
+           right_paren: simple(:rparen)) do
         Math::Formula.new(
           [
-            Math::Function::Left.new(lparen),
+            Utility.left_right_objects(lparen, "left"),
+            Utility.left_right_objects(rparen, "right"),
+          ],
+        )
+      end
+
+      rule(left: simple(:left),
+           left_paren: simple(:lparen)) do
+        Utility.left_right_objects(lparen, "left")
+      end
+
+      rule(left: simple(:left),
+           left_paren: simple(:lparen),
+           expression: simple(:expr),
+           right: simple(:right),
+           right_paren: simple(:rparen)) do
+        Math::Formula.new(
+          [
+            Utility.left_right_objects(lparen, "left"),
             expr,
-            Math::Function::Right.new(rparen),
+            Utility.left_right_objects(rparen, "right"),
+          ],
+        )
+      end
+
+      rule(left: simple(:left),
+           expression: simple(:expr),
+           right: simple(:right)) do
+        Math::Formula.new(
+          [
+            Math::Function::Left.new,
+            expr,
+            Math::Function::Right.new,
+          ],
+        )
+      end
+
+      rule(left: simple(:left),
+           expression: sequence(:expr),
+           right: simple(:right)) do
+        Math::Formula.new(
+          [
+            Math::Function::Left.new,
+            Math::Formula.new(expr),
+            Math::Function::Right.new,
           ],
         )
       end
@@ -168,14 +220,14 @@ module Plurimath
       end
 
       rule(left: simple(:left),
-           lparen: simple(:lparen),
+           left_paren: simple(:lparen),
            dividend: subtree(:dividend),
            divisor: subtree(:divisor),
            right: simple(:right),
-           rparen: simple(:rparen)) do
+           right_paren: simple(:rparen)) do
         Math::Formula.new(
           [
-            Math::Function::Left.new(lparen),
+            Utility.left_right_objects(lparen, "left"),
             Math::Function::Over.new(
               Math::Formula.new(
                 Array(dividend).flatten,
@@ -184,7 +236,7 @@ module Plurimath
                 Array(divisor).flatten,
               ),
             ),
-            Math::Function::Right.new(rparen),
+            Utility.left_right_objects(rparen, "right"),
           ],
         )
       end
@@ -333,6 +385,14 @@ module Plurimath
         )
       end
 
+      rule(intermediate_exp: simple(:int_exp),
+           supscript: simple(:supscript)) do
+        Math::Function::Power.new(
+          int_exp,
+          supscript,
+        )
+      end
+
       rule(unicode_symbols: simple(:sym),
            subscript: simple(:subscript)) do
         Math::Function::Base.new(
@@ -449,6 +509,26 @@ module Plurimath
            expression: sequence(:expr),
            rparen: simple(:rparen)) do
         Math::Formula.new(expr)
+      end
+
+      rule(left_paren: simple(:lparen),
+           expression: simple(:expr),
+           right_paren: simple(:rparen)) do
+        Math::Function::Fenced.new(
+          lparen,
+          [expr],
+          rparen,
+        )
+      end
+
+      rule(left_paren: simple(:lparen),
+           expression: sequence(:expr),
+           right_paren: simple(:rparen)) do
+        Math::Function::Fenced.new(
+          lparen,
+          expr,
+          rparen,
+        )
       end
 
       rule(expression: sequence(:expr)) do

--- a/lib/plurimath/math/function/fenced.rb
+++ b/lib/plurimath/math/function/fenced.rb
@@ -35,7 +35,7 @@ module Plurimath
           close_paren  = parameter_three ? parameter_three.value : ")"
           first_value  = latex_paren(open_paren, false)
           second_value = latex_paren(close_paren, true)
-          "#{first_value}#{fenced_value}#{second_value}"
+          "#{first_value} #{fenced_value} #{second_value}"
         end
 
         def to_omml_without_math_tag
@@ -96,11 +96,10 @@ module Plurimath
         end
 
         def latex_paren(paren, right)
-          paren_side = right ? "\\right" : "\\left"
-          return "#{paren_side} ." if paren&.include?(":")
+          return "" if paren.nil? || paren.empty?
 
           paren = %w[{ }].include?(paren) ? "\\#{paren}" : paren
-          " #{paren_side} #{paren} "
+          "#{paren}"
         end
 
         def mathml_paren(field)

--- a/lib/plurimath/math/function/left.rb
+++ b/lib/plurimath/math/function/left.rb
@@ -27,8 +27,7 @@ module Plurimath
         end
 
         def to_latex
-          prefix = "\\" if parameter_one == "{"
-          "\\left #{prefix}#{parameter_one}"
+          "\\left #{Latex::Constants::LEFT_RIGHT_PARENTHESIS.invert[parameter_one] || "."}"
         end
 
         protected

--- a/lib/plurimath/math/function/right.rb
+++ b/lib/plurimath/math/function/right.rb
@@ -27,8 +27,7 @@ module Plurimath
         end
 
         def to_latex
-          prefix = "\\" if parameter_one == "}"
-          "\\right #{prefix}#{parameter_one}"
+          "\\right #{Latex::Constants::LEFT_RIGHT_PARENTHESIS.invert[parameter_one] || "."}"
         end
 
         protected

--- a/lib/plurimath/utility.rb
+++ b/lib/plurimath/utility.rb
@@ -407,6 +407,15 @@ module Plurimath
           end
         end
       end
+
+      def left_right_objects(paren, function)
+        paren = if paren.to_s.match?(/\\{|\\}/)
+                  paren.to_s.gsub(/\\/, "")
+                else
+                  Latex::Constants::LEFT_RIGHT_PARENTHESIS[paren.to_sym]
+                end
+        get_class(function).new(paren)
+      end
     end
   end
 end

--- a/spec/plurimath/asciimath_spec.rb
+++ b/spec/plurimath/asciimath_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Plurimath::Asciimath do
       let(:string) { 'cos(2)' }
 
       it 'returns parsed Asciimath to Formula' do
-        latex = '\cos{ \left ( 2 \right ) }'
+        latex = '\cos{( 2 )}'
         asciimath = 'cos(2)'
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
@@ -50,7 +50,7 @@ RSpec.describe Plurimath::Asciimath do
       let(:string) { 'sum_(i=1)^n i^3=((n(n+1))/2)^2' }
 
       it 'returns parsed Asciimath to Formula' do
-        latex = '\sum_{i = 1}^{n} i^{3} =  \left ( \frac{n  \left ( n + 1 \right ) }{2} \right ) ^{2}'
+        latex = '\sum_{i = 1}^{n} i^{3} = ( \frac{n ( n + 1 )}{2} )^{2}'
         asciimath = 'sum_(i = 1)^(n) i^(3) = (frac(n (n + 1))(2))^(2)'
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
@@ -102,7 +102,7 @@ RSpec.describe Plurimath::Asciimath do
       let(:string) { 'unitsml(V*s//A,symbol:V cdot s//A)' }
 
       it 'returns parsed Asciimath to Formula' do
-        latex = 'u n i t s m l  \left ( V \\cdot s / A , s y m b o l : V \\cdot s / A \right ) '
+        latex = 'u n i t s m l ( V \\cdot s / A , s y m b o l : V \\cdot s / A )'
         asciimath = 'u n i t s m l (V * s // A , s y m b o l : V * s // A)'
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
@@ -208,7 +208,7 @@ RSpec.describe Plurimath::Asciimath do
       let(:string) { 'int_0^1f(x)dx' }
 
       it 'returns parsed Asciimath to Formula' do
-        latex = '\int_{0}^{1} f \left ( x \right )  d x'
+        latex = '\int_{0}^{1} f( x ) d x'
         asciimath = 'int_(0)^(1) f(x) d x'
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
@@ -472,7 +472,7 @@ RSpec.describe Plurimath::Asciimath do
       let(:string) { '12mod1234(i)' }
 
       it 'returns parsed Asciimath to Formula' do
-        latex = '{12} \mod {1234}  \left ( i \right ) '
+        latex = '{12} \mod {1234} ( i )'
         asciimath = '12 mod 1234 (i)'
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
@@ -522,7 +522,7 @@ RSpec.describe Plurimath::Asciimath do
       let(:string) { 'log(1+2+3+4)^text("theta")' }
 
       it 'returns parsed Asciimath to Formula' do
-        latex = '\log  \left ( 1 + 2 + 3 + 4 \right ) ^{\text{"theta"}}'
+        latex = '\log ( 1 + 2 + 3 + 4 )^{\text{"theta"}}'
         asciimath = 'log (1 + 2 + 3 + 4)^(""theta"")'
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
@@ -555,7 +555,7 @@ RSpec.describe Plurimath::Asciimath do
       let(:string) { 'sum_(i=1)^ni^3=sin((n(n+1))/2)^2' }
 
       it 'returns parsed Asciimath to Formula' do
-        latex = '\sum_{i = 1}^{n} i^{3} = \sin{ \left ( \frac{n  \left ( n + 1 \right ) }{2} \right ) }^{2}'
+        latex = '\sum_{i = 1}^{n} i^{3} = \sin{( \frac{n ( n + 1 )}{2} )}^{2}'
         asciimath = 'sum_(i = 1)^(n) i^(3) = sin(frac(n (n + 1))(2))^(2)'
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
@@ -610,7 +610,7 @@ RSpec.describe Plurimath::Asciimath do
       let(:string) { 'int_0^1 f(x)dx' }
 
       it 'returns parsed Asciimath to Formula' do
-        latex = '\int_{0}^{1} f \left ( x \right )  d x'
+        latex = '\int_{0}^{1} f( x ) d x'
         asciimath = 'int_(0)^(1) f(x) d x'
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
@@ -645,7 +645,7 @@ RSpec.describe Plurimath::Asciimath do
       let(:string) { 'mathfrak"theta" (i)' }
 
       it 'returns parsed Asciimath to Formula' do
-        latex = '\mathfrak{\text{theta}}  \left ( i \right ) '
+        latex = '\mathfrak{\text{theta}} ( i )'
         asciimath = 'mathfrak("theta") (i)'
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
@@ -671,7 +671,7 @@ RSpec.describe Plurimath::Asciimath do
       let(:string) { 'mathbb("theta") (i)' }
 
       it 'returns parsed Asciimath to Formula' do
-        latex = '\mathbb{\text{theta}}  \left ( i \right ) '
+        latex = '\mathbb{\text{theta}} ( i )'
         asciimath = 'mathbb("theta") (i)'
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
@@ -849,7 +849,7 @@ RSpec.describe Plurimath::Asciimath do
       let(:string) { 'underset(_)(hat A)(^) = hat A exp j vartheta_0' }
 
       it 'returns parsed Asciimath to Formula' do
-        latex = '\underset{\_}{\hat{A}}  \left ( ^ \right )  = \hat{A} \exp{j} \vartheta_{0}'
+        latex = '\underset{\_}{\hat{A}} ( ^ ) = \hat{A} \exp{j} \vartheta_{0}'
         asciimath = 'underset(_)(hat(A)) (^) = hat(A) expj vartheta_(0)'
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
@@ -998,7 +998,7 @@ RSpec.describe Plurimath::Asciimath do
       let(:string) { 'd/dx [x^n] = nx^(n - 1)' }
 
       it 'returns parsed Asciimath to Formula' do
-        latex = '\frac{d}{d x}  \left [ x^{n} \right ]  = n x^{n - 1}'
+        latex = '\frac{d}{d x} [ x^{n} ] = n x^{n - 1}'
         asciimath = 'frac(d)(d x) [x^(n)] = n x^(n - 1)'
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
@@ -1544,7 +1544,7 @@ RSpec.describe Plurimath::Asciimath do
       let(:string) { '{ x\ : \ x in A ^^ x in B }' }
 
       it 'returns parsed Asciimath to Formula' do
-        latex = ' \left \{ x \  : \  x \in A \land x \in B \right \} '
+        latex = '\\{ x \\  : \\  x \\in A \\land x \\in B \\}'
         asciimath = '{x \  : \  x in A ^^ x in B}'
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
@@ -1677,7 +1677,7 @@ RSpec.describe Plurimath::Asciimath do
       let(:string) { 'ii(V)(ii(X)) = (b-a)^2/12 + d^2/9.' }
 
       it 'returns parsed Asciimath to Formula' do
-        latex = '\mathit{V}  \left ( \mathit{X} \right )  = \frac{ \left ( b - a \right ) ^{2}}{12} + \frac{d^{2}}{9} .'
+        latex = '\mathit{V} ( \mathit{X} ) = \frac{( b - a )^{2}}{12} + \frac{d^{2}}{9} .'
         asciimath = 'ii(V) (ii(X)) = frac((b - a)^(2))(12) + frac(d^(2))(9) .'
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
@@ -1786,7 +1786,7 @@ RSpec.describe Plurimath::Asciimath do
       let(:string) { 'u(w_("cal")) = w_("cal") *sqrt([(u(m_("stock")))/m_("stock")]^2 +[(u(b_("stock")))/b_("stock")]^2 +[(u(w_("stock")))/w_("stock")]^2 +[(u(m_("sol")))/m_("sol")]^2 +[(u(b_("sol")))/b_("sol")]^2 +2*[(u(ii(V)))/ii(V)]^2)' }
 
       it 'returns parsed Asciimath to Formula' do
-        latex = 'u  \left ( w_{\text{cal}} \right )  = w_{\text{cal}} \cdot \sqrt{ \left [ \frac{u  \left ( m_{\text{stock}} \right ) }{m_{\text{stock}}} \right ] ^{2} +  \left [ \frac{u  \left ( b_{\text{stock}} \right ) }{b_{\text{stock}}} \right ] ^{2} +  \left [ \frac{u  \left ( w_{\text{stock}} \right ) }{w_{\text{stock}}} \right ] ^{2} +  \left [ \frac{u  \left ( m_{\text{sol}} \right ) }{m_{\text{sol}}} \right ] ^{2} +  \left [ \frac{u  \left ( b_{\text{sol}} \right ) }{b_{\text{sol}}} \right ] ^{2} + 2 \cdot  \left [ \frac{u  \left ( \mathit{V} \right ) }{\mathit{V}} \right ] ^{2}}'
+        latex = 'u ( w_{\text{cal}} ) = w_{\text{cal}} \cdot \sqrt{[ \frac{u ( m_{\text{stock}} )}{m_{\text{stock}}} ]^{2} + [ \frac{u ( b_{\text{stock}} )}{b_{\text{stock}}} ]^{2} + [ \frac{u ( w_{\text{stock}} )}{w_{\text{stock}}} ]^{2} + [ \frac{u ( m_{\text{sol}} )}{m_{\text{sol}}} ]^{2} + [ \frac{u ( b_{\text{sol}} )}{b_{\text{sol}}} ]^{2} + 2 \cdot [ \frac{u ( \mathit{V} )}{\mathit{V}} ]^{2}}'
         asciimath = 'u (w_("cal")) = w_("cal") * sqrt([frac(u (m_("stock")))(m_("stock"))]^(2) + [frac(u (b_("stock")))(b_("stock"))]^(2) + [frac(u (w_("stock")))(w_("stock"))]^(2) + [frac(u (m_("sol")))(m_("sol"))]^(2) + [frac(u (b_("sol")))(b_("sol"))]^(2) + 2 * [frac(u (ii(V)))(ii(V))]^(2))'
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
@@ -1972,7 +1972,7 @@ RSpec.describe Plurimath::Asciimath do
       let(:string) { '1 "unitsml(A)" = ( ((4pi xx 10^(-7)))/((9192631770)(299792458)(1)) )^(1/2) ( (Delta ii(nu)_("Cs")cm_(cc K))/(ii(mu)_0) )^(1/2) = 6.789687... xx 10^(-13) ((Delta ii(nu)_("Cs")c m_(cc K))/(ii(mu)_0))^(1/2)' }
 
       it 'returns parsed Asciimath to Formula' do
-        latex = '1 \text{unitsml(A)} =  \left ( \frac{\left (\begin{matrix}4 \pi \times 10^{- 7}\end{matrix}\right )}{ \left ( 9192631770 \right )   \left ( 299792458 \right )   \left ( 1 \right ) } \right ) ^{\frac{1}{2}}  \left ( \frac{\Delta \mathit{\nu}_{\text{Cs}} c m_{\mathcal{K}}}{\mathit{\mu}_{0}} \right ) ^{\frac{1}{2}} = 6.789687 \ldots \times 10^{- 13}  \left ( \frac{\Delta \mathit{\nu}_{\text{Cs}} c m_{\mathcal{K}}}{\mathit{\mu}_{0}} \right ) ^{\frac{1}{2}}'
+        latex = '1 \text{unitsml(A)} = ( \frac{\left (\begin{matrix}4 \pi \times 10^{- 7}\end{matrix}\right )}{( 9192631770 ) ( 299792458 ) ( 1 )} )^{\frac{1}{2}} ( \frac{\Delta \mathit{\nu}_{\text{Cs}} c m_{\mathcal{K}}}{\mathit{\mu}_{0}} )^{\frac{1}{2}} = 6.789687 \ldots \times 10^{- 13} ( \frac{\Delta \mathit{\nu}_{\text{Cs}} c m_{\mathcal{K}}}{\mathit{\mu}_{0}} )^{\frac{1}{2}}'
         asciimath = '1 "unitsml(A)" = (frac(([4 pi xx 10^(- 7)]))((9192631770) (299792458) (1)))^(frac(1)(2)) (frac(Delta ii(nu)_("Cs") c m_(mathcal(K)))(ii(mu)_(0)))^(frac(1)(2)) = 6.789687 ... xx 10^(- 13) (frac(Delta ii(nu)_("Cs") c m_(mathcal(K)))(ii(mu)_(0)))^(frac(1)(2))'
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
@@ -2121,7 +2121,7 @@ RSpec.describe Plurimath::Asciimath do
       let(:string) { '""_rZZ_n = sum_(j=1)^n (-1)^j j^r, " with " r = 1,2,...,' }
 
       it 'returns parsed Asciimath to Formula' do
-        latex = '\text{}_{r} \mathbb{Z}_{n} = \sum_{j = 1}^{n}  \left ( - 1 \right ) ^{j} j^{r} ,  \text{ with } r = 1 , 2 , \ldots ,'
+        latex = '\text{}_{r} \mathbb{Z}_{n} = \sum_{j = 1}^{n} ( - 1 )^{j} j^{r} ,  \text{ with } r = 1 , 2 , \ldots ,'
         asciimath = '""_(r) mathbb(Z)_(n) = sum_(j = 1)^(n) (- 1)^(j) j^(r) ,  " with " r = 1 , 2 , ... ,'
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
@@ -2182,7 +2182,7 @@ RSpec.describe Plurimath::Asciimath do
       let(:string) { '(ii(T)_1+ii(T)_2-a_1-a_2)*f(t) = {(0,pour,{(0&#x3c;t&#x3c;a_(-)),("ou "t&#x3e;ii(T)_(-)+a_2):}),(1,"''",{(a_(-)&#x3c;t&#x3c;a_+","),(ii(T)_1-a_1&#x3c;t&#x3c;ii(T)_(-)),("ou "ii(T)_1&#x3c;t&#x3c;ii(T)_(-)+a_2):}),(2,"''",a_+&#x3c;t&#x3c;ii(T)_1-a_1),((ii(T)_3-ii(T)_(-)+a_1)*delta(t-ii(T)_1),pour,t=ii(T)_1),((ii(T)_1-ii(T)_4)*delta(t-ii(T)_2),"''",t=ii(T)_2","):}' }
 
       it 'returns parsed Asciimath to Formula' do
-        latex = ' \left ( \mathit{T}_{1} + \mathit{T}_{2} - a_{1} - a_{2} \right )  \cdot f \left ( t \right )  = \left \{\begin{matrix}0 & p o u r & \left \{\begin{matrix}0 \& \# x 3 c ; t \& \# x 3 c ; a_{-} \\\\ \text{ou } t \& \# x 3 e ; \mathit{T}_{-} + a_{2}\end{matrix}\right  . \\\\ 1 & \text{} & \left \{\begin{matrix}a_{-} \& \# x 3 c ; t \& \# x 3 c ; a_{+} \text{,} \\\\ \mathit{T}_{1} - a_{1} \& \# x 3 c ; t \& \# x 3 c ; \mathit{T}_{-} \\\\ \text{ou } \mathit{T}_{1} \& \# x 3 c ; t \& \# x 3 c ; \mathit{T}_{-} + a_{2}\end{matrix}\right  . \\\\ 2 & \text{} & a_{+} \& \# x 3 c ; t \& \# x 3 c ; \mathit{T}_{1} - a_{1} \\\\  \left ( \mathit{T}_{3} - \mathit{T}_{-} + a_{1} \right )  \cdot \delta  \left ( t - \mathit{T}_{1} \right )  & p o u r & t = \mathit{T}_{1} \\\\  \left ( \mathit{T}_{1} - \mathit{T}_{4} \right )  \cdot \delta  \left ( t - \mathit{T}_{2} \right )  & \text{} & t = \mathit{T}_{2} \text{,}\end{matrix}\right  .'
+        latex = '( \mathit{T}_{1} + \mathit{T}_{2} - a_{1} - a_{2} ) \cdot f( t ) = \left \{\begin{matrix}0 & p o u r & \left \{\begin{matrix}0 \& \# x 3 c ; t \& \# x 3 c ; a_{-} \\\\ \text{ou } t \& \# x 3 e ; \mathit{T}_{-} + a_{2}\end{matrix}\right  . \\\\ 1 & \text{} & \left \{\begin{matrix}a_{-} \& \# x 3 c ; t \& \# x 3 c ; a_{+} \text{,} \\\\ \mathit{T}_{1} - a_{1} \& \# x 3 c ; t \& \# x 3 c ; \mathit{T}_{-} \\\\ \text{ou } \mathit{T}_{1} \& \# x 3 c ; t \& \# x 3 c ; \mathit{T}_{-} + a_{2}\end{matrix}\right  . \\\\ 2 & \text{} & a_{+} \& \# x 3 c ; t \& \# x 3 c ; \mathit{T}_{1} - a_{1} \\\\ ( \mathit{T}_{3} - \mathit{T}_{-} + a_{1} ) \cdot \delta ( t - \mathit{T}_{1} ) & p o u r & t = \mathit{T}_{1} \\\\ ( \mathit{T}_{1} - \mathit{T}_{4} ) \cdot \delta ( t - \mathit{T}_{2} ) & \text{} & t = \mathit{T}_{2} \text{,}\end{matrix}\right  .'
         asciimath = '(ii(T)_(1) + ii(T)_(2) - a_(1) - a_(2)) * f(t) = {[0, p o u r, {[0 & # x 3 c ; t & # x 3 c ; a_(-)], ["ou " t & # x 3 e ; ii(T)_(-) + a_(2)]:}], [1, "", {[a_(-) & # x 3 c ; t & # x 3 c ; a_(+) ","], [ii(T)_(1) - a_(1) & # x 3 c ; t & # x 3 c ; ii(T)_(-)], ["ou " ii(T)_(1) & # x 3 c ; t & # x 3 c ; ii(T)_(-) + a_(2)]:}], [2, "", a_(+) & # x 3 c ; t & # x 3 c ; ii(T)_(1) - a_(1)], [(ii(T)_(3) - ii(T)_(-) + a_(1)) * delta (t - ii(T)_(1)), p o u r, t = ii(T)_(1)], [(ii(T)_(1) - ii(T)_(4)) * delta (t - ii(T)_(2)), "", t = ii(T)_(2) ","]:}'
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
@@ -2674,7 +2674,7 @@ RSpec.describe Plurimath::Asciimath do
       let(:string) { 'H_s(z)=(1-A(ztext(/)overset(~)(gamma)))/(1-A(ztext(/)overset(~)(gamma)))(1+mu z^(-1)), text( with ) 0&#x3c;overset(~)(gamma)_1&#x3c;overset(~)(gamma)_2&#x3c;=1' }
 
       it 'returns parsed Asciimath to Formula' do
-        latex = 'H_{s}  \left ( z \right )  = \frac{1 - A  \left ( z \text{/} \overset{\sptilde}{\gamma} \right ) }{1 - A  \left ( z \text{/} \overset{\sptilde}{\gamma} \right ) }  \left ( 1 + \mu z^{- 1} \right )  ,  \text{ with } 0 \& \# x 3 c ; \overset{\sptilde}{\gamma}_{1} \& \# x 3 c ; \overset{\sptilde}{\gamma}_{2} \& \# x 3 c ; = 1'
+        latex = 'H_{s} ( z ) = \frac{1 - A ( z \text{/} \overset{\sptilde}{\gamma} )}{1 - A ( z \text{/} \overset{\sptilde}{\gamma} )} ( 1 + \mu z^{- 1} ) ,  \text{ with } 0 \& \# x 3 c ; \overset{\sptilde}{\gamma}_{1} \& \# x 3 c ; \overset{\sptilde}{\gamma}_{2} \& \# x 3 c ; = 1'
         asciimath = 'H_(s) (z) = frac(1 - A (z "/" overset(~)(gamma)))(1 - A (z "/" overset(~)(gamma))) (1 + mu z^(- 1)) ,  " with " 0 & # x 3 c ; overset(~)(gamma)_(1) & # x 3 c ; overset(~)(gamma)_(2) & # x 3 c ; = 1'
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
@@ -2789,7 +2789,7 @@ RSpec.describe Plurimath::Asciimath do
       let(:string) { '&lt; &lt; mode, &lt; s(ag) &gt; &gt;, s' }
 
       it 'returns parsed Asciimath to Formula' do
-        latex = '\& < ; \& < {;} \mod {e} ,  \& < ; s  \left ( a g \right )  \& > ; \& > ; ,  s'
+        latex = '\& < ; \& < {;} \mod {e} ,  \& < ; s ( a g ) \& > ; \& > ; ,  s'
         asciimath = '& lt ; & lt ; mod e ,  & lt ; s (a g) & gt ; & gt ; ,  s'
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
@@ -2838,7 +2838,7 @@ RSpec.describe Plurimath::Asciimath do
       let(:string) { '{:(u^2(delta y), = {:[({partial f}/{partial ii(X)_1})^2 u^2(x_1) +({partial f}/{partial ii(X)_2})^2 u^2(x_2) +2 {partial f}/{partial ii(X)_1} {partial f}/{partial ii(X)_2} r(x_1,x_2)u(x_1)u(x_2)]|_{bb(X)=bb(x)}),(" ",= 4x_1^2 u^2 (x_1) + 4x_2^2 u^2 (x_2) + 8r(x_1,x_2) x_1 x_2 u(x_1) u(x_2).):}' }
 
       it 'returns parsed Asciimath to Formula' do
-        latex = '\left . \left ( u^{2}  \left ( \delta y \right )  ,  = \left . \left [  \left ( \frac{\partial f}{\partial \mathit{X}_{1}} \right ) ^{2} u^{2}  \left ( x_{1} \right )  +  \left ( \frac{\partial f}{\partial \mathit{X}_{2}} \right ) ^{2} u^{2}  \left ( x_{2} \right )  + 2 \frac{\partial f}{\partial \mathit{X}_{1}} \frac{\partial f}{\partial \mathit{X}_{2}} r  \left ( x_{1 ,} x_{2} \right )  u  \left ( x_{1} \right )  u  \left ( x_{2} \right )  \right ]  |_{\mathbf{X} = \mathbf{x}} \right )  ,  \left ( \text{ } , = 4 x_{1}^{2} u^{2}  \left ( x_{1} \right )  + 4 x_{2}^{2} u^{2}  \left ( x_{2} \right )  + 8 r  \left ( x_{1 ,} x_{2} \right )  x_{1} x_{2} u  \left ( x_{1} \right )  u  \left ( x_{2} \right )  . \right )   \right   \right  '
+        latex = '{: ( u^{2} ( \delta y ) ,  = {: [ ( \frac{\partial f}{\partial \mathit{X}_{1}} )^{2} u^{2} ( x_{1} ) + ( \frac{\partial f}{\partial \mathit{X}_{2}} )^{2} u^{2} ( x_{2} ) + 2 \frac{\partial f}{\partial \mathit{X}_{1}} \frac{\partial f}{\partial \mathit{X}_{2}} r ( x_{1 ,} x_{2} ) u ( x_{1} ) u ( x_{2} ) ] |_{\mathbf{X} = \mathbf{x}} ) , ( \text{ } , = 4 x_{1}^{2} u^{2} ( x_{1} ) + 4 x_{2}^{2} u^{2} ( x_{2} ) + 8 r ( x_{1 ,} x_{2} ) x_{1} x_{2} u ( x_{1} ) u ( x_{2} ) . )   '
         asciimath = '{:(u^(2) (delta y) ,  = {:[(frac(del f)(del ii(X)_(1)))^(2) u^(2) (x_(1)) + (frac(del f)(del ii(X)_(2)))^(2) u^(2) (x_(2)) + 2 frac(del f)(del ii(X)_(1)) frac(del f)(del ii(X)_(2)) r (x_(1 ,) x_(2)) u (x_(1)) u (x_(2))] |_(mathbf(X) = mathbf(x))) , (" " , = 4 x_(1)^(2) u^(2) (x_(1)) + 4 x_(2)^(2) u^(2) (x_(2)) + 8 r (x_(1 ,) x_(2)) x_(1) x_(2) u (x_(1)) u (x_(2)) .) :}'
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
@@ -3130,7 +3130,7 @@ RSpec.describe Plurimath::Asciimath do
       let(:string) { 'u^2(delta y) = {:[({partial f}/{partial ii(X)_1})^2 u^2(x_1) + ({partial f}/{partial ii(X)_2})^2]|_{bb(X)=bb(x)} = 4 x_1^2 u^2 (x_1) + 4 x_2^2 u^2 (x_2),' }
 
       it 'returns parsed Asciimath to Formula' do
-        latex = 'u^{2}  \left ( \delta y \right )  = \left . \left [  \left ( \frac{\partial f}{\partial \mathit{X}_{1}} \right ) ^{2} u^{2}  \left ( x_{1} \right )  +  \left ( \frac{\partial f}{\partial \mathit{X}_{2}} \right ) ^{2} \right ]  |_{\mathbf{X} = \mathbf{x}} = 4 x_{1}^{2} u^{2}  \left ( x_{1} \right )  + 4 x_{2}^{2} u^{2}  \left ( x_{2} \right )  , \right  '
+        latex = 'u^{2} ( \delta y ) = {: [ ( \frac{\partial f}{\partial \mathit{X}_{1}} )^{2} u^{2} ( x_{1} ) + ( \frac{\partial f}{\partial \mathit{X}_{2}} )^{2} ] |_{\mathbf{X} = \mathbf{x}} = 4 x_{1}^{2} u^{2} ( x_{1} ) + 4 x_{2}^{2} u^{2} ( x_{2} ) , '
         asciimath = 'u^(2) (delta y) = {:[(frac(del f)(del ii(X)_(1)))^(2) u^(2) (x_(1)) + (frac(del f)(del ii(X)_(2)))^(2)] |_(mathbf(X) = mathbf(x)) = 4 x_(1)^(2) u^(2) (x_(1)) + 4 x_(2)^(2) u^(2) (x_(2)) ,'
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
@@ -3279,7 +3279,7 @@ RSpec.describe Plurimath::Asciimath do
       let(:string) { 'lambda_1 = {|:(b_1 - a_1) - (b_2 - a_2):|}/2, " " " " lambda_2 = {b - a}/2,' }
 
       it 'returns parsed Asciimath to Formula' do
-        latex = '\lambda_{1} = \frac{|  \left ( b_{1} - a_{1} \right )  -  \left ( b_{2} - a_{2} \right )  |}{2} ,  \text{ } \text{ } \lambda_{2} = \frac{b - a}{2} ,'
+        latex = '\lambda_{1} = \frac{| ( b_{1} - a_{1} ) - ( b_{2} - a_{2} ) |}{2} ,  \text{ } \text{ } \lambda_{2} = \frac{b - a}{2} ,'
         asciimath = 'lambda_(1) = frac(| (b_(1) - a_(1)) - (b_(2) - a_(2)) |)(2) ,  " " " " lambda_(2) = frac(b - a)(2) ,'
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
@@ -3357,7 +3357,7 @@ RSpec.describe Plurimath::Asciimath do
       let(:string) { 'ii(E)(ii(X)) = {a + b}/2, "    " ii(V)(ii(X)) = {(b - a)^2}/12' }
 
       it 'returns parsed Asciimath to Formula' do
-        latex = '\mathit{E}  \left ( \mathit{X} \right )  = \frac{a + b}{2} ,  \text{    } \mathit{V}  \left ( \mathit{X} \right )  = \frac{ \left ( b - a \right ) ^{2}}{12}'
+        latex = '\mathit{E} ( \mathit{X} ) = \frac{a + b}{2} ,  \text{    } \mathit{V} ( \mathit{X} ) = \frac{( b - a )^{2}}{12}'
         asciimath = 'ii(E) (ii(X)) = frac(a + b)(2) ,  "    " ii(V) (ii(X)) = frac((b - a)^(2))(12)'
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
@@ -3422,7 +3422,7 @@ RSpec.describe Plurimath::Asciimath do
       let(:string) { 'i_j = (a_j xx i_j) mod d_j' }
 
       it 'returns parsed Asciimath to Formula' do
-        latex = 'i_{j} = { \left ( a_{j} \times i_{j} \right ) } \mod {d_{j}}'
+        latex = 'i_{j} = {( a_{j} \times i_{j} )} \mod {d_{j}}'
         asciimath = 'i_(j) = (a_(j) xx i_(j)) mod d_(j)'
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
@@ -3465,7 +3465,7 @@ RSpec.describe Plurimath::Asciimath do
       let(:string) { 'i_j = a_j xx (i_j mod b_j) - c_j xx floor(i_j//b_j)' }
 
       it 'returns parsed Asciimath to Formula' do
-        latex = 'i_{j} = a_{j} \times  \left ( {i_{j}} \mod {b_{j}} \right )  - c_{j} \times \lfloor i_{j} / b_{j} \rfloor'
+        latex = 'i_{j} = a_{j} \times ( {i_{j}} \mod {b_{j}} ) - c_{j} \times \lfloor i_{j} / b_{j} \rfloor'
         asciimath = 'i_(j) = a_(j) xx (i_(j) mod b_(j)) - c_(j) xx floor(i_(j) // b_(j))'
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
@@ -3529,7 +3529,7 @@ RSpec.describe Plurimath::Asciimath do
       let(:string) { '[(x_1),(x_2)], " " [(u^2(x_1),ru(x_1)u(x_2)),(ru(x_1)u(x_2),u^2(x_2))].' }
 
       it 'returns parsed Asciimath to Formula' do
-        latex = '\left [\begin{matrix}x_{1} \\\\ x_{2}\end{matrix}\right ] ,  \text{ } \left [\begin{matrix}u^{2}  \left ( x_{1} \right )  & r u  \left ( x_{1} \right )  u  \left ( x_{2} \right )  \\\\ r u  \left ( x_{1} \right )  u  \left ( x_{2} \right )  & u^{2}  \left ( x_{2} \right ) \end{matrix}\right ] .'
+        latex = '\left [\begin{matrix}x_{1} \\\\ x_{2}\end{matrix}\right ] ,  \text{ } \left [\begin{matrix}u^{2} ( x_{1} ) & r u ( x_{1} ) u ( x_{2} ) \\\\ r u ( x_{1} ) u ( x_{2} ) & u^{2} ( x_{2} )\end{matrix}\right ] .'
         asciimath = '[[x_(1)], [x_(2)]] ,  " " [[u^(2) (x_(1)), r u (x_(1)) u (x_(2))], [r u (x_(1)) u (x_(2)), u^(2) (x_(2))]] .'
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
@@ -3654,7 +3654,7 @@ RSpec.describe Plurimath::Asciimath do
       let(:string) { '1 + (ii(rho)_a - ii(rho)_a_0 )(1//ii(rho)_W - 1//ii(rho)_R)' }
 
       it 'returns parsed Asciimath to Formula' do
-        latex = '1 +  \left ( \mathit{\rho}_{a} - \mathit{\rho}_{a}_{0} \right )   \left ( 1 / \mathit{\rho}_{W} - 1 / \mathit{\rho}_{R} \right ) '
+        latex = '1 + ( \mathit{\rho}_{a} - \mathit{\rho}_{a}_{0} ) ( 1 / \mathit{\rho}_{W} - 1 / \mathit{\rho}_{R} )'
         asciimath = '1 + (ii(rho)_(a) - ii(rho)_(a)_(0)) (1 // ii(rho)_(W) - 1 // ii(rho)_(R))'
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
@@ -3715,7 +3715,7 @@ RSpec.describe Plurimath::Asciimath do
       let(:string) { "f'(x) = dy/dx" }
 
       it 'returns parsed Asciimath to Formula' do
-        latex = "f\\prime  \\left ( x \\right )  = d \\frac{y}{d x}"
+        latex = "f\\prime ( x ) = d \\frac{y}{d x}"
         asciimath = "f' (x) = d frac(y)(d x)"
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
@@ -3921,7 +3921,7 @@ RSpec.describe Plurimath::Asciimath do
       let(:string) { 'n_"S"("X") = m_"S" // ii(M)("X"), " and " ii(M)(""X"") = ii(A)_"r"("X") "unitsml(g/mol)"' }
 
       it 'returns parsed Asciimath to Formula' do
-        latex = 'n_{\text{S}}  \left ( \text{X} \right )  = m_{\text{S}} / \mathit{M}  \left ( \text{X} \right )  ,  \text{ and } \mathit{M}  \left ( \text{} X \text{} \right )  = \mathit{A}_{\text{r}}  \left ( \text{X} \right )  \text{unitsml(g/mol)}'
+        latex = 'n_{\text{S}} ( \text{X} ) = m_{\text{S}} / \mathit{M} ( \text{X} ) ,  \text{ and } \mathit{M} ( \text{} X \text{} ) = \mathit{A}_{\text{r}} ( \text{X} ) \text{unitsml(g/mol)}'
         asciimath = 'n_("S") ("X") = m_("S") // ii(M) ("X") ,  " and " ii(M) ("" X "") = ii(A)_("r") ("X") "unitsml(g/mol)"'
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
@@ -4114,7 +4114,7 @@ RSpec.describe Plurimath::Asciimath do
       let(:string) { '{x_i | i in I}' }
 
       it 'returns parsed Asciimath to Formula' do
-        latex = ' \left \{ x_{i} | i \in I \right \} '
+        latex = '\{ x_{i} | i \in I \}'
         asciimath = '{x_(i) | i in I}'
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
@@ -4144,7 +4144,7 @@ RSpec.describe Plurimath::Asciimath do
       let(:string) { '"H"_nu^((1))(z)' }
 
       it 'returns parsed Asciimath to Formula' do
-        latex = '\text{H}_{\nu}^{ \left ( 1 \right ) }  \left ( z \right ) '
+        latex = '\text{H}_{\nu}^{( 1 )} ( z )'
         asciimath = '"H"_(nu)^((1)) (z)'
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
@@ -4176,7 +4176,7 @@ RSpec.describe Plurimath::Asciimath do
       let(:string) { '(a)_n' }
 
       it 'returns parsed Asciimath to Formula' do
-        latex = ' \left ( a \right ) _{n}'
+        latex = '( a )_{n}'
         asciimath = '(a)_(n)'
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">

--- a/spec/plurimath/latex/latexmath_aggregator_spec.rb
+++ b/spec/plurimath/latex/latexmath_aggregator_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Plurimath::Latex::Parser do
       it "returns formula" do
         expected_value = Plurimath::Math::Formula.new([
           Plurimath::Math::Formula.new([
-            Plurimath::Math::Function::Left.new("\\{"),
+            Plurimath::Math::Function::Left.new("{"),
             Plurimath::Math::Function::Right.new
           ]),
         ])
@@ -103,7 +103,7 @@ RSpec.describe Plurimath::Latex::Parser do
       it "returns formula" do
         expected_value = Plurimath::Math::Formula.new([
           Plurimath::Math::Formula.new([
-            Plurimath::Math::Function::Left.new("\\{"),
+            Plurimath::Math::Function::Left.new("{"),
             Plurimath::Math::Function::Table::Array.new(
               [
                 Plurimath::Math::Function::Tr.new([
@@ -164,7 +164,7 @@ RSpec.describe Plurimath::Latex::Parser do
               nil,
               nil,
             ),
-            Plurimath::Math::Function::Right.new("\\}")
+            Plurimath::Math::Function::Right.new("}")
           ])
         ])
         expect(formula).to eq(expected_value)
@@ -565,15 +565,17 @@ RSpec.describe Plurimath::Latex::Parser do
       it "returns formula" do
         expected_value = Plurimath::Math::Formula.new([
           Plurimath::Math::Function::Sqrt.new(
-            Plurimath::Math::Formula.new([
-              Plurimath::Math::Symbol.new("("),
-              Plurimath::Math::Symbol.new("-"),
-              Plurimath::Math::Number.new("25"),
-              Plurimath::Math::Function::Power.new(
+            Plurimath::Math::Function::Power.new(
+              Plurimath::Math::Function::Fenced.new(
+                Plurimath::Math::Symbol.new("("),
+                [
+                  Plurimath::Math::Symbol.new("-"),
+                  Plurimath::Math::Number.new("25"),
+                ],
                 Plurimath::Math::Symbol.new(")"),
-                Plurimath::Math::Number.new("2")
-              )
-            ]),
+              ),
+              Plurimath::Math::Number.new("2"),
+            )
           ),
           Plurimath::Math::Symbol.new("="),
           Plurimath::Math::Symbol.new("&#xb1;"),
@@ -1269,9 +1271,13 @@ RSpec.describe Plurimath::Latex::Parser do
             ])
           ),
           Plurimath::Math::Symbol.new("f"),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Symbol.new("x"),
-          Plurimath::Math::Symbol.new(")"),
+          Plurimath::Math::Function::Fenced.new(
+            Plurimath::Math::Symbol.new("("),
+            [
+              Plurimath::Math::Symbol.new("x"),
+            ],
+            Plurimath::Math::Symbol.new(")"),
+          )
         ])
         expect(formula).to eq(expected_value)
       end
@@ -1289,9 +1295,13 @@ RSpec.describe Plurimath::Latex::Parser do
             ])
           ),
           Plurimath::Math::Symbol.new("f"),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Symbol.new("x"),
-          Plurimath::Math::Symbol.new(")"),
+          Plurimath::Math::Function::Fenced.new(
+            Plurimath::Math::Symbol.new("("),
+            [
+              Plurimath::Math::Symbol.new("x"),
+            ],
+            Plurimath::Math::Symbol.new(")"),
+          )
         ])
         expect(formula).to eq(expected_value)
       end
@@ -1313,9 +1323,13 @@ RSpec.describe Plurimath::Latex::Parser do
             ])
           ),
           Plurimath::Math::Symbol.new("f"),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Symbol.new("x"),
-          Plurimath::Math::Symbol.new(")"),
+          Plurimath::Math::Function::Fenced.new(
+            Plurimath::Math::Symbol.new("("),
+            [
+              Plurimath::Math::Symbol.new("x"),
+            ],
+            Plurimath::Math::Symbol.new(")"),
+          ),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -1330,17 +1344,25 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Formula.new([
               Plurimath::Math::Symbol.new("x"),
               Plurimath::Math::Symbol.new("&#x2208;"),
-              Plurimath::Math::Symbol.new("["),
-              Plurimath::Math::Symbol.new("a"),
-              Plurimath::Math::Symbol.new(","),
-              Plurimath::Math::Symbol.new("b"),
-              Plurimath::Math::Symbol.new("]")
+              Plurimath::Math::Function::Fenced.new(
+                Plurimath::Math::Symbol.new("\\["),
+                [
+                  Plurimath::Math::Symbol.new("a"),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new("b"),
+                ],
+                Plurimath::Math::Symbol.new("\\]")
+              )
             ])
           ),
           Plurimath::Math::Symbol.new("f"),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Symbol.new("x"),
-          Plurimath::Math::Symbol.new(")"),
+          Plurimath::Math::Function::Fenced.new(
+            Plurimath::Math::Symbol.new("("),
+            [
+              Plurimath::Math::Symbol.new("x"),
+            ],
+            Plurimath::Math::Symbol.new(")"),
+          )
         ])
         expect(formula).to eq(expected_value)
       end
@@ -1355,17 +1377,25 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Formula.new([
               Plurimath::Math::Symbol.new("x"),
               Plurimath::Math::Symbol.new("&#x2208;"),
-              Plurimath::Math::Symbol.new("["),
-              Plurimath::Math::Symbol.new("&#x3b1;"),
-              Plurimath::Math::Symbol.new(","),
-              Plurimath::Math::Symbol.new("&#x3b2;"),
-              Plurimath::Math::Symbol.new("]")
+              Plurimath::Math::Function::Fenced.new(
+                Plurimath::Math::Symbol.new("\\["),
+                [
+                  Plurimath::Math::Symbol.new("&#x3b1;"),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new("&#x3b2;"),
+                ],
+                Plurimath::Math::Symbol.new("\\]"),
+              )
             ])
           ),
           Plurimath::Math::Symbol.new("f"),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Symbol.new("x"),
-          Plurimath::Math::Symbol.new(")"),
+          Plurimath::Math::Function::Fenced.new(
+            Plurimath::Math::Symbol.new("("),
+            [
+              Plurimath::Math::Symbol.new("x"),
+            ],
+            Plurimath::Math::Symbol.new(")"),
+          )
         ])
         expect(formula).to eq(expected_value)
       end
@@ -1434,18 +1464,26 @@ RSpec.describe Plurimath::Latex::Parser do
       let(:string) { "(1+(x-y)^{2})" }
       it "returns formula" do
         expected_value = Plurimath::Math::Formula.new([
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Number.new("1"),
-          Plurimath::Math::Symbol.new("+"),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Symbol.new("x"),
-          Plurimath::Math::Symbol.new("-"),
-          Plurimath::Math::Symbol.new("y"),
-          Plurimath::Math::Function::Power.new(
+          Plurimath::Math::Function::Fenced.new(
+            Plurimath::Math::Symbol.new("("),
+            [
+              Plurimath::Math::Number.new("1"),
+              Plurimath::Math::Symbol.new("+"),
+              Plurimath::Math::Function::Power.new(
+                Plurimath::Math::Function::Fenced.new(
+                  Plurimath::Math::Symbol.new("("),
+                  [
+                    Plurimath::Math::Symbol.new("x"),
+                    Plurimath::Math::Symbol.new("-"),
+                    Plurimath::Math::Symbol.new("y")
+                  ],
+                  Plurimath::Math::Symbol.new(")"),
+                ),
+                Plurimath::Math::Number.new("2"),
+              ),
+            ],
             Plurimath::Math::Symbol.new(")"),
-            Plurimath::Math::Number.new("2"),
-          ),
-          Plurimath::Math::Symbol.new(")"),
+          )
         ])
         expect(formula).to eq(expected_value)
       end

--- a/spec/plurimath/latex/metanorma_examples_spec.rb
+++ b/spec/plurimath/latex/metanorma_examples_spec.rb
@@ -214,9 +214,13 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Symbol.new("I"),
             Plurimath::Math::Symbol.new("p")
           ),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Symbol.new("z"),
-          Plurimath::Math::Symbol.new(")"),
+          Plurimath::Math::Function::Fenced.new(
+            Plurimath::Math::Symbol.new("("),
+            [
+              Plurimath::Math::Symbol.new("z"),
+            ],
+            Plurimath::Math::Symbol.new(")"),
+          ),
           Plurimath::Math::Symbol.new("="),
           Plurimath::Math::Symbol.new("K"),
           Plurimath::Math::Symbol.new("+"),

--- a/spec/plurimath/latex/parse_spec.rb
+++ b/spec/plurimath/latex/parse_spec.rb
@@ -48,11 +48,11 @@ RSpec.describe Plurimath::Latex::Parse do
         left_right = formula[:left_right]
         expression = left_right[:expression]
 
-        expect(left_right[:lparen]).to eq("(")
+        expect(left_right[:left_paren]).to eq("(")
         expect(expression[:sequence][:symbols]).to eq("beta")
         expect(left_right[:expression][:expression][:sequence][:symbols]).to eq("slash")
         expect(left_right[:expression][:expression][:expression][:expression][:symbols]).to eq("t")
-        expect(left_right[:rparen]).to eq(")")
+        expect(left_right[:right_paren]).to eq(")")
       end
     end
 
@@ -374,14 +374,14 @@ RSpec.describe Plurimath::Latex::Parse do
         environment = formula[:environment]
         table_data = formula[:environment][:table_data]
         expression = table_data[:sequence][:binary][:intermediate_exp][:expression]
-        power_base = expression[:expression][:expression][:expression][:power_base]
+        power_base = expression[:power][:intermediate_exp]
 
         expect(environment[:environment]).to eq("Vmatrix")
         expect(table_data[:sequence][:binary][:sqrt]).to eq("sqrt")
-        expect(expression[:expression][:sequence][:operant]).to eq("-")
-        expect(expression[:expression][:expression][:sequence][:number]).to eq("25")
-        expect(power_base[:rparen]).to eq(")")
-        expect(power_base[:supscript][:expression][:number]).to eq("2")
+        expect(power_base[:expression][:sequence][:operant]).to eq("-")
+        expect(power_base[:expression][:expression][:number]).to eq("25")
+        expect(power_base[:right_paren][:rparen]).to eq(")")
+        expect(expression[:power][:supscript][:expression][:number]).to eq("2")
         expect(environment[:ending][:environment]).to eq("Vmatrix")
       end
     end
@@ -418,8 +418,9 @@ RSpec.describe Plurimath::Latex::Parse do
         expect(expression[:expression][:sequence][:operant]).to eq("+")
         expect(expression[:expression][:expression][:symbols]).to eq("infty")
         expect(formula[:expression][:sequence][:symbols]).to eq("f")
-        expect(formula[:expression][:expression][:expression][:sequence][:symbols]).to eq("x")
-        expect(formula[:expression][:expression][:expression][:expression][:rparen]).to eq(")")
+        expect(formula[:expression][:expression][:intermediate_exp][:left_paren][:lparen]).to eq("(")
+        expect(formula[:expression][:expression][:intermediate_exp][:expression][:symbols]).to eq("x")
+        expect(formula[:expression][:expression][:intermediate_exp][:right_paren][:rparen]).to eq(")")
       end
     end
 
@@ -436,7 +437,7 @@ RSpec.describe Plurimath::Latex::Parse do
         sequence = environment[:table_data][:sequence]
         expression = environment[:table_data][:expression][:expression]
 
-        expect(formula[:left_right][:lparen]).to eq("(")
+        expect(formula[:left_right][:left_paren]).to eq("(")
         expect(environment[:environment]).to eq("array")
         expect(environment[:args][:symbols]).to eq("c")
         expect(sequence[:base][:symbols]).to eq("V")

--- a/spec/plurimath/latex/parser_spec.rb
+++ b/spec/plurimath/latex/parser_spec.rb
@@ -709,15 +709,17 @@ RSpec.describe Plurimath::Latex::Parser do
               Plurimath::Math::Function::Tr.new([
                 Plurimath::Math::Function::Td.new([
                   Plurimath::Math::Function::Sqrt.new(
-                    Plurimath::Math::Formula.new([
-                      Plurimath::Math::Symbol.new("("),
-                      Plurimath::Math::Symbol.new("-"),
-                      Plurimath::Math::Number.new("25"),
-                      Plurimath::Math::Function::Power.new(
+                    Plurimath::Math::Function::Power.new(
+                      Plurimath::Math::Function::Fenced.new(
+                        Plurimath::Math::Symbol.new("("),
+                        [
+                          Plurimath::Math::Symbol.new("-"),
+                          Plurimath::Math::Number.new("25"),
+                        ],
                         Plurimath::Math::Symbol.new(")"),
-                        Plurimath::Math::Number.new("2"),
                       ),
-                    ]),
+                      Plurimath::Math::Number.new("2"),
+                    ),
                   ),
                   Plurimath::Math::Symbol.new("="),
                   Plurimath::Math::Symbol.new("&#xb1;"),
@@ -786,9 +788,13 @@ RSpec.describe Plurimath::Latex::Parser do
             ]),
           ),
           Plurimath::Math::Symbol.new("f"),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Symbol.new("x"),
-          Plurimath::Math::Symbol.new(")"),
+          Plurimath::Math::Function::Fenced.new(
+            Plurimath::Math::Symbol.new("("),
+            [
+              Plurimath::Math::Symbol.new("x"),
+            ],
+            Plurimath::Math::Symbol.new(")"),
+          )
         ])
         expect(formula).to eq(expected_value)
       end
@@ -851,12 +857,16 @@ RSpec.describe Plurimath::Latex::Parser do
       it "returns formula" do
         expected_value = Plurimath::Math::Formula.new([
           Plurimath::Math::Function::Mbox.new(
-            Plurimath::Math::Symbol.new("("),
+            Plurimath::Math::Function::Fenced.new(
+              Plurimath::Math::Symbol.new("("),
+              [
+                Plurimath::Math::Symbol.new("a"),
+                Plurimath::Math::Symbol.new("+"),
+                Plurimath::Math::Symbol.new("b"),
+              ],
+              Plurimath::Math::Symbol.new(")"),
+            ),
           ),
-          Plurimath::Math::Symbol.new("a"),
-          Plurimath::Math::Symbol.new("+"),
-          Plurimath::Math::Symbol.new("b"),
-          Plurimath::Math::Symbol.new(")"),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -1141,18 +1151,22 @@ RSpec.describe Plurimath::Latex::Parser do
           ),
           Plurimath::Math::Symbol.new("="),
           Plurimath::Math::Symbol.new("&#x222b;"),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Function::Vec.new(
-            Plurimath::Math::Symbol.new("r")
+          Plurimath::Math::Function::Fenced.new(
+            Plurimath::Math::Symbol.new("("),
+            [
+              Plurimath::Math::Function::Vec.new(
+                Plurimath::Math::Symbol.new("r")
+              ),
+              Plurimath::Math::Symbol.new("-"),
+              Plurimath::Math::Function::Base.new(
+                Plurimath::Math::Function::Vec.new(
+                  Plurimath::Math::Symbol.new("r")
+                ),
+                Plurimath::Math::Number.new("0")
+              ),
+            ],
+            Plurimath::Math::Symbol.new(")"),
           ),
-          Plurimath::Math::Symbol.new("-"),
-          Plurimath::Math::Function::Base.new(
-            Plurimath::Math::Function::Vec.new(
-              Plurimath::Math::Symbol.new("r")
-            ),
-            Plurimath::Math::Number.new("0")
-          ),
-          Plurimath::Math::Symbol.new(")"),
           Plurimath::Math::Symbol.new("&#xd7;"),
           Plurimath::Math::Function::Vec.new(
             Plurimath::Math::Symbol.new("f")
@@ -1283,18 +1297,22 @@ RSpec.describe Plurimath::Latex::Parser do
           ),
           Plurimath::Math::Symbol.new("="),
           Plurimath::Math::Symbol.new("&#x222b;"),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Function::Vec.new(
-            Plurimath::Math::Symbol.new("r")
+          Plurimath::Math::Function::Fenced.new(
+            Plurimath::Math::Symbol.new("("),
+            [
+              Plurimath::Math::Function::Vec.new(
+                Plurimath::Math::Symbol.new("r")
+              ),
+              Plurimath::Math::Symbol.new("-"),
+              Plurimath::Math::Function::Base.new(
+                Plurimath::Math::Function::Vec.new(
+                  Plurimath::Math::Symbol.new("r")
+                ),
+                Plurimath::Math::Number.new("0")
+              ),
+            ],
+            Plurimath::Math::Symbol.new(")"),
           ),
-          Plurimath::Math::Symbol.new("-"),
-          Plurimath::Math::Function::Base.new(
-            Plurimath::Math::Function::Vec.new(
-              Plurimath::Math::Symbol.new("r")
-            ),
-            Plurimath::Math::Number.new("0")
-          ),
-          Plurimath::Math::Symbol.new(")"),
           Plurimath::Math::Symbol.new("&#xd7;"),
           Plurimath::Math::Function::Vec.new(
             Plurimath::Math::Symbol.new("f")
@@ -2761,36 +2779,40 @@ RSpec.describe Plurimath::Latex::Parser do
               Plurimath::Math::Symbol.new("l")
             ])
           ),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Symbol.new("&#x394;"),
-          Plurimath::Math::Function::Base.new(
-            Plurimath::Math::Symbol.new("&#x03b5;"),
-            Plurimath::Math::Formula.new([
-              Plurimath::Math::Symbol.new("k"),
-              Plurimath::Math::Symbol.new("l")
-            ])
+          Plurimath::Math::Function::Fenced.new(
+            Plurimath::Math::Symbol.new("("),
+            [
+              Plurimath::Math::Symbol.new("&#x394;"),
+              Plurimath::Math::Function::Base.new(
+                Plurimath::Math::Symbol.new("&#x03b5;"),
+                Plurimath::Math::Formula.new([
+                  Plurimath::Math::Symbol.new("k"),
+                  Plurimath::Math::Symbol.new("l")
+                ])
+              ),
+              Plurimath::Math::Symbol.new("-"),
+              Plurimath::Math::Function::Base.new(
+                Plurimath::Math::Symbol.new("&#x3b1;"),
+                Plurimath::Math::Formula.new([
+                  Plurimath::Math::Symbol.new("k"),
+                  Plurimath::Math::Symbol.new("l")
+                ])
+              ),
+              Plurimath::Math::Symbol.new("&#x394;"),
+              Plurimath::Math::Symbol.new("T"),
+              Plurimath::Math::Symbol.new("-"),
+              Plurimath::Math::Function::Base.new(
+                Plurimath::Math::Symbol.new("&#x3b2;"),
+                Plurimath::Math::Formula.new([
+                  Plurimath::Math::Symbol.new("k"),
+                  Plurimath::Math::Symbol.new("l")
+                ])
+              ),
+              Plurimath::Math::Symbol.new("&#x394;"),
+              Plurimath::Math::Symbol.new("M"),
+            ],
+            Plurimath::Math::Symbol.new(")"),
           ),
-          Plurimath::Math::Symbol.new("-"),
-          Plurimath::Math::Function::Base.new(
-            Plurimath::Math::Symbol.new("&#x3b1;"),
-            Plurimath::Math::Formula.new([
-              Plurimath::Math::Symbol.new("k"),
-              Plurimath::Math::Symbol.new("l")
-            ])
-          ),
-          Plurimath::Math::Symbol.new("&#x394;"),
-          Plurimath::Math::Symbol.new("T"),
-          Plurimath::Math::Symbol.new("-"),
-          Plurimath::Math::Function::Base.new(
-            Plurimath::Math::Symbol.new("&#x3b2;"),
-            Plurimath::Math::Formula.new([
-              Plurimath::Math::Symbol.new("k"),
-              Plurimath::Math::Symbol.new("l")
-            ])
-          ),
-          Plurimath::Math::Symbol.new("&#x394;"),
-          Plurimath::Math::Symbol.new("M"),
-          Plurimath::Math::Symbol.new(")"),
           Plurimath::Math::Symbol.new("&#x3b;"),
           Plurimath::Math::Formula.new([
             Plurimath::Math::Function::FontStyle::Normal.new(
@@ -2841,11 +2863,15 @@ RSpec.describe Plurimath::Latex::Parser do
               Plurimath::Math::Symbol.new("E"),
               Plurimath::Math::Formula.new([
                 Plurimath::Math::Number.new("2"),
-                Plurimath::Math::Symbol.new("("),
-                Plurimath::Math::Number.new("1"),
-                Plurimath::Math::Symbol.new("+"),
-                Plurimath::Math::Symbol.new("&#x3bd;"),
-                Plurimath::Math::Symbol.new(")"),
+                Plurimath::Math::Function::Fenced.new(
+                  Plurimath::Math::Symbol.new("("),
+                  [
+                    Plurimath::Math::Number.new("1"),
+                    Plurimath::Math::Symbol.new("+"),
+                    Plurimath::Math::Symbol.new("&#x3bd;"),
+                  ],
+                  Plurimath::Math::Symbol.new(")"),
+                ),
               ]),
             ),
             "displaystyle",
@@ -2985,11 +3011,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Function::Tr.new([
                   Plurimath::Math::Function::Td.new(
                     [
-                      Plurimath::Math::Symbol.new("["),
-                      Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::Fenced.new(
+                        Plurimath::Math::Symbol.new("["),
+                        [
+                          Plurimath::Math::Number.new("3"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                        ],
+                        Plurimath::Math::Symbol.new("]"),
+                      ),
                     ],
                     { columnalign: "center" }
                   ),
@@ -3063,11 +3093,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Function::Tr.new([
                   Plurimath::Math::Function::Td.new(
                     [
-                      Plurimath::Math::Symbol.new("["),
-                      Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::Fenced.new(
+                        Plurimath::Math::Symbol.new("["),
+                        [
+                          Plurimath::Math::Number.new("3"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                        ],
+                        Plurimath::Math::Symbol.new("]"),
+                      ),
                     ],
                     { columnalign: "center" }
                   ),
@@ -3121,11 +3155,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Function::Tr.new([
                   Plurimath::Math::Function::Td.new(
                     [
-                      Plurimath::Math::Symbol.new("["),
-                      Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::Fenced.new(
+                        Plurimath::Math::Symbol.new("["),
+                        [
+                          Plurimath::Math::Number.new("3"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                        ],
+                        Plurimath::Math::Symbol.new("]"),
+                      )
                     ],
                     { columnalign: "center" }
                   ),
@@ -3158,11 +3196,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Function::Tr.new([
                   Plurimath::Math::Function::Td.new(
                     [
-                      Plurimath::Math::Symbol.new("["),
-                      Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::Fenced.new(
+                        Plurimath::Math::Symbol.new("["),
+                        [
+                          Plurimath::Math::Number.new("3"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                        ],
+                        Plurimath::Math::Symbol.new("]"),
+                      )
                     ],
                     { columnalign: "center" }
                   ),
@@ -3227,11 +3269,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Function::Tr.new([
                   Plurimath::Math::Function::Td.new(
                     [
-                      Plurimath::Math::Symbol.new("["),
-                      Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::Fenced.new(
+                        Plurimath::Math::Symbol.new("["),
+                        [
+                          Plurimath::Math::Number.new("3"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                        ],
+                        Plurimath::Math::Symbol.new("]"),
+                      ),
                     ],
                     { columnalign: "center" }
                   ),
@@ -3383,11 +3429,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Function::Tr.new([
                   Plurimath::Math::Function::Td.new(
                     [
-                      Plurimath::Math::Symbol.new("["),
-                      Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::Fenced.new(
+                        Plurimath::Math::Symbol.new("["),
+                        [
+                          Plurimath::Math::Number.new("3"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                        ],
+                        Plurimath::Math::Symbol.new("]"),
+                      ),
                     ],
                     { columnalign: "center" }
                   ),
@@ -3443,11 +3493,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Function::Tr.new([
                   Plurimath::Math::Function::Td.new(
                     [
-                      Plurimath::Math::Symbol.new("["),
-                      Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::Fenced.new(
+                        Plurimath::Math::Symbol.new("["),
+                        [
+                          Plurimath::Math::Number.new("3"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                        ],
+                        Plurimath::Math::Symbol.new("]"),
+                      ),
                     ],
                     { columnalign: "center" }
                   ),
@@ -3483,11 +3537,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Function::Tr.new([
                   Plurimath::Math::Function::Td.new(
                     [
-                      Plurimath::Math::Symbol.new("["),
-                      Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::Fenced.new(
+                        Plurimath::Math::Symbol.new("["),
+                        [
+                          Plurimath::Math::Number.new("3"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                        ],
+                        Plurimath::Math::Symbol.new("]"),
+                      ),
                     ],
                     { columnalign: "center" }
                   ),
@@ -3520,11 +3578,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Function::Tr.new([
                   Plurimath::Math::Function::Td.new(
                     [
-                      Plurimath::Math::Symbol.new("["),
-                      Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::Fenced.new(
+                        Plurimath::Math::Symbol.new("["),
+                        [
+                          Plurimath::Math::Number.new("3"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                        ],
+                        Plurimath::Math::Symbol.new("]"),
+                      ),
                     ],
                     { columnalign: "center" }
                   ),
@@ -3571,11 +3633,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Function::Tr.new([
                   Plurimath::Math::Function::Td.new(
                     [
-                      Plurimath::Math::Symbol.new("["),
-                      Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::Fenced.new(
+                        Plurimath::Math::Symbol.new("["),
+                        [
+                          Plurimath::Math::Number.new("3"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                        ],
+                        Plurimath::Math::Symbol.new("]"),
+                      ),
                     ],
                     { columnalign: "center" }
                   ),
@@ -3638,17 +3704,21 @@ RSpec.describe Plurimath::Latex::Parser do
               ),
               Plurimath::Math::Formula.new([
                 Plurimath::Math::Number.new("2"),
-                Plurimath::Math::Symbol.new("("),
-                Plurimath::Math::Number.new("1"),
-                Plurimath::Math::Symbol.new("+"),
-                Plurimath::Math::Function::Base.new(
-                  Plurimath::Math::Symbol.new("&#x3bd;"),
-                  Plurimath::Math::Formula.new([
-                    Plurimath::Math::Symbol.new("t"),
-                    Plurimath::Math::Symbol.new("t")
-                  ])
-                ),
-                Plurimath::Math::Symbol.new(")")
+                Plurimath::Math::Function::Fenced.new(
+                  Plurimath::Math::Symbol.new("("),
+                  [
+                    Plurimath::Math::Number.new("1"),
+                    Plurimath::Math::Symbol.new("+"),
+                    Plurimath::Math::Function::Base.new(
+                      Plurimath::Math::Symbol.new("&#x3bd;"),
+                      Plurimath::Math::Formula.new([
+                        Plurimath::Math::Symbol.new("t"),
+                        Plurimath::Math::Symbol.new("t")
+                      ])
+                    ),
+                  ],
+                  Plurimath::Math::Symbol.new(")")
+                )
               ])
             ),
             "displaystyle"
@@ -3789,11 +3859,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Function::Tr.new([
                   Plurimath::Math::Function::Td.new(
                     [
-                      Plurimath::Math::Symbol.new("["),
-                      Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::Fenced.new(
+                        Plurimath::Math::Symbol.new("["),
+                        [
+                          Plurimath::Math::Number.new("3"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                        ],
+                        Plurimath::Math::Symbol.new("]"),
+                      ),
                     ],
                     { columnalign: "center" }
                   ),
@@ -3858,11 +3932,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Function::Tr.new([
                   Plurimath::Math::Function::Td.new(
                     [
-                      Plurimath::Math::Symbol.new("["),
-                      Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::Fenced.new(
+                        Plurimath::Math::Symbol.new("["),
+                        [
+                          Plurimath::Math::Number.new("3"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                        ],
+                        Plurimath::Math::Symbol.new("]"),
+                      ),
                     ],
                     { columnalign: "center" }
                   ),
@@ -3901,11 +3979,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Function::Tr.new([
                   Plurimath::Math::Function::Td.new(
                     [
-                      Plurimath::Math::Symbol.new("["),
-                      Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::Fenced.new(
+                        Plurimath::Math::Symbol.new("["),
+                        [
+                          Plurimath::Math::Number.new("3"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                        ],
+                        Plurimath::Math::Symbol.new("]"),
+                      ),
                     ],
                     { columnalign: "center" }
                   ),
@@ -3941,11 +4023,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Function::Tr.new([
                   Plurimath::Math::Function::Td.new(
                     [
-                      Plurimath::Math::Symbol.new("["),
-                      Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::Fenced.new(
+                        Plurimath::Math::Symbol.new("["),
+                        [
+                          Plurimath::Math::Number.new("3"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                        ],
+                        Plurimath::Math::Symbol.new("]"),
+                      )
                     ],
                     { columnalign: "center" }
                   ),
@@ -3995,11 +4081,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Function::Tr.new([
                   Plurimath::Math::Function::Td.new(
                     [
-                      Plurimath::Math::Symbol.new("["),
-                      Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::Fenced.new(
+                        Plurimath::Math::Symbol.new("["),
+                        [
+                          Plurimath::Math::Number.new("3"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                        ],
+                        Plurimath::Math::Symbol.new("]"),
+                      ),
                     ],
                     { columnalign: "center" }
                   ),
@@ -4169,11 +4259,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Function::Tr.new([
                   Plurimath::Math::Function::Td.new(
                     [
-                      Plurimath::Math::Symbol.new("["),
-                      Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::Fenced.new(
+                        Plurimath::Math::Symbol.new("["),
+                        [
+                          Plurimath::Math::Number.new("3"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                        ],
+                        Plurimath::Math::Symbol.new("]"),
+                      ),
                     ],
                     { columnalign: "center" }
                   ),
@@ -4238,11 +4332,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Function::Tr.new([
                   Plurimath::Math::Function::Td.new(
                     [
-                      Plurimath::Math::Symbol.new("["),
-                      Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::Fenced.new(
+                        Plurimath::Math::Symbol.new("["),
+                        [
+                          Plurimath::Math::Number.new("3"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                        ],
+                        Plurimath::Math::Symbol.new("]"),
+                      ),
                     ],
                     { columnalign: "center" }
                   ),
@@ -4281,11 +4379,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Function::Tr.new([
                   Plurimath::Math::Function::Td.new(
                     [
-                      Plurimath::Math::Symbol.new("["),
-                      Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::Fenced.new(
+                        Plurimath::Math::Symbol.new("["),
+                        [
+                          Plurimath::Math::Number.new("3"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                        ],
+                        Plurimath::Math::Symbol.new("]"),
+                      ),
                     ],
                     { columnalign: "center" }
                   ),
@@ -4321,11 +4423,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Function::Tr.new([
                   Plurimath::Math::Function::Td.new(
                     [
-                      Plurimath::Math::Symbol.new("["),
-                      Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::Fenced.new(
+                        Plurimath::Math::Symbol.new("["),
+                        [
+                          Plurimath::Math::Number.new("3"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                        ],
+                        Plurimath::Math::Symbol.new("]"),
+                      ),
                     ],
                     { columnalign: "center" }
                   ),
@@ -4375,11 +4481,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Function::Tr.new([
                   Plurimath::Math::Function::Td.new(
                     [
-                      Plurimath::Math::Symbol.new("["),
-                      Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::Fenced.new(
+                        Plurimath::Math::Symbol.new("["),
+                        [
+                          Plurimath::Math::Number.new("3"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                        ],
+                        Plurimath::Math::Symbol.new("]"),
+                      )
                     ],
                     { columnalign: "center" }
                   ),
@@ -4518,11 +4628,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Function::Tr.new([
                   Plurimath::Math::Function::Td.new(
                     [
-                      Plurimath::Math::Symbol.new("["),
-                      Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::Fenced.new(
+                        Plurimath::Math::Symbol.new("["),
+                        [
+                          Plurimath::Math::Number.new("3"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                        ],
+                        Plurimath::Math::Symbol.new("]"),
+                      ),
                     ],
                     { columnalign: "center" }
                   ),
@@ -4569,11 +4683,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Function::Tr.new([
                   Plurimath::Math::Function::Td.new(
                     [
-                      Plurimath::Math::Symbol.new("["),
-                      Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::Fenced.new(
+                        Plurimath::Math::Symbol.new("["),
+                        [
+                          Plurimath::Math::Number.new("3"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                        ],
+                        Plurimath::Math::Symbol.new("]"),
+                      ),
                     ],
                     { columnalign: "center" }
                   ),
@@ -4606,11 +4724,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Function::Tr.new([
                   Plurimath::Math::Function::Td.new(
                     [
-                      Plurimath::Math::Symbol.new("["),
-                      Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::Fenced.new(
+                        Plurimath::Math::Symbol.new("["),
+                        [
+                          Plurimath::Math::Number.new("3"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                        ],
+                        Plurimath::Math::Symbol.new("]"),
+                      ),
                     ],
                     { columnalign: "center" }
                   ),
@@ -4640,11 +4762,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Function::Tr.new([
                   Plurimath::Math::Function::Td.new(
                     [
-                      Plurimath::Math::Symbol.new("["),
-                      Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::Fenced.new(
+                        Plurimath::Math::Symbol.new("["),
+                        [
+                          Plurimath::Math::Number.new("3"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                        ],
+                        Plurimath::Math::Symbol.new("]"),
+                      ),
                     ],
                     { columnalign: "center" }
                   ),
@@ -4688,11 +4814,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Function::Tr.new([
                   Plurimath::Math::Function::Td.new(
                     [
-                      Plurimath::Math::Symbol.new("["),
-                      Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::Fenced.new(
+                        Plurimath::Math::Symbol.new("["),
+                        [
+                          Plurimath::Math::Number.new("3"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                        ],
+                        Plurimath::Math::Symbol.new("]"),
+                      ),
                     ],
                     { columnalign: "center" }
                   ),
@@ -4856,24 +4986,28 @@ RSpec.describe Plurimath::Latex::Parser do
               Plurimath::Math::Symbol.new("j")
             ])
           ),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Function::Base.new(
-            Plurimath::Math::Symbol.new("E"),
-            Plurimath::Math::Symbol.new("j")
+          Plurimath::Math::Function::Fenced.new(
+            Plurimath::Math::Symbol.new("("),
+            [
+              Plurimath::Math::Function::Base.new(
+                Plurimath::Math::Symbol.new("E"),
+                Plurimath::Math::Symbol.new("j")
+              ),
+              Plurimath::Math::Symbol.new("-"),
+              Plurimath::Math::Function::PowerBase.new(
+                Plurimath::Math::Symbol.new("E"),
+                Plurimath::Math::Symbol.new("j"),
+                Plurimath::Math::Symbol.new("T")
+              ),
+              Plurimath::Math::Symbol.new("-"),
+              Plurimath::Math::Function::PowerBase.new(
+                Plurimath::Math::Symbol.new("E"),
+                Plurimath::Math::Symbol.new("j"),
+                Plurimath::Math::Symbol.new("M")
+              ),
+            ],
+            Plurimath::Math::Symbol.new(")"),
           ),
-          Plurimath::Math::Symbol.new("-"),
-          Plurimath::Math::Function::PowerBase.new(
-            Plurimath::Math::Symbol.new("E"),
-            Plurimath::Math::Symbol.new("j"),
-            Plurimath::Math::Symbol.new("T")
-          ),
-          Plurimath::Math::Symbol.new("-"),
-          Plurimath::Math::Function::PowerBase.new(
-            Plurimath::Math::Symbol.new("E"),
-            Plurimath::Math::Symbol.new("j"),
-            Plurimath::Math::Symbol.new("M")
-          ),
-          Plurimath::Math::Symbol.new(")"),
           Plurimath::Math::Symbol.new("&#x3b;"),
           Plurimath::Math::Formula.new([
             Plurimath::Math::Function::FontStyle::Normal.new(
@@ -5685,17 +5819,21 @@ RSpec.describe Plurimath::Latex::Parser do
                     Plurimath::Math::Symbol.new("="),
                     Plurimath::Math::Symbol.new("p"),
                     Plurimath::Math::Symbol.new("/"),
-                    Plurimath::Math::Symbol.new("("),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("&#x3c1;"),
-                      Plurimath::Math::Symbol.new("&#x221e;")
+                    Plurimath::Math::Function::Fenced.new(
+                      Plurimath::Math::Symbol.new("("),
+                      [
+                        Plurimath::Math::Function::Base.new(
+                          Plurimath::Math::Symbol.new("&#x3c1;"),
+                          Plurimath::Math::Symbol.new("&#x221e;")
+                        ),
+                        Plurimath::Math::Function::PowerBase.new(
+                          Plurimath::Math::Symbol.new("c"),
+                          Plurimath::Math::Symbol.new("&#x221e;"),
+                          Plurimath::Math::Number.new("2")
+                        ),
+                      ],
+                      Plurimath::Math::Symbol.new(")"),
                     ),
-                    Plurimath::Math::Function::PowerBase.new(
-                      Plurimath::Math::Symbol.new("c"),
-                      Plurimath::Math::Symbol.new("&#x221e;"),
-                      Plurimath::Math::Number.new("2")
-                    ),
-                    Plurimath::Math::Symbol.new(")"),
                     Plurimath::Math::Symbol.new(","),
                   ],
                   { columnalign: "center" }
@@ -5783,11 +5921,15 @@ RSpec.describe Plurimath::Latex::Parser do
           Plurimath::Math::Symbol.new("="),
           Plurimath::Math::Symbol.new("u"),
           Plurimath::Math::Symbol.new("/"),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Symbol.new("L"),
-          Plurimath::Math::Symbol.new("/"),
-          Plurimath::Math::Symbol.new("T"),
-          Plurimath::Math::Symbol.new(")"),
+          Plurimath::Math::Function::Fenced.new(
+            Plurimath::Math::Symbol.new("("),
+            [
+              Plurimath::Math::Symbol.new("L"),
+              Plurimath::Math::Symbol.new("/"),
+              Plurimath::Math::Symbol.new("T"),
+            ],
+            Plurimath::Math::Symbol.new(")"),
+          ),
           Plurimath::Math::Symbol.new(","),
           Plurimath::Math::Symbol.new("&"),
           Plurimath::Math::Symbol.new("&#x3c1;"),
@@ -5795,14 +5937,18 @@ RSpec.describe Plurimath::Latex::Parser do
           Plurimath::Math::Symbol.new("="),
           Plurimath::Math::Symbol.new("&#x3c1;"),
           Plurimath::Math::Symbol.new("/"),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Symbol.new("M"),
-          Plurimath::Math::Symbol.new("/"),
-          Plurimath::Math::Function::Power.new(
-            Plurimath::Math::Symbol.new("L"),
-            Plurimath::Math::Number.new("3")
+          Plurimath::Math::Function::Fenced.new(
+            Plurimath::Math::Symbol.new("("),
+            [
+              Plurimath::Math::Symbol.new("M"),
+              Plurimath::Math::Symbol.new("/"),
+              Plurimath::Math::Function::Power.new(
+                Plurimath::Math::Symbol.new("L"),
+                Plurimath::Math::Number.new("3")
+              ),
+            ],
+            Plurimath::Math::Symbol.new(")"),
           ),
-          Plurimath::Math::Symbol.new(")"),
           Plurimath::Math::Symbol.new(","),
           Plurimath::Math::Symbol.new("\\\\"),
           Plurimath::Math::Symbol.new("y"),
@@ -5818,11 +5964,15 @@ RSpec.describe Plurimath::Latex::Parser do
           Plurimath::Math::Symbol.new("="),
           Plurimath::Math::Symbol.new("v"),
           Plurimath::Math::Symbol.new("/"),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Symbol.new("L"),
-          Plurimath::Math::Symbol.new("/"),
-          Plurimath::Math::Symbol.new("T"),
-          Plurimath::Math::Symbol.new(")"),
+          Plurimath::Math::Function::Fenced.new(
+            Plurimath::Math::Symbol.new("("),
+            [
+              Plurimath::Math::Symbol.new("L"),
+              Plurimath::Math::Symbol.new("/"),
+              Plurimath::Math::Symbol.new("T"),
+            ],
+            Plurimath::Math::Symbol.new(")"),
+          ),
           Plurimath::Math::Symbol.new(","),
           Plurimath::Math::Symbol.new("&"),
           Plurimath::Math::Symbol.new("p"),
@@ -5830,17 +5980,25 @@ RSpec.describe Plurimath::Latex::Parser do
           Plurimath::Math::Symbol.new("="),
           Plurimath::Math::Symbol.new("p"),
           Plurimath::Math::Symbol.new("/"),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Symbol.new("M"),
-          Plurimath::Math::Symbol.new("/"),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Symbol.new("L"),
-          Plurimath::Math::Function::Power.new(
-            Plurimath::Math::Symbol.new("T"),
-            Plurimath::Math::Number.new("2")
+          Plurimath::Math::Function::Fenced.new(
+            Plurimath::Math::Symbol.new("("),
+            [
+              Plurimath::Math::Symbol.new("M"),
+              Plurimath::Math::Symbol.new("/"),
+              Plurimath::Math::Function::Fenced.new(
+                Plurimath::Math::Symbol.new("("),
+                [
+                  Plurimath::Math::Symbol.new("L"),
+                  Plurimath::Math::Function::Power.new(
+                    Plurimath::Math::Symbol.new("T"),
+                    Plurimath::Math::Number.new("2")
+                  ),
+                ],
+                Plurimath::Math::Symbol.new(")"),
+              ),
+            ],
+            Plurimath::Math::Symbol.new(")"),
           ),
-          Plurimath::Math::Symbol.new(")"),
-          Plurimath::Math::Symbol.new(")"),
           Plurimath::Math::Symbol.new(","),
           Plurimath::Math::Symbol.new("\\\\"),
           Plurimath::Math::Symbol.new("z"),
@@ -5857,11 +6015,15 @@ RSpec.describe Plurimath::Latex::Parser do
           Plurimath::Math::Symbol.new("="),
           Plurimath::Math::Symbol.new("w"),
           Plurimath::Math::Symbol.new("/"),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Symbol.new("L"),
-          Plurimath::Math::Symbol.new("/"),
-          Plurimath::Math::Symbol.new("T"),
-          Plurimath::Math::Symbol.new(")"),
+          Plurimath::Math::Function::Fenced.new(
+            Plurimath::Math::Symbol.new("("),
+            [
+              Plurimath::Math::Symbol.new("L"),
+              Plurimath::Math::Symbol.new("/"),
+              Plurimath::Math::Symbol.new("T"),
+            ],
+            Plurimath::Math::Symbol.new(")"),
+          ),
           Plurimath::Math::Symbol.new(","),
           Plurimath::Math::Symbol.new("&#x2001;"),
           Plurimath::Math::Symbol.new("&"),
@@ -5870,14 +6032,22 @@ RSpec.describe Plurimath::Latex::Parser do
           Plurimath::Math::Symbol.new("="),
           Plurimath::Math::Symbol.new("&#x3bc;"),
           Plurimath::Math::Symbol.new("/"),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Symbol.new("M"),
-          Plurimath::Math::Symbol.new("/"),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Symbol.new("L"),
-          Plurimath::Math::Symbol.new("T"),
-          Plurimath::Math::Symbol.new(")"),
-          Plurimath::Math::Symbol.new(")"),
+          Plurimath::Math::Function::Fenced.new(
+            Plurimath::Math::Symbol.new("("),
+            [
+              Plurimath::Math::Symbol.new("M"),
+              Plurimath::Math::Symbol.new("/"),
+              Plurimath::Math::Function::Fenced.new(
+                Plurimath::Math::Symbol.new("("),
+                [
+                  Plurimath::Math::Symbol.new("L"),
+                  Plurimath::Math::Symbol.new("T"),
+                ],
+                Plurimath::Math::Symbol.new(")"),
+              ),
+            ],
+            Plurimath::Math::Symbol.new(")"),
+          ),
           Plurimath::Math::Symbol.new(",")
         ])
         expect(formula).to eq(expected_value)
@@ -5958,11 +6128,15 @@ RSpec.describe Plurimath::Latex::Parser do
                       )
                     ),
                     Plurimath::Math::Symbol.new("/"),
-                    Plurimath::Math::Symbol.new("("),
-                    Plurimath::Math::Symbol.new("L"),
-                    Plurimath::Math::Symbol.new("/"),
-                    Plurimath::Math::Symbol.new("T"),
-                    Plurimath::Math::Symbol.new(")"),
+                    Plurimath::Math::Function::Fenced.new(
+                      Plurimath::Math::Symbol.new("("),
+                      [
+                        Plurimath::Math::Symbol.new("L"),
+                        Plurimath::Math::Symbol.new("/"),
+                        Plurimath::Math::Symbol.new("T"),
+                      ],
+                      Plurimath::Math::Symbol.new(")"),
+                    ),
                     Plurimath::Math::Symbol.new(","),
                   ],
                   { columnalign: "center" }
@@ -5994,14 +6168,18 @@ RSpec.describe Plurimath::Latex::Parser do
                       )
                     ),
                     Plurimath::Math::Symbol.new("/"),
-                    Plurimath::Math::Symbol.new("("),
-                    Plurimath::Math::Symbol.new("M"),
-                    Plurimath::Math::Symbol.new("/"),
-                    Plurimath::Math::Function::Power.new(
-                      Plurimath::Math::Symbol.new("L"),
-                      Plurimath::Math::Number.new("3")
+                    Plurimath::Math::Function::Fenced.new(
+                      Plurimath::Math::Symbol.new("("),
+                      [
+                        Plurimath::Math::Symbol.new("M"),
+                        Plurimath::Math::Symbol.new("/"),
+                        Plurimath::Math::Function::Power.new(
+                          Plurimath::Math::Symbol.new("L"),
+                          Plurimath::Math::Number.new("3")
+                        ),
+                      ],
+                      Plurimath::Math::Symbol.new(")"),
                     ),
-                    Plurimath::Math::Symbol.new(")"),
                     Plurimath::Math::Symbol.new(","),
                   ],
                   { columnalign: "center" }
@@ -6067,11 +6245,15 @@ RSpec.describe Plurimath::Latex::Parser do
                       )
                     ),
                     Plurimath::Math::Symbol.new("/"),
-                    Plurimath::Math::Symbol.new("("),
-                    Plurimath::Math::Symbol.new("L"),
-                    Plurimath::Math::Symbol.new("/"),
-                    Plurimath::Math::Symbol.new("T"),
-                    Plurimath::Math::Symbol.new(")"),
+                    Plurimath::Math::Function::Fenced.new(
+                      Plurimath::Math::Symbol.new("("),
+                      [
+                        Plurimath::Math::Symbol.new("L"),
+                        Plurimath::Math::Symbol.new("/"),
+                        Plurimath::Math::Symbol.new("T"),
+                      ],
+                      Plurimath::Math::Symbol.new(")"),
+                    ),
                     Plurimath::Math::Symbol.new(","),
                   ],
                   { columnalign: "center" }
@@ -6103,17 +6285,25 @@ RSpec.describe Plurimath::Latex::Parser do
                       )
                     ),
                     Plurimath::Math::Symbol.new("/"),
-                    Plurimath::Math::Symbol.new("("),
-                    Plurimath::Math::Symbol.new("M"),
-                    Plurimath::Math::Symbol.new("/"),
-                    Plurimath::Math::Symbol.new("("),
-                    Plurimath::Math::Symbol.new("L"),
-                    Plurimath::Math::Function::Power.new(
-                      Plurimath::Math::Symbol.new("T"),
-                      Plurimath::Math::Number.new("2")
+                    Plurimath::Math::Function::Fenced.new(
+                      Plurimath::Math::Symbol.new("("),
+                      [
+                        Plurimath::Math::Symbol.new("M"),
+                        Plurimath::Math::Symbol.new("/"),
+                        Plurimath::Math::Function::Fenced.new(
+                          Plurimath::Math::Symbol.new("("),
+                          [
+                            Plurimath::Math::Symbol.new("L"),
+                            Plurimath::Math::Function::Power.new(
+                              Plurimath::Math::Symbol.new("T"),
+                              Plurimath::Math::Number.new("2")
+                            ),
+                          ],
+                          Plurimath::Math::Symbol.new(")"),
+                        ),
+                      ],
+                      Plurimath::Math::Symbol.new(")"),
                     ),
-                    Plurimath::Math::Symbol.new(")"),
-                    Plurimath::Math::Symbol.new(")"),
                   ],
                   { columnalign: "center" }
                 ),
@@ -6179,11 +6369,15 @@ RSpec.describe Plurimath::Latex::Parser do
                       )
                     ),
                     Plurimath::Math::Symbol.new("/"),
-                    Plurimath::Math::Symbol.new("("),
-                    Plurimath::Math::Symbol.new("L"),
-                    Plurimath::Math::Symbol.new("/"),
-                    Plurimath::Math::Symbol.new("T"),
-                    Plurimath::Math::Symbol.new(")"),
+                    Plurimath::Math::Function::Fenced.new(
+                      Plurimath::Math::Symbol.new("("),
+                      [
+                        Plurimath::Math::Symbol.new("L"),
+                        Plurimath::Math::Symbol.new("/"),
+                        Plurimath::Math::Symbol.new("T"),
+                      ],
+                      Plurimath::Math::Symbol.new(")"),
+                    ),
                     Plurimath::Math::Symbol.new(","),
                     Plurimath::Math::Symbol.new("&#x2001;"),
                   ],
@@ -6216,14 +6410,22 @@ RSpec.describe Plurimath::Latex::Parser do
                       )
                     ),
                     Plurimath::Math::Symbol.new("/"),
-                    Plurimath::Math::Symbol.new("("),
-                    Plurimath::Math::Symbol.new("M"),
-                    Plurimath::Math::Symbol.new("/"),
-                    Plurimath::Math::Symbol.new("("),
-                    Plurimath::Math::Symbol.new("L"),
-                    Plurimath::Math::Symbol.new("T"),
-                    Plurimath::Math::Symbol.new(")"),
-                    Plurimath::Math::Symbol.new(")"),
+                    Plurimath::Math::Function::Fenced.new(
+                      Plurimath::Math::Symbol.new("("),
+                      [
+                        Plurimath::Math::Symbol.new("M"),
+                        Plurimath::Math::Symbol.new("/"),
+                        Plurimath::Math::Function::Fenced.new(
+                          Plurimath::Math::Symbol.new("("),
+                          [
+                            Plurimath::Math::Symbol.new("L"),
+                            Plurimath::Math::Symbol.new("T"),
+                          ],
+                          Plurimath::Math::Symbol.new(")"),
+                        ),
+                      ],
+                      Plurimath::Math::Symbol.new(")"),
+                    ),
                     Plurimath::Math::Symbol.new("."),
                   ],
                   { columnalign: "center" }
@@ -6281,37 +6483,45 @@ RSpec.describe Plurimath::Latex::Parser do
                       ])
                     ),
                     Plurimath::Math::Symbol.new("/"),
-                    Plurimath::Math::Symbol.new("("),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("&#x3c1;"),
-                      Plurimath::Math::Function::FontStyle::Normal.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("r"),
-                          Plurimath::Math::Symbol.new("e"),
-                          Plurimath::Math::Symbol.new("f"),
-                        ]),
-                        "textrm"
-                      )
+                    Plurimath::Math::Function::Fenced.new(
+                      Plurimath::Math::Symbol.new("("),
+                      [
+                        Plurimath::Math::Function::Base.new(
+                          Plurimath::Math::Symbol.new("&#x3c1;"),
+                          Plurimath::Math::Function::FontStyle::Normal.new(
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("r"),
+                              Plurimath::Math::Symbol.new("e"),
+                              Plurimath::Math::Symbol.new("f"),
+                            ]),
+                            "textrm"
+                          )
+                        ),
+                        Plurimath::Math::Function::PowerBase.new(
+                          Plurimath::Math::Symbol.new("c"),
+                          Plurimath::Math::Function::FontStyle::Normal.new(
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("r"),
+                              Plurimath::Math::Symbol.new("e"),
+                              Plurimath::Math::Symbol.new("f"),
+                            ]),
+                            "textrm"
+                          ),
+                          Plurimath::Math::Number.new("2")
+                        ),
+                      ],
+                      Plurimath::Math::Symbol.new(")"),
                     ),
-                    Plurimath::Math::Function::PowerBase.new(
-                      Plurimath::Math::Symbol.new("c"),
-                      Plurimath::Math::Function::FontStyle::Normal.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("r"),
-                          Plurimath::Math::Symbol.new("e"),
-                          Plurimath::Math::Symbol.new("f"),
-                        ]),
-                        "textrm"
-                      ),
-                      Plurimath::Math::Number.new("2")
+                    Plurimath::Math::Function::Fenced.new(
+                      Plurimath::Math::Symbol.new("["),
+                      [
+                        Plurimath::Math::Symbol.new("."),
+                        Plurimath::Math::Number.new("02"),
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("n"),
+                      ],
+                      Plurimath::Math::Symbol.new("]"),
                     ),
-                    Plurimath::Math::Symbol.new(")"),
-                    Plurimath::Math::Symbol.new("["),
-                    Plurimath::Math::Symbol.new("."),
-                    Plurimath::Math::Number.new("02"),
-                    Plurimath::Math::Symbol.new("i"),
-                    Plurimath::Math::Symbol.new("n"),
-                    Plurimath::Math::Symbol.new("]"),
                   ],
                   nil
                 ),
@@ -6341,13 +6551,17 @@ RSpec.describe Plurimath::Latex::Parser do
                       Plurimath::Math::Formula.new([
                         Plurimath::Math::Symbol.new("M"),
                         Plurimath::Math::Symbol.new("/"),
-                        Plurimath::Math::Symbol.new("("),
-                        Plurimath::Math::Symbol.new("L"),
-                        Plurimath::Math::Function::Power.new(
-                          Plurimath::Math::Symbol.new("T"),
-                          Plurimath::Math::Number.new("2")
+                        Plurimath::Math::Function::Fenced.new(
+                          Plurimath::Math::Symbol.new("("),
+                          [
+                            Plurimath::Math::Symbol.new("L"),
+                            Plurimath::Math::Function::Power.new(
+                              Plurimath::Math::Symbol.new("T"),
+                              Plurimath::Math::Number.new("2")
+                            ),
+                          ],
+                          Plurimath::Math::Symbol.new(")"),
                         ),
-                        Plurimath::Math::Symbol.new(")"),
                       ])
                     ),
                     Plurimath::Math::Function::Over.new(
@@ -6405,7 +6619,7 @@ RSpec.describe Plurimath::Latex::Parser do
                 ),
               ]),
               Plurimath::Math::Function::Tr.new([
-                Plurimath::Math::Function::Td.new([], nil),
+                Plurimath::Math::Function::Td.new([]),
               ]),
               Plurimath::Math::Function::Tr.new([
                 Plurimath::Math::Function::Td.new(
@@ -6425,37 +6639,45 @@ RSpec.describe Plurimath::Latex::Parser do
                       ])
                     ),
                     Plurimath::Math::Symbol.new("/"),
-                    Plurimath::Math::Symbol.new("("),
-                    Plurimath::Math::Symbol.new("&#x3c1;"),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Unicode.new("&#x27;"),
-                      Plurimath::Math::Function::FontStyle::Normal.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("r"),
-                          Plurimath::Math::Symbol.new("e"),
-                          Plurimath::Math::Symbol.new("f"),
-                        ]),
-                        "textrm"
-                      )
-                    ),
-                    Plurimath::Math::Symbol.new("("),
-                    Plurimath::Math::Symbol.new("c"),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Unicode.new("&#x27;"),
-                      Plurimath::Math::Function::FontStyle::Normal.new(
-                        Plurimath::Math::Formula.new([
-                          Plurimath::Math::Symbol.new("r"),
-                          Plurimath::Math::Symbol.new("e"),
-                          Plurimath::Math::Symbol.new("f"),
-                        ]),
-                        "textrm"
-                      )
-                    ),
-                    Plurimath::Math::Function::Power.new(
+                    Plurimath::Math::Function::Fenced.new(
+                      Plurimath::Math::Symbol.new("("),
+                      [
+                        Plurimath::Math::Symbol.new("&#x3c1;"),
+                        Plurimath::Math::Function::Base.new(
+                          Plurimath::Math::Unicode.new("&#x27;"),
+                          Plurimath::Math::Function::FontStyle::Normal.new(
+                            Plurimath::Math::Formula.new([
+                              Plurimath::Math::Symbol.new("r"),
+                              Plurimath::Math::Symbol.new("e"),
+                              Plurimath::Math::Symbol.new("f"),
+                            ]),
+                            "textrm"
+                          )
+                        ),
+                        Plurimath::Math::Function::Power.new(
+                          Plurimath::Math::Function::Fenced.new(
+                            Plurimath::Math::Symbol.new("("),
+                            [
+                              Plurimath::Math::Symbol.new("c"),
+                              Plurimath::Math::Function::Base.new(
+                                Plurimath::Math::Unicode.new("&#x27;"),
+                                Plurimath::Math::Function::FontStyle::Normal.new(
+                                  Plurimath::Math::Formula.new([
+                                    Plurimath::Math::Symbol.new("r"),
+                                    Plurimath::Math::Symbol.new("e"),
+                                    Plurimath::Math::Symbol.new("f"),
+                                  ]),
+                                  "textrm"
+                                )
+                              ),
+                            ],
+                            Plurimath::Math::Symbol.new(")"),
+                          ),
+                          Plurimath::Math::Number.new("2")
+                        ),
+                      ],
                       Plurimath::Math::Symbol.new(")"),
-                      Plurimath::Math::Number.new("2")
                     ),
-                    Plurimath::Math::Symbol.new(")"),
                   ],
                   nil
                 ),
@@ -6653,24 +6875,32 @@ RSpec.describe Plurimath::Latex::Parser do
                       ])
                     ),
                     Plurimath::Math::Symbol.new("/"),
-                    Plurimath::Math::Symbol.new("("),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("&#x3c1;"),
-                      Plurimath::Math::Symbol.new("&#x221e;")
+                    Plurimath::Math::Function::Fenced.new(
+                      Plurimath::Math::Symbol.new("("),
+                      [
+                        Plurimath::Math::Function::Base.new(
+                          Plurimath::Math::Symbol.new("&#x3c1;"),
+                          Plurimath::Math::Symbol.new("&#x221e;")
+                        ),
+                        Plurimath::Math::Function::PowerBase.new(
+                          Plurimath::Math::Symbol.new("c"),
+                          Plurimath::Math::Symbol.new("&#x221e;"),
+                          Plurimath::Math::Number.new("2")
+                        ),
+                      ],
+                      Plurimath::Math::Symbol.new(")"),
                     ),
-                    Plurimath::Math::Function::PowerBase.new(
-                      Plurimath::Math::Symbol.new("c"),
-                      Plurimath::Math::Symbol.new("&#x221e;"),
-                      Plurimath::Math::Number.new("2")
-                    ),
-                    Plurimath::Math::Symbol.new(")"),
                     Plurimath::Math::Symbol.new(","),
-                    Plurimath::Math::Symbol.new("["),
-                    Plurimath::Math::Symbol.new("."),
-                    Plurimath::Math::Number.new("02"),
-                    Plurimath::Math::Symbol.new("i"),
-                    Plurimath::Math::Symbol.new("n"),
-                    Plurimath::Math::Symbol.new("]"),
+                    Plurimath::Math::Function::Fenced.new(
+                      Plurimath::Math::Symbol.new("["),
+                      [
+                        Plurimath::Math::Symbol.new("."),
+                        Plurimath::Math::Number.new("02"),
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("n"),
+                      ],
+                      Plurimath::Math::Symbol.new("]"),
+                    ),
                   ],
                   { columnalign: "center" }
                 ),
@@ -6757,17 +6987,21 @@ RSpec.describe Plurimath::Latex::Parser do
                       ])
                     ),
                     Plurimath::Math::Symbol.new("/"),
-                    Plurimath::Math::Symbol.new("("),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("&#x3c1;"),
-                      Plurimath::Math::Symbol.new("&#x221e;")
+                    Plurimath::Math::Function::Fenced.new(
+                      Plurimath::Math::Symbol.new("("),
+                      [
+                        Plurimath::Math::Function::Base.new(
+                          Plurimath::Math::Symbol.new("&#x3c1;"),
+                          Plurimath::Math::Symbol.new("&#x221e;")
+                        ),
+                        Plurimath::Math::Function::Base.new(
+                          Plurimath::Math::Symbol.new("c"),
+                          Plurimath::Math::Symbol.new("&#x221e;")
+                        ),
+                        Plurimath::Math::Symbol.new("L"),
+                      ],
+                      Plurimath::Math::Symbol.new(")"),
                     ),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("c"),
-                      Plurimath::Math::Symbol.new("&#x221e;")
-                    ),
-                    Plurimath::Math::Symbol.new("L"),
-                    Plurimath::Math::Symbol.new(")"),
                     Plurimath::Math::Symbol.new(","),
                   ],
                   { columnalign: "center" }
@@ -6883,28 +7117,36 @@ RSpec.describe Plurimath::Latex::Parser do
                       Plurimath::Math::Symbol.new("&#x221e;")
                     ),
                     Plurimath::Math::Symbol.new("/"),
-                    Plurimath::Math::Symbol.new("("),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("&#x3c1;"),
-                      Plurimath::Math::Symbol.new("&#x221e;")
+                    Plurimath::Math::Function::Fenced.new(
+                      Plurimath::Math::Symbol.new("("),
+                      [
+                        Plurimath::Math::Function::Base.new(
+                          Plurimath::Math::Symbol.new("&#x3c1;"),
+                          Plurimath::Math::Symbol.new("&#x221e;")
+                        ),
+                        Plurimath::Math::Function::PowerBase.new(
+                          Plurimath::Math::Symbol.new("c"),
+                          Plurimath::Math::Symbol.new("&#x221e;"),
+                          Plurimath::Math::Number.new("2")
+                        ),
+                      ],
+                      Plurimath::Math::Symbol.new(")"),
                     ),
-                    Plurimath::Math::Function::PowerBase.new(
-                      Plurimath::Math::Symbol.new("c"),
-                      Plurimath::Math::Symbol.new("&#x221e;"),
-                      Plurimath::Math::Number.new("2")
-                    ),
-                    Plurimath::Math::Symbol.new(")"),
                     Plurimath::Math::Symbol.new("="),
                     Plurimath::Math::Number.new("1"),
                     Plurimath::Math::Symbol.new("/"),
                     Plurimath::Math::Symbol.new("&#x3b3;"),
                     Plurimath::Math::Symbol.new(","),
-                    Plurimath::Math::Symbol.new("["),
-                    Plurimath::Math::Symbol.new("."),
-                    Plurimath::Math::Number.new("02"),
-                    Plurimath::Math::Symbol.new("i"),
-                    Plurimath::Math::Symbol.new("n"),
-                    Plurimath::Math::Symbol.new("]"),
+                    Plurimath::Math::Function::Fenced.new(
+                      Plurimath::Math::Symbol.new("["),
+                      [
+                        Plurimath::Math::Symbol.new("."),
+                        Plurimath::Math::Number.new("02"),
+                        Plurimath::Math::Symbol.new("i"),
+                        Plurimath::Math::Symbol.new("n"),
+                      ],
+                      Plurimath::Math::Symbol.new("]"),
+                    ),
                   ],
                   { columnalign: "center" }
                 ),
@@ -6948,25 +7190,33 @@ RSpec.describe Plurimath::Latex::Parser do
                       Plurimath::Math::Symbol.new("&#x221e;")
                     ),
                     Plurimath::Math::Symbol.new("/"),
-                    Plurimath::Math::Symbol.new("("),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("&#x3c1;"),
-                      Plurimath::Math::Symbol.new("&#x221e;")
+                    Plurimath::Math::Function::Fenced.new(
+                      Plurimath::Math::Symbol.new("("),
+                      [
+                        Plurimath::Math::Function::Base.new(
+                          Plurimath::Math::Symbol.new("&#x3c1;"),
+                          Plurimath::Math::Symbol.new("&#x221e;")
+                        ),
+                        Plurimath::Math::Function::Base.new(
+                          Plurimath::Math::Symbol.new("c"),
+                          Plurimath::Math::Symbol.new("&#x221e;")
+                        ),
+                        Plurimath::Math::Symbol.new("L"),
+                      ],
+                      Plurimath::Math::Symbol.new(")"),
                     ),
-                    Plurimath::Math::Function::Base.new(
-                      Plurimath::Math::Symbol.new("c"),
-                      Plurimath::Math::Symbol.new("&#x221e;")
-                    ),
-                    Plurimath::Math::Symbol.new("L"),
-                    Plurimath::Math::Symbol.new(")"),
                     Plurimath::Math::Symbol.new("&#x223c;"),
                     Plurimath::Math::Symbol.new("O"),
-                    Plurimath::Math::Symbol.new("("),
-                    Plurimath::Math::Number.new("1"),
-                    Plurimath::Math::Symbol.new("/"),
-                    Plurimath::Math::Symbol.new("R"),
-                    Plurimath::Math::Symbol.new("e"),
-                    Plurimath::Math::Symbol.new(")"),
+                    Plurimath::Math::Function::Fenced.new(
+                      Plurimath::Math::Symbol.new("("),
+                      [
+                        Plurimath::Math::Number.new("1"),
+                        Plurimath::Math::Symbol.new("/"),
+                        Plurimath::Math::Symbol.new("R"),
+                        Plurimath::Math::Symbol.new("e"),
+                      ],
+                      Plurimath::Math::Symbol.new(")"),
+                    ),
                     Plurimath::Math::Symbol.new(","),
                   ],
                   { columnalign: "center" }
@@ -7118,22 +7368,26 @@ RSpec.describe Plurimath::Latex::Parser do
               Plurimath::Math::Number.new("2")
             ])
           ),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Function::Power.new(
-            Plurimath::Math::Symbol.new("u"),
-            Plurimath::Math::Number.new("2")
+          Plurimath::Math::Function::Fenced.new(
+            Plurimath::Math::Symbol.new("("),
+            [
+              Plurimath::Math::Function::Power.new(
+                Plurimath::Math::Symbol.new("u"),
+                Plurimath::Math::Number.new("2")
+              ),
+              Plurimath::Math::Symbol.new("+"),
+              Plurimath::Math::Function::Power.new(
+                Plurimath::Math::Symbol.new("v"),
+                Plurimath::Math::Number.new("2")
+              ),
+              Plurimath::Math::Symbol.new("+"),
+              Plurimath::Math::Function::Power.new(
+                Plurimath::Math::Symbol.new("w"),
+                Plurimath::Math::Number.new("2")
+              ),
+            ],
+            Plurimath::Math::Symbol.new(")"),
           ),
-          Plurimath::Math::Symbol.new("+"),
-          Plurimath::Math::Function::Power.new(
-            Plurimath::Math::Symbol.new("v"),
-            Plurimath::Math::Number.new("2")
-          ),
-          Plurimath::Math::Symbol.new("+"),
-          Plurimath::Math::Function::Power.new(
-            Plurimath::Math::Symbol.new("w"),
-            Plurimath::Math::Number.new("2")
-          ),
-          Plurimath::Math::Symbol.new(")"),
           Plurimath::Math::Symbol.new("="),
           Plurimath::Math::Function::Over.new(
             Plurimath::Math::Formula.new([
@@ -7195,23 +7449,27 @@ RSpec.describe Plurimath::Latex::Parser do
               )
             ])
           ),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Function::Base.new(
-            Plurimath::Math::Symbol.new("C"),
-            Plurimath::Math::Symbol.new("w")
+          Plurimath::Math::Function::Fenced.new(
+            Plurimath::Math::Symbol.new("("),
+            [
+              Plurimath::Math::Function::Base.new(
+                Plurimath::Math::Symbol.new("C"),
+                Plurimath::Math::Symbol.new("w")
+              ),
+              Plurimath::Math::Symbol.new("&#x3a;"),
+              Plurimath::Math::Function::Frac.new(
+                Plurimath::Math::Formula.new([
+                  Plurimath::Math::Symbol.new("&#x2202;"),
+                  Plurimath::Math::Symbol.new("&#x3b8;")
+                ]),
+                Plurimath::Math::Formula.new([
+                  Plurimath::Math::Symbol.new("&#x2202;"),
+                  Plurimath::Math::Symbol.new("x")
+                ])
+              ),
+            ],
+            Plurimath::Math::Symbol.new(")")
           ),
-          Plurimath::Math::Symbol.new("&#x3a;"),
-          Plurimath::Math::Function::Frac.new(
-            Plurimath::Math::Formula.new([
-              Plurimath::Math::Symbol.new("&#x2202;"),
-              Plurimath::Math::Symbol.new("&#x3b8;")
-            ]),
-            Plurimath::Math::Formula.new([
-              Plurimath::Math::Symbol.new("&#x2202;"),
-              Plurimath::Math::Symbol.new("x")
-            ])
-          ),
-          Plurimath::Math::Symbol.new(")")
         ])
         expect(formula).to eq(expected_value)
       end
@@ -7500,11 +7758,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Function::Tr.new([
                   Plurimath::Math::Function::Td.new(
                     [
-                      Plurimath::Math::Symbol.new("["),
-                      Plurimath::Math::Number.new("2"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::Fenced.new(
+                        Plurimath::Math::Symbol.new("["),
+                        [
+                          Plurimath::Math::Number.new("2"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                        ],
+                        Plurimath::Math::Symbol.new("]"),
+                      ),
                       Plurimath::Math::Function::Base.new(
                         Plurimath::Math::Symbol.new("h"),
                         Plurimath::Math::Symbol.new("b")
@@ -7526,29 +7788,33 @@ RSpec.describe Plurimath::Latex::Parser do
                     [
                       Plurimath::Math::Formula.new([
                         Plurimath::Math::Function::FontStyle.new(
-                          Plurimath::Math::Symbol.new("("),
+                          Plurimath::Math::Function::Fenced.new(
+                            Plurimath::Math::Symbol.new("("),
+                            [
+                              Plurimath::Math::Function::Frac.new(
+                                Plurimath::Math::Number.new("1"),
+                                Plurimath::Math::Number.new("12")
+                              ),
+                              Plurimath::Math::Function::PowerBase.new(
+                                Plurimath::Math::Symbol.new("h"),
+                                Plurimath::Math::Symbol.new("b"),
+                                Plurimath::Math::Number.new("3")
+                              ),
+                              Plurimath::Math::Symbol.new("+"),
+                              Plurimath::Math::Function::Base.new(
+                                Plurimath::Math::Symbol.new("h"),
+                                Plurimath::Math::Symbol.new("b")
+                              ),
+                              Plurimath::Math::Symbol.new("&#x2c;"),
+                              Plurimath::Math::Function::Power.new(
+                                Plurimath::Math::Symbol.new("p"),
+                                Plurimath::Math::Number.new("2")
+                              ),
+                            ],
+                            Plurimath::Math::Symbol.new(")"),
+                          ),
                           "displaystyle"
                         ),
-                        Plurimath::Math::Function::Frac.new(
-                          Plurimath::Math::Number.new("1"),
-                          Plurimath::Math::Number.new("12")
-                        ),
-                        Plurimath::Math::Function::PowerBase.new(
-                          Plurimath::Math::Symbol.new("h"),
-                          Plurimath::Math::Symbol.new("b"),
-                          Plurimath::Math::Number.new("3")
-                        ),
-                        Plurimath::Math::Symbol.new("+"),
-                        Plurimath::Math::Function::Base.new(
-                          Plurimath::Math::Symbol.new("h"),
-                          Plurimath::Math::Symbol.new("b")
-                        ),
-                        Plurimath::Math::Symbol.new("&#x2c;"),
-                        Plurimath::Math::Function::Power.new(
-                          Plurimath::Math::Symbol.new("p"),
-                          Plurimath::Math::Number.new("2")
-                        ),
-                        Plurimath::Math::Symbol.new(")"),
                         Plurimath::Math::Symbol.new("&#x2c;"),
                         Plurimath::Math::Function::Base.new(
                           Plurimath::Math::Symbol.new("D"),
@@ -7602,16 +7868,18 @@ RSpec.describe Plurimath::Latex::Parser do
           Plurimath::Math::Symbol.new("="),
           Plurimath::Math::Function::Frac.new(
             Plurimath::Math::Symbol.new("E"),
-            Plurimath::Math::Formula.new([
+            Plurimath::Math::Function::Fenced.new(
               Plurimath::Math::Symbol.new("("),
-              Plurimath::Math::Number.new("1"),
-              Plurimath::Math::Symbol.new("-"),
-              Plurimath::Math::Function::Power.new(
-                Plurimath::Math::Symbol.new("&#x3bd;"),
-                Plurimath::Math::Number.new("2")
-              ),
+              [
+                Plurimath::Math::Number.new("1"),
+                Plurimath::Math::Symbol.new("-"),
+                Plurimath::Math::Function::Power.new(
+                  Plurimath::Math::Symbol.new("&#x3bd;"),
+                  Plurimath::Math::Number.new("2")
+                ),
+              ],
               Plurimath::Math::Symbol.new(")"),
-            ])
+            )
           ),
           Plurimath::Math::Symbol.new("&#x3a;"),
           Plurimath::Math::Formula.new([
@@ -7635,11 +7903,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Function::Tr.new([
                   Plurimath::Math::Function::Td.new(
                     [
-                      Plurimath::Math::Symbol.new("["),
-                      Plurimath::Math::Number.new("2"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::Fenced.new(
+                        Plurimath::Math::Symbol.new("["),
+                        [
+                          Plurimath::Math::Number.new("2"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                        ],
+                        Plurimath::Math::Symbol.new("]"),
+                      ),
                       Plurimath::Math::Symbol.new("&#x3bd;"),
                     ],
                     { columnalign: "center" }
@@ -7656,11 +7928,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Function::Tr.new([
                   Plurimath::Math::Function::Td.new(
                     [
-                      Plurimath::Math::Symbol.new("["),
-                      Plurimath::Math::Number.new("2"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::Fenced.new(
+                        Plurimath::Math::Symbol.new("["),
+                        [
+                          Plurimath::Math::Number.new("2"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                        ],
+                        Plurimath::Math::Symbol.new("]"),
+                      ),
                       Plurimath::Math::Number.new("0"),
                     ],
                     { columnalign: "center" }
@@ -7673,13 +7949,15 @@ RSpec.describe Plurimath::Latex::Parser do
                     [
                       Plurimath::Math::Function::FontStyle.new(
                         Plurimath::Math::Function::Frac.new(
-                          Plurimath::Math::Formula.new([
+                          Plurimath::Math::Function::Fenced.new(
                             Plurimath::Math::Symbol.new("("),
-                            Plurimath::Math::Number.new("1"),
-                            Plurimath::Math::Symbol.new("-"),
-                            Plurimath::Math::Symbol.new("&#x3bd;"),
+                            [
+                              Plurimath::Math::Number.new("1"),
+                              Plurimath::Math::Symbol.new("-"),
+                              Plurimath::Math::Symbol.new("&#x3bd;"),
+                            ],
                             Plurimath::Math::Symbol.new(")"),
-                          ]),
+                          ),
                           Plurimath::Math::Number.new("2")
                         ),
                         "displaystyle"
@@ -7751,11 +8029,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Function::Tr.new([
                   Plurimath::Math::Function::Td.new(
                     [
-                      Plurimath::Math::Symbol.new("["),
-                      Plurimath::Math::Number.new("2"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::Fenced.new(
+                        Plurimath::Math::Symbol.new("["),
+                        [
+                          Plurimath::Math::Number.new("2"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                        ],
+                        Plurimath::Math::Symbol.new("]"),
+                      ),
                       Plurimath::Math::Symbol.new("h"),
                       Plurimath::Math::Symbol.new("&#x2c;"),
                       Plurimath::Math::Symbol.new("p"),
@@ -7771,25 +8053,29 @@ RSpec.describe Plurimath::Latex::Parser do
                     [
                       Plurimath::Math::Formula.new([
                         Plurimath::Math::Function::FontStyle.new(
-                          Plurimath::Math::Symbol.new("("),
-                          "displaystyle"
+                          Plurimath::Math::Function::Fenced.new(
+                            Plurimath::Math::Symbol.new("("),
+                            [
+                              Plurimath::Math::Function::Frac.new(
+                                Plurimath::Math::Number.new("1"),
+                                Plurimath::Math::Number.new("12")
+                              ),
+                              Plurimath::Math::Function::Power.new(
+                                Plurimath::Math::Symbol.new("h"),
+                                Plurimath::Math::Number.new("3")
+                              ),
+                              Plurimath::Math::Symbol.new("+"),
+                              Plurimath::Math::Symbol.new("h"),
+                              Plurimath::Math::Symbol.new("&#x2c;"),
+                              Plurimath::Math::Function::Power.new(
+                                Plurimath::Math::Symbol.new("p"),
+                                Plurimath::Math::Number.new("2")
+                              ),
+                            ],
+                            Plurimath::Math::Symbol.new(")"),
+                          ),
+                          "displaystyle",
                         ),
-                        Plurimath::Math::Function::Frac.new(
-                          Plurimath::Math::Number.new("1"),
-                          Plurimath::Math::Number.new("12")
-                        ),
-                        Plurimath::Math::Function::Power.new(
-                          Plurimath::Math::Symbol.new("h"),
-                          Plurimath::Math::Number.new("3")
-                        ),
-                        Plurimath::Math::Symbol.new("+"),
-                        Plurimath::Math::Symbol.new("h"),
-                        Plurimath::Math::Symbol.new("&#x2c;"),
-                        Plurimath::Math::Function::Power.new(
-                          Plurimath::Math::Symbol.new("p"),
-                          Plurimath::Math::Number.new("2")
-                        ),
-                        Plurimath::Math::Symbol.new(")"),
                         Plurimath::Math::Symbol.new("&#x2c;"),
                         Plurimath::Math::Function::Base.new(
                           Plurimath::Math::Symbol.new("D"),
@@ -8325,11 +8611,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Function::Tr.new([
                   Plurimath::Math::Function::Td.new(
                     [
-                      Plurimath::Math::Symbol.new("["),
-                      Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::Fenced.new(
+                        Plurimath::Math::Symbol.new("["),
+                        [
+                          Plurimath::Math::Number.new("3"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                        ],
+                        Plurimath::Math::Symbol.new("]"),
+                      ),
                       Plurimath::Math::Formula.new([
                         Plurimath::Math::Function::FontStyle.new(
                           Plurimath::Math::Function::Frac.new(
@@ -8545,11 +8835,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Function::Tr.new([
                   Plurimath::Math::Function::Td.new(
                     [
-                      Plurimath::Math::Symbol.new("["),
-                      Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::Fenced.new(
+                        Plurimath::Math::Symbol.new("["),
+                        [
+                          Plurimath::Math::Number.new("3"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                        ],
+                        Plurimath::Math::Symbol.new("]"),
+                      ),
                       Plurimath::Math::Formula.new([
                         Plurimath::Math::Function::FontStyle.new(
                           Plurimath::Math::Symbol.new("-"),
@@ -8732,11 +9026,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Function::Tr.new([
                   Plurimath::Math::Function::Td.new(
                     [
-                      Plurimath::Math::Symbol.new("["),
-                      Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::Fenced.new(
+                        Plurimath::Math::Symbol.new("["),
+                        [
+                          Plurimath::Math::Number.new("3"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                        ],
+                        Plurimath::Math::Symbol.new("]"),
+                      ),
                       Plurimath::Math::Function::FontStyle.new(
                         Plurimath::Math::Function::Frac.new(
                           Plurimath::Math::Formula.new([
@@ -8798,14 +9096,18 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Number.new("1"),
             Plurimath::Math::Number.new("2")
           ),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Symbol.new("J"),
-          Plurimath::Math::Symbol.new("+"),
-          Plurimath::Math::Function::Power.new(
-            Plurimath::Math::Symbol.new("J"),
-            Plurimath::Math::Symbol.new("t")
+          Plurimath::Math::Function::Fenced.new(
+            Plurimath::Math::Symbol.new("("),
+            [
+              Plurimath::Math::Symbol.new("J"),
+              Plurimath::Math::Symbol.new("+"),
+              Plurimath::Math::Function::Power.new(
+                Plurimath::Math::Symbol.new("J"),
+                Plurimath::Math::Symbol.new("t")
+              ),
+            ],
+            Plurimath::Math::Symbol.new(")")
           ),
-          Plurimath::Math::Symbol.new(")")
         ])
         expect(formula).to eq(expected_value)
       end
@@ -8891,9 +9193,13 @@ RSpec.describe Plurimath::Latex::Parser do
               Plurimath::Math::Symbol.new("j")
             ])
           ),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Symbol.new("M"),
-          Plurimath::Math::Symbol.new(")"),
+          Plurimath::Math::Function::Fenced.new(
+            Plurimath::Math::Symbol.new("("),
+            [
+              Plurimath::Math::Symbol.new("M"),
+            ],
+            Plurimath::Math::Symbol.new(")"),
+          ),
           Plurimath::Math::Symbol.new("&#x3a;"),
           Plurimath::Math::Symbol.new("&#x394;"),
           Plurimath::Math::Symbol.new("M")
@@ -8926,16 +9232,20 @@ RSpec.describe Plurimath::Latex::Parser do
             ])
           ),
           Plurimath::Math::Symbol.new("&#x3a;"),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Symbol.new("T"),
-          Plurimath::Math::Symbol.new("&#x3a;"),
-          Plurimath::Math::Symbol.new("-"),
-          Plurimath::Math::Symbol.new("&#x3a;"),
-          Plurimath::Math::Function::Base.new(
-            Plurimath::Math::Symbol.new("T"),
-            Plurimath::Math::Symbol.new("o")
-          ),
-          Plurimath::Math::Symbol.new(")")
+          Plurimath::Math::Function::Fenced.new(
+            Plurimath::Math::Symbol.new("("),
+            [
+              Plurimath::Math::Symbol.new("T"),
+              Plurimath::Math::Symbol.new("&#x3a;"),
+              Plurimath::Math::Symbol.new("-"),
+              Plurimath::Math::Symbol.new("&#x3a;"),
+              Plurimath::Math::Function::Base.new(
+                Plurimath::Math::Symbol.new("T"),
+                Plurimath::Math::Symbol.new("o")
+              ),
+            ],
+            Plurimath::Math::Symbol.new(")"),
+          )
         ])
         expect(formula).to eq(expected_value)
       end
@@ -8965,9 +9275,13 @@ RSpec.describe Plurimath::Latex::Parser do
               Plurimath::Math::Symbol.new("j")
             ])
           ),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Symbol.new("T"),
-          Plurimath::Math::Symbol.new(")"),
+          Plurimath::Math::Function::Fenced.new(
+            Plurimath::Math::Symbol.new("("),
+            [
+              Plurimath::Math::Symbol.new("T"),
+            ],
+            Plurimath::Math::Symbol.new(")"),
+          ),
           Plurimath::Math::Symbol.new("&#x3a;"),
           Plurimath::Math::Symbol.new("&#x394;"),
           Plurimath::Math::Symbol.new("T")
@@ -10858,53 +11172,77 @@ RSpec.describe Plurimath::Latex::Parser do
       }
       it "returns formula" do
         expected_value = Plurimath::Math::Formula.new([
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Number.new("1"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new(")"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Number.new("2"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Number.new("0"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new(")"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Number.new("3"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new(")"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Number.new("0"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new("d"),
-          Plurimath::Math::Symbol.new("d"),
-          Plurimath::Math::Symbol.new("o"),
-          Plurimath::Math::Symbol.new("t"),
-          Plurimath::Math::Symbol.new("s"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new(")"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new("n"),
-          Plurimath::Math::Symbol.new(")"),
-          Plurimath::Math::Symbol.new(")")
+          Plurimath::Math::Function::Fenced.new(
+            Plurimath::Math::Symbol.new("("),
+            [
+              Plurimath::Math::Function::Fenced.new(
+                Plurimath::Math::Symbol.new("("),
+                [
+                  Plurimath::Math::Number.new("1"),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new(","),
+                ],
+                Plurimath::Math::Symbol.new(")"),
+              ),
+              Plurimath::Math::Symbol.new(","),
+              Plurimath::Math::Function::Fenced.new(
+                Plurimath::Math::Symbol.new("("),
+                [
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Number.new("2"),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Number.new("0"),
+                  Plurimath::Math::Symbol.new(","),
+                ],
+                Plurimath::Math::Symbol.new(")"),
+              ),
+              Plurimath::Math::Symbol.new(","),
+              Plurimath::Math::Function::Fenced.new(
+                Plurimath::Math::Symbol.new("("),
+                [
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Number.new("3"),
+                  Plurimath::Math::Symbol.new(","),
+                ],
+                Plurimath::Math::Symbol.new(")"),
+              ),
+              Plurimath::Math::Symbol.new(","),
+              Plurimath::Math::Function::Fenced.new(
+                Plurimath::Math::Symbol.new("("),
+                [
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Number.new("0"),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new("d"),
+                  Plurimath::Math::Symbol.new("d"),
+                  Plurimath::Math::Symbol.new("o"),
+                  Plurimath::Math::Symbol.new("t"),
+                  Plurimath::Math::Symbol.new("s"),
+                  Plurimath::Math::Symbol.new(","),
+                ],
+                Plurimath::Math::Symbol.new(")"),
+              ),
+              Plurimath::Math::Symbol.new(","),
+              Plurimath::Math::Function::Fenced.new(
+                Plurimath::Math::Symbol.new("("),
+                [
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new("n"),
+                ],
+                Plurimath::Math::Symbol.new(")"),
+              ),
+            ],
+            Plurimath::Math::Symbol.new(")"),
+          ),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -10918,132 +11256,172 @@ RSpec.describe Plurimath::Latex::Parser do
       }
       it "returns formula" do
         expected_value = Plurimath::Math::Formula.new([
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Number.new("1"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Symbol.new("\""),
-          Plurimath::Math::Symbol.new("s"),
-          Plurimath::Math::Symbol.new("y"),
-          Plurimath::Math::Symbol.new("m"),
-          Plurimath::Math::Symbol.new("e"),
-          Plurimath::Math::Symbol.new("t"),
-          Plurimath::Math::Symbol.new("r"),
-          Plurimath::Math::Symbol.new("i"),
-          Plurimath::Math::Symbol.new("c"),
-          Plurimath::Math::Symbol.new("\""),
-          Plurimath::Math::Symbol.new(")"),
-          Plurimath::Math::Symbol.new(")"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Number.new("2"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new("n"),
-          Plurimath::Math::Symbol.new("+"),
-          Plurimath::Math::Number.new("1"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new(")"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Number.new("3"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new("n"),
-          Plurimath::Math::Symbol.new("+"),
-          Plurimath::Math::Number.new("2"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Number.new("2"),
-          Plurimath::Math::Symbol.new("n"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new(")"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Symbol.new("*"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new("*"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new("*"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Number.new("3"),
-          Plurimath::Math::Symbol.new("n"),
-          Plurimath::Math::Symbol.new("-"),
-          Plurimath::Math::Number.new("2"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new(")"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Symbol.new("*"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new("*"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new("*"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new("*"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new("*"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new(")"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Symbol.new("*"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new("*"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new("*"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new("*"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new("*"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new("*"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new(")"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Symbol.new("n"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Number.new("2"),
-          Plurimath::Math::Symbol.new("n"),
-          Plurimath::Math::Symbol.new("-"),
-          Plurimath::Math::Number.new("1"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Number.new("3"),
-          Plurimath::Math::Symbol.new("n"),
-          Plurimath::Math::Symbol.new("-"),
-          Plurimath::Math::Number.new("3"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new("*"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new("*"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new("*"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new("n"),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Symbol.new("n"),
-          Plurimath::Math::Symbol.new("+"),
-          Plurimath::Math::Number.new("1"),
-          Plurimath::Math::Symbol.new(")"),
-          Plurimath::Math::Symbol.new("/"),
-          Plurimath::Math::Symbol.new("/"),
-          Plurimath::Math::Number.new("2"),
-          Plurimath::Math::Symbol.new(")"),
-          Plurimath::Math::Symbol.new(")")
+          Plurimath::Math::Function::Fenced.new(
+            Plurimath::Math::Symbol.new("("),
+            [
+              Plurimath::Math::Function::Fenced.new(
+                Plurimath::Math::Symbol.new("("),
+                [
+                  Plurimath::Math::Number.new("1"),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Function::Fenced.new(
+                    Plurimath::Math::Symbol.new("("),
+                    [
+                      Plurimath::Math::Symbol.new("\""),
+                      Plurimath::Math::Symbol.new("s"),
+                      Plurimath::Math::Symbol.new("y"),
+                      Plurimath::Math::Symbol.new("m"),
+                      Plurimath::Math::Symbol.new("e"),
+                      Plurimath::Math::Symbol.new("t"),
+                      Plurimath::Math::Symbol.new("r"),
+                      Plurimath::Math::Symbol.new("i"),
+                      Plurimath::Math::Symbol.new("c"),
+                      Plurimath::Math::Symbol.new("\""),
+                    ],
+                    Plurimath::Math::Symbol.new(")"),
+                  ),
+                ],
+                Plurimath::Math::Symbol.new(")"),
+              ),
+              Plurimath::Math::Symbol.new(","),
+              Plurimath::Math::Function::Fenced.new(
+                Plurimath::Math::Symbol.new("("),
+                [
+                  Plurimath::Math::Number.new("2"),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new("n"),
+                  Plurimath::Math::Symbol.new("+"),
+                  Plurimath::Math::Number.new("1"),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new(","),
+                ],
+                Plurimath::Math::Symbol.new(")"),
+              ),
+              Plurimath::Math::Symbol.new(","),
+              Plurimath::Math::Function::Fenced.new(
+                Plurimath::Math::Symbol.new("("),
+                [
+                  Plurimath::Math::Number.new("3"),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new("n"),
+                  Plurimath::Math::Symbol.new("+"),
+                  Plurimath::Math::Number.new("2"),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Number.new("2"),
+                  Plurimath::Math::Symbol.new("n"),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new(","),
+                ],
+                Plurimath::Math::Symbol.new(")"),
+              ),
+              Plurimath::Math::Symbol.new(","),
+              Plurimath::Math::Function::Fenced.new(
+                Plurimath::Math::Symbol.new("("),
+                [
+                  Plurimath::Math::Symbol.new("*"),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new("*"),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new("*"),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Number.new("3"),
+                  Plurimath::Math::Symbol.new("n"),
+                  Plurimath::Math::Symbol.new("-"),
+                  Plurimath::Math::Number.new("2"),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new(","),
+                ],
+                Plurimath::Math::Symbol.new(")"),
+              ),
+              Plurimath::Math::Symbol.new(","),
+              Plurimath::Math::Function::Fenced.new(
+                Plurimath::Math::Symbol.new("("),
+                [
+                  Plurimath::Math::Symbol.new("*"),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new("*"),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new("*"),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new("*"),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new("*"),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new(","),
+                ],
+                Plurimath::Math::Symbol.new(")"),
+              ),
+              Plurimath::Math::Symbol.new(","),
+              Plurimath::Math::Function::Fenced.new(
+                Plurimath::Math::Symbol.new("("),
+                [
+                  Plurimath::Math::Symbol.new("*"),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new("*"),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new("*"),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new("*"),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new("*"),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new("*"),
+                  Plurimath::Math::Symbol.new(","),
+                ],
+                Plurimath::Math::Symbol.new(")"),
+              ),
+              Plurimath::Math::Symbol.new(","),
+              Plurimath::Math::Function::Fenced.new(
+                Plurimath::Math::Symbol.new("("),
+                [
+                  Plurimath::Math::Symbol.new("n"),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Number.new("2"),
+                  Plurimath::Math::Symbol.new("n"),
+                  Plurimath::Math::Symbol.new("-"),
+                  Plurimath::Math::Number.new("1"),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Number.new("3"),
+                  Plurimath::Math::Symbol.new("n"),
+                  Plurimath::Math::Symbol.new("-"),
+                  Plurimath::Math::Number.new("3"),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new("*"),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new("*"),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new("*"),
+                  Plurimath::Math::Symbol.new(","),
+                  Plurimath::Math::Symbol.new("n"),
+                  Plurimath::Math::Function::Fenced.new(
+                    Plurimath::Math::Symbol.new("("),
+                    [
+                      Plurimath::Math::Symbol.new("n"),
+                      Plurimath::Math::Symbol.new("+"),
+                      Plurimath::Math::Number.new("1"),
+                    ],
+                    Plurimath::Math::Symbol.new(")"),
+                  ),
+                  Plurimath::Math::Symbol.new("/"),
+                  Plurimath::Math::Symbol.new("/"),
+                  Plurimath::Math::Number.new("2"),
+                ],
+                Plurimath::Math::Symbol.new(")"),
+              ),
+            ],
+            Plurimath::Math::Symbol.new(")"),
+          )
         ])
         expect(formula).to eq(expected_value)
       end
@@ -11273,30 +11651,38 @@ RSpec.describe Plurimath::Latex::Parser do
       }
       it "returns formula" do
         expected_value = Plurimath::Math::Formula.new([
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Function::Base.new(
-            Plurimath::Math::Symbol.new("x"),
-            Plurimath::Math::Number.new("1")
+          Plurimath::Math::Function::Fenced.new(
+            Plurimath::Math::Symbol.new("("),
+            [
+              Plurimath::Math::Function::Base.new(
+                Plurimath::Math::Symbol.new("x"),
+                Plurimath::Math::Number.new("1")
+              ),
+              Plurimath::Math::Symbol.new(","),
+              Plurimath::Math::Function::Base.new(
+                Plurimath::Math::Symbol.new("x"),
+                Plurimath::Math::Number.new("2")
+              ),
+              Plurimath::Math::Symbol.new(","),
+              Plurimath::Math::Function::Base.new(
+                Plurimath::Math::Symbol.new("x"),
+                Plurimath::Math::Number.new("3")
+              ),
+            ],
+            Plurimath::Math::Symbol.new(")"),
           ),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Function::Base.new(
-            Plurimath::Math::Symbol.new("x"),
-            Plurimath::Math::Number.new("2")
-          ),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Function::Base.new(
-            Plurimath::Math::Symbol.new("x"),
-            Plurimath::Math::Number.new("3")
-          ),
-          Plurimath::Math::Symbol.new(")"),
           Plurimath::Math::Symbol.new("="),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Symbol.new("x"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new("y"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new("z"),
-          Plurimath::Math::Symbol.new(")")
+          Plurimath::Math::Function::Fenced.new(
+            Plurimath::Math::Symbol.new("("),
+            [
+              Plurimath::Math::Symbol.new("x"),
+              Plurimath::Math::Symbol.new(","),
+              Plurimath::Math::Symbol.new("y"),
+              Plurimath::Math::Symbol.new(","),
+              Plurimath::Math::Symbol.new("z"),
+            ],
+            Plurimath::Math::Symbol.new(")"),
+          ),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -11310,30 +11696,38 @@ RSpec.describe Plurimath::Latex::Parser do
       }
       it "returns formula" do
         expected_value = Plurimath::Math::Formula.new([
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Function::Base.new(
-            Plurimath::Math::Symbol.new("u"),
-            Plurimath::Math::Number.new("1")
+          Plurimath::Math::Function::Fenced.new(
+            Plurimath::Math::Symbol.new("("),
+            [
+              Plurimath::Math::Function::Base.new(
+                Plurimath::Math::Symbol.new("u"),
+                Plurimath::Math::Number.new("1")
+              ),
+              Plurimath::Math::Symbol.new(","),
+              Plurimath::Math::Function::Base.new(
+                Plurimath::Math::Symbol.new("u"),
+                Plurimath::Math::Number.new("2")
+              ),
+              Plurimath::Math::Symbol.new(","),
+              Plurimath::Math::Function::Base.new(
+                Plurimath::Math::Symbol.new("u"),
+                Plurimath::Math::Number.new("3")
+              ),
+            ],
+            Plurimath::Math::Symbol.new(")"),
           ),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Function::Base.new(
-            Plurimath::Math::Symbol.new("u"),
-            Plurimath::Math::Number.new("2")
-          ),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Function::Base.new(
-            Plurimath::Math::Symbol.new("u"),
-            Plurimath::Math::Number.new("3")
-          ),
-          Plurimath::Math::Symbol.new(")"),
           Plurimath::Math::Symbol.new("="),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Symbol.new("u"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new("v"),
-          Plurimath::Math::Symbol.new(","),
-          Plurimath::Math::Symbol.new("w"),
-          Plurimath::Math::Symbol.new(")")
+          Plurimath::Math::Function::Fenced.new(
+            Plurimath::Math::Symbol.new("("),
+            [
+              Plurimath::Math::Symbol.new("u"),
+              Plurimath::Math::Symbol.new(","),
+              Plurimath::Math::Symbol.new("v"),
+              Plurimath::Math::Symbol.new(","),
+              Plurimath::Math::Symbol.new("w"),
+            ],
+            Plurimath::Math::Symbol.new(")"),
+          ),
         ])
         expect(formula).to eq(expected_value)
       end
@@ -11484,34 +11878,38 @@ RSpec.describe Plurimath::Latex::Parser do
               Plurimath::Math::Number.new("2")
             ])
           ),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Function::Bar.new(
-            Plurimath::Math::Formula.new([
-              Plurimath::Math::Symbol.new("u"),
-              Plurimath::Math::Unicode.new("&#x27;"),
-              Plurimath::Math::Symbol.new("u"),
-              Plurimath::Math::Unicode.new("&#x27;")
-            ])
+          Plurimath::Math::Function::Fenced.new(
+            Plurimath::Math::Symbol.new("("),
+            [
+              Plurimath::Math::Function::Bar.new(
+                Plurimath::Math::Formula.new([
+                  Plurimath::Math::Symbol.new("u"),
+                  Plurimath::Math::Unicode.new("&#x27;"),
+                  Plurimath::Math::Symbol.new("u"),
+                  Plurimath::Math::Unicode.new("&#x27;")
+                ])
+              ),
+              Plurimath::Math::Symbol.new("+"),
+              Plurimath::Math::Function::Bar.new(
+                Plurimath::Math::Formula.new([
+                  Plurimath::Math::Symbol.new("v"),
+                  Plurimath::Math::Unicode.new("&#x27;"),
+                  Plurimath::Math::Symbol.new("v"),
+                  Plurimath::Math::Unicode.new("&#x27;")
+                ])
+              ),
+              Plurimath::Math::Symbol.new("+"),
+              Plurimath::Math::Function::Bar.new(
+                Plurimath::Math::Formula.new([
+                  Plurimath::Math::Symbol.new("w"),
+                  Plurimath::Math::Unicode.new("&#x27;"),
+                  Plurimath::Math::Symbol.new("w"),
+                  Plurimath::Math::Unicode.new("&#x27;")
+                ])
+              ),
+            ],
+            Plurimath::Math::Symbol.new(")")
           ),
-          Plurimath::Math::Symbol.new("+"),
-          Plurimath::Math::Function::Bar.new(
-            Plurimath::Math::Formula.new([
-              Plurimath::Math::Symbol.new("v"),
-              Plurimath::Math::Unicode.new("&#x27;"),
-              Plurimath::Math::Symbol.new("v"),
-              Plurimath::Math::Unicode.new("&#x27;")
-            ])
-          ),
-          Plurimath::Math::Symbol.new("+"),
-          Plurimath::Math::Function::Bar.new(
-            Plurimath::Math::Formula.new([
-              Plurimath::Math::Symbol.new("w"),
-              Plurimath::Math::Unicode.new("&#x27;"),
-              Plurimath::Math::Symbol.new("w"),
-              Plurimath::Math::Unicode.new("&#x27;")
-            ])
-          ),
-          Plurimath::Math::Symbol.new(")")
         ])
         expect(formula).to eq(expected_value)
       end
@@ -11788,18 +12186,22 @@ RSpec.describe Plurimath::Latex::Parser do
       }
       it "returns formula" do
         expected_value = Plurimath::Math::Formula.new([
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Function::Vec.new(
-            Plurimath::Math::Symbol.new("q")
+          Plurimath::Math::Function::Fenced.new(
+            Plurimath::Math::Symbol.new("("),
+            [
+              Plurimath::Math::Function::Vec.new(
+                Plurimath::Math::Symbol.new("q")
+              ),
+              Plurimath::Math::Symbol.new("&#x22c5;"),
+              Plurimath::Math::Function::Base.new(
+                Plurimath::Math::Function::Hat.new(
+                  Plurimath::Math::Symbol.new("e")
+                ),
+                Plurimath::Math::Symbol.new("x")
+              ),
+            ],
+            Plurimath::Math::Symbol.new(")"),
           ),
-          Plurimath::Math::Symbol.new("&#x22c5;"),
-          Plurimath::Math::Function::Base.new(
-            Plurimath::Math::Function::Hat.new(
-              Plurimath::Math::Symbol.new("e")
-            ),
-            Plurimath::Math::Symbol.new("x")
-          ),
-          Plurimath::Math::Symbol.new(")"),
           Plurimath::Math::Symbol.new("/"),
           Plurimath::Math::Symbol.new("q")
         ])
@@ -11815,18 +12217,22 @@ RSpec.describe Plurimath::Latex::Parser do
       }
       it "returns formula" do
         expected_value = Plurimath::Math::Formula.new([
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Function::Vec.new(
-            Plurimath::Math::Symbol.new("q")
+          Plurimath::Math::Function::Fenced.new(
+            Plurimath::Math::Symbol.new("("),
+            [
+              Plurimath::Math::Function::Vec.new(
+                Plurimath::Math::Symbol.new("q")
+              ),
+              Plurimath::Math::Symbol.new("&#x22c5;"),
+              Plurimath::Math::Function::Base.new(
+                Plurimath::Math::Function::Hat.new(
+                  Plurimath::Math::Symbol.new("e")
+                ),
+                Plurimath::Math::Symbol.new("y")
+              ),
+            ],
+            Plurimath::Math::Symbol.new(")"),
           ),
-          Plurimath::Math::Symbol.new("&#x22c5;"),
-          Plurimath::Math::Function::Base.new(
-            Plurimath::Math::Function::Hat.new(
-              Plurimath::Math::Symbol.new("e")
-            ),
-            Plurimath::Math::Symbol.new("y")
-          ),
-          Plurimath::Math::Symbol.new(")"),
           Plurimath::Math::Symbol.new("/"),
           Plurimath::Math::Symbol.new("q")
         ])
@@ -11842,18 +12248,22 @@ RSpec.describe Plurimath::Latex::Parser do
       }
       it "returns formula" do
         expected_value = Plurimath::Math::Formula.new([
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Function::Vec.new(
-            Plurimath::Math::Symbol.new("q")
+          Plurimath::Math::Function::Fenced.new(
+            Plurimath::Math::Symbol.new("("),
+            [
+              Plurimath::Math::Function::Vec.new(
+                Plurimath::Math::Symbol.new("q")
+              ),
+              Plurimath::Math::Symbol.new("&#x22c5;"),
+              Plurimath::Math::Function::Base.new(
+                Plurimath::Math::Function::Hat.new(
+                  Plurimath::Math::Symbol.new("e")
+                ),
+                Plurimath::Math::Symbol.new("z")
+              ),
+            ],
+            Plurimath::Math::Symbol.new(")"),
           ),
-          Plurimath::Math::Symbol.new("&#x22c5;"),
-          Plurimath::Math::Function::Base.new(
-            Plurimath::Math::Function::Hat.new(
-              Plurimath::Math::Symbol.new("e")
-            ),
-            Plurimath::Math::Symbol.new("z")
-          ),
-          Plurimath::Math::Symbol.new(")"),
           Plurimath::Math::Symbol.new("/"),
           Plurimath::Math::Symbol.new("q")
         ])
@@ -12291,11 +12701,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Function::Tr.new([
                   Plurimath::Math::Function::Td.new(
                     [
-                      Plurimath::Math::Symbol.new("["),
-                      Plurimath::Math::Number.new("2"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::Fenced.new(
+                        Plurimath::Math::Symbol.new("["),
+                        [
+                          Plurimath::Math::Number.new("2"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                        ],
+                        Plurimath::Math::Symbol.new("]"),
+                      ),
                       Plurimath::Math::Formula.new([
                         Plurimath::Math::Function::FontStyle.new(
                           Plurimath::Math::Symbol.new("-"),
@@ -12374,11 +12788,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Function::Tr.new([
                   Plurimath::Math::Function::Td.new(
                     [
-                      Plurimath::Math::Symbol.new("["),
-                      Plurimath::Math::Number.new("3"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::Fenced.new(
+                        Plurimath::Math::Symbol.new("["),
+                        [
+                          Plurimath::Math::Number.new("3"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                        ],
+                        Plurimath::Math::Symbol.new("]"),
+                      ),
                       Plurimath::Math::Function::FontStyle.new(
                         Plurimath::Math::Function::Frac.new(
                           Plurimath::Math::Formula.new([
@@ -12527,11 +12945,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Function::Tr.new([
                   Plurimath::Math::Function::Td.new(
                     [
-                      Plurimath::Math::Symbol.new("["),
-                      Plurimath::Math::Number.new("2"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::Fenced.new(
+                        Plurimath::Math::Symbol.new("["),
+                        [
+                          Plurimath::Math::Number.new("2"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                        ],
+                        Plurimath::Math::Symbol.new("]"),
+                      ),
                       Plurimath::Math::Formula.new([
                         Plurimath::Math::Function::FontStyle.new(
                           Plurimath::Math::Function::Frac.new(
@@ -12636,11 +13058,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Function::Tr.new([
                   Plurimath::Math::Function::Td.new(
                     [
-                      Plurimath::Math::Symbol.new("["),
-                      Plurimath::Math::Number.new("2"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::Fenced.new(
+                        Plurimath::Math::Symbol.new("["),
+                        [
+                          Plurimath::Math::Number.new("2"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                        ],
+                        Plurimath::Math::Symbol.new("]"),
+                      ),
                       Plurimath::Math::Function::FontStyle.new(
                         Plurimath::Math::Function::Frac.new(
                           Plurimath::Math::Formula.new([
@@ -12767,11 +13193,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 Plurimath::Math::Function::Tr.new([
                   Plurimath::Math::Function::Td.new(
                     [
-                      Plurimath::Math::Symbol.new("["),
-                      Plurimath::Math::Number.new("2"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("m"),
-                      Plurimath::Math::Symbol.new("]"),
+                      Plurimath::Math::Function::Fenced.new(
+                        Plurimath::Math::Symbol.new("["),
+                        [
+                          Plurimath::Math::Number.new("2"),
+                          Plurimath::Math::Symbol.new("m"),
+                          Plurimath::Math::Symbol.new("m"),
+                        ],
+                        Plurimath::Math::Symbol.new("]"),
+                      ),
                       Plurimath::Math::Formula.new([
                         Plurimath::Math::Function::FontStyle.new(
                           Plurimath::Math::Symbol.new("-"),
@@ -12928,14 +13358,18 @@ RSpec.describe Plurimath::Latex::Parser do
               Plurimath::Math::Symbol.new("j")
             ])
           ),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Symbol.new("T"),
-          Plurimath::Math::Symbol.new("-"),
-          Plurimath::Math::Function::Base.new(
-            Plurimath::Math::Symbol.new("T"),
-            Plurimath::Math::Number.new("0")
-          ),
-          Plurimath::Math::Symbol.new(")")
+          Plurimath::Math::Function::Fenced.new(
+            Plurimath::Math::Symbol.new("("),
+            [
+              Plurimath::Math::Symbol.new("T"),
+              Plurimath::Math::Symbol.new("-"),
+              Plurimath::Math::Function::Base.new(
+                Plurimath::Math::Symbol.new("T"),
+                Plurimath::Math::Number.new("0")
+              ),
+            ],
+            Plurimath::Math::Symbol.new(")"),
+          )
         ])
         expect(formula).to eq(expected_value)
       end
@@ -13108,11 +13542,15 @@ RSpec.describe Plurimath::Latex::Parser do
                 ])
               ),
               Plurimath::Math::Symbol.new("+"),
-              Plurimath::Math::Symbol.new("("),
-              Plurimath::Math::Symbol.new("u"),
-              Plurimath::Math::Symbol.new("&#xb1;"),
-              Plurimath::Math::Symbol.new("c"),
-              Plurimath::Math::Symbol.new(")"),
+              Plurimath::Math::Function::Fenced.new(
+                Plurimath::Math::Symbol.new("("),
+                [
+                  Plurimath::Math::Symbol.new("u"),
+                  Plurimath::Math::Symbol.new("&#xb1;"),
+                  Plurimath::Math::Symbol.new("c"),
+                ],
+                Plurimath::Math::Symbol.new(")"),
+              ),
               Plurimath::Math::Function::Frac.new(
                 Plurimath::Math::Symbol.new("&#x2202;"),
                 Plurimath::Math::Formula.new([
@@ -13588,16 +14026,24 @@ RSpec.describe Plurimath::Latex::Parser do
       }
       it "returns formula" do
         expected_value = Plurimath::Math::Formula.new([
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Function::FontStyle::Script.new(
-            Plurimath::Math::Symbol.new("F"),
-            "mathcal"
+          Plurimath::Math::Function::Fenced.new(
+            Plurimath::Math::Symbol.new("("),
+            [
+              Plurimath::Math::Function::FontStyle::Script.new(
+                Plurimath::Math::Symbol.new("F"),
+                "mathcal"
+              ),
+              Plurimath::Math::Symbol.new("f"),
+            ],
+            Plurimath::Math::Symbol.new(")"),
           ),
-          Plurimath::Math::Symbol.new("f"),
-          Plurimath::Math::Symbol.new(")"),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Symbol.new("y"),
-          Plurimath::Math::Symbol.new(")"),
+          Plurimath::Math::Function::Fenced.new(
+            Plurimath::Math::Symbol.new("("),
+            [
+              Plurimath::Math::Symbol.new("y"),
+            ],
+            Plurimath::Math::Symbol.new(")"),
+          ),
           Plurimath::Math::Symbol.new("="),
           Plurimath::Math::Function::Frac.new(
             Plurimath::Math::Number.new("1"),
@@ -13625,9 +14071,13 @@ RSpec.describe Plurimath::Latex::Parser do
             )
           ),
           Plurimath::Math::Symbol.new("f"),
-          Plurimath::Math::Symbol.new("("),
-          Plurimath::Math::Symbol.new("x"),
-          Plurimath::Math::Symbol.new(")"),
+          Plurimath::Math::Function::Fenced.new(
+            Plurimath::Math::Symbol.new("("),
+            [
+              Plurimath::Math::Symbol.new("x"),
+            ],
+            Plurimath::Math::Symbol.new(")"),
+          ),
           Plurimath::Math::Symbol.new("&#x2c;"),
           Plurimath::Math::Function::Power.new(
             Plurimath::Math::Symbol.new("e"),

--- a/spec/plurimath/latex_spec.rb
+++ b/spec/plurimath/latex_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe Plurimath::Latex do
             </mstyle>
           </math>
         MATHML
-        latex = "\\left \\{ \\right"
+        latex = "\\left \\{ \\right ."
         expect(formula.to_latex).to be_equivalent_to(latex)
         expect(formula.to_mathml).to be_equivalent_to(mathml)
       end
@@ -607,15 +607,15 @@ RSpec.describe Plurimath::Latex do
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
             <mstyle displaystyle="true">
               <msqrt>
-                <mrow>
-                  <mo>(</mo>
-                  <mo>&#x2212;</mo>
-                  <mn>25</mn>
-                  <msup>
+                <msup>
+                  <mrow>
+                    <mo>(</mo>
+                    <mo>&#x2212;</mo>
+                    <mn>25</mn>
                     <mo>)</mo>
-                    <mn>2</mn>
-                  </msup>
-                </mrow>
+                  </mrow>
+                  <mn>2</mn>
+                </msup>
               </msqrt>
               <mo>=</mo>
               <mo>&#xb1;</mo>
@@ -1346,9 +1346,11 @@ RSpec.describe Plurimath::Latex do
                 </mrow>
               </munder>
               <mi>f</mi>
-              <mo>(</mo>
-              <mi>x</mi>
-              <mo>)</mo>
+              <mrow>
+                <mo>(</mo>
+                <mi>x</mi>
+                <mo>)</mo>
+              </mrow>
             </mstyle>
           </math>
         MATHML
@@ -1374,9 +1376,11 @@ RSpec.describe Plurimath::Latex do
                 </mrow>
               </munder>
               <mi>f</mi>
-              <mo>(</mo>
-              <mi>x</mi>
-              <mo>)</mo>
+              <mrow>
+                <mo>(</mo>
+                <mi>x</mi>
+                <mo>)</mo>
+              </mrow>
             </mstyle>
           </math>
         MATHML
@@ -1404,9 +1408,11 @@ RSpec.describe Plurimath::Latex do
                 </mrow>
               </msub>
               <mi>f</mi>
-              <mo>(</mo>
-              <mi>x</mi>
-              <mo>)</mo>
+              <mrow>
+                <mo>(</mo>
+                <mi>x</mi>
+                <mo>)</mo>
+              </mrow>
             </mstyle>
           </math>
         MATHML
@@ -1430,21 +1436,25 @@ RSpec.describe Plurimath::Latex do
                 <mrow>
                   <mi>x</mi>
                   <mo>&#x2208;</mo>
-                  <mo>[</mo>
-                  <mi>a</mi>
-                  <mo>,</mo>
-                  <mi>b</mi>
-                  <mo>]</mo>
+                  <mrow>
+                    <mo>\\[</mo>
+                    <mi>a</mi>
+                    <mo>,</mo>
+                    <mi>b</mi>
+                    <mo>\\]</mo>
+                  </mrow>
                 </mrow>
               </munder>
               <mi>f</mi>
-              <mo>(</mo>
-              <mi>x</mi>
-              <mo>)</mo>
+              <mrow>
+                <mo>(</mo>
+                <mi>x</mi>
+                <mo>)</mo>
+              </mrow>
             </mstyle>
           </math>
         MATHML
-        latex = "\\max_{x \\in [ a , b ]} f ( x )"
+        latex = "\\max_{x \\in \\[ a , b \\]} f ( x )"
         expect(formula.to_latex).to eql(latex)
         expect(formula.to_mathml).to be_equivalent_to(mathml)
       end
@@ -1464,21 +1474,25 @@ RSpec.describe Plurimath::Latex do
                 <mrow>
                   <mi>x</mi>
                   <mo>&#x2208;</mo>
-                  <mo>[</mo>
-                  <mi>&#x3b1;</mi>
-                  <mo>,</mo>
-                  <mi>&#x3b2;</mi>
-                  <mo>]</mo>
+                  <mrow>
+                    <mo>\\[</mo>
+                    <mi>&#x3b1;</mi>
+                    <mo>,</mo>
+                    <mi>&#x3b2;</mi>
+                    <mo>\\]</mo>
+                  </mrow>
                 </mrow>
               </munder>
               <mi>f</mi>
-              <mo>(</mo>
-              <mi>x</mi>
-              <mo>)</mo>
+              <mrow>
+                <mo>(</mo>
+                <mi>x</mi>
+                <mo>)</mo>
+              </mrow>
             </mstyle>
           </math>
         MATHML
-        latex = "\\min_{x \\in [ \\alpha , \\beta ]} f ( x )"
+        latex = "\\min_{x \\in \\[ \\alpha , \\beta \\]} f ( x )"
         expect(formula.to_latex).to eql(latex)
         expect(formula.to_mathml).to be_equivalent_to(mathml)
       end
@@ -1571,18 +1585,22 @@ RSpec.describe Plurimath::Latex do
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
             <mstyle displaystyle="true">
-              <mo>(</mo>
-              <mn>1</mn>
-              <mo>+</mo>
-              <mo>(</mo>
-              <mi>x</mi>
-              <mo>&#x2212;</mo>
-              <mi>y</mi>
-              <msup>
+              <mrow>
+                <mo>(</mo>
+                <mn>1</mn>
+                <mo>+</mo>
+                <msup>
+                  <mrow>
+                    <mo>(</mo>
+                    <mi>x</mi>
+                    <mo>&#x2212;</mo>
+                    <mi>y</mi>
+                    <mo>)</mo>
+                  </mrow>
+                  <mn>2</mn>
+                </msup>
                 <mo>)</mo>
-                <mn>2</mn>
-              </msup>
-              <mo>)</mo>
+              </mrow>
             </mstyle>
           </math>
         MATHML
@@ -2251,57 +2269,156 @@ RSpec.describe Plurimath::Latex do
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
             <mstyle displaystyle="true">
-              <mo>[</mo>
-              <mi>o</mi>
-              <mi>u</mi>
-              <msub>
-                <mi>t</mi>
-                <mi>k</mi>
-              </msub>
-              <mo>=</mo>
-              <mfrac>
-                <mn>1</mn>
-                <mi>s</mi>
-              </mfrac>
-              <mo>(</mo>
               <mrow>
-                <mi>k</mi>
+                <mo>\\[</mo>
+                <mi>o</mi>
+                <mi>u</mi>
+                <msub>
+                  <mi>t</mi>
+                  <mi>k</mi>
+                </msub>
                 <mo>=</mo>
-                <mo>=</mo>
-                <mn>0</mn>
-                <mi>?</mi>
-                <mn>1</mn>
-                <mo>:</mo>
-                <msqrt>
-                  <mn>2</mn>
-                </msqrt>
-              </mrow>
-              <mo>)</mo>
-              <munderover>
-                <mo>&#x2211;</mo>
+                <mfrac>
+                  <mn>1</mn>
+                  <mi>s</mi>
+                </mfrac>
+                <mo>(</mo>
                 <mrow>
-                  <mi>n</mi>
+                  <mi>k</mi>
+                  <mo>=</mo>
                   <mo>=</mo>
                   <mn>0</mn>
-                </mrow>
-                <mrow>
-                  <mi>s</mi>
-                  <mo>&#x2212;</mo>
+                  <mi>?</mi>
                   <mn>1</mn>
+                  <mo>:</mo>
+                  <msqrt>
+                    <mn>2</mn>
+                  </msqrt>
                 </mrow>
-              </munderover>
-              <mrow>
-                <mi>i</mi>
-                <msub>
-                  <mi>n</mi>
-                  <mi>n</mi>
-                </msub>
-                <mo>&#x22c5;</mo>
-                <mrow>
-                  <mi>cos</mi>
+                <mo>)</mo>
+                <munderover>
+                  <mo>&#x2211;</mo>
                   <mrow>
-                    <mo>(</mo>
+                    <mi>n</mi>
+                    <mo>=</mo>
+                    <mn>0</mn>
+                  </mrow>
+                  <mrow>
+                    <mi>s</mi>
+                    <mo>&#x2212;</mo>
+                    <mn>1</mn>
+                  </mrow>
+                </munderover>
+                <mrow>
+                  <mi>i</mi>
+                  <msub>
+                    <mi>n</mi>
+                    <mi>n</mi>
+                  </msub>
+                  <mo>&#x22c5;</mo>
+                  <mrow>
+                    <mi>cos</mi>
                     <mrow>
+                      <mo>(</mo>
+                      <mrow>
+                        <mfrac>
+                          <mrow>
+                            <mi>&#x3c0;</mi>
+                            <mi>k</mi>
+                          </mrow>
+                          <mi>s</mi>
+                        </mfrac>
+                        <mo>(</mo>
+                        <mrow>
+                          <mi>n</mi>
+                          <mo>+</mo>
+                          <mfrac>
+                            <mn>1</mn>
+                            <mn>2</mn>
+                          </mfrac>
+                        </mrow>
+                        <mo>)</mo>
+                      </mrow>
+                      <mo>)</mo>
+                    </mrow>
+                  </mrow>
+                </mrow>
+                <mo>\\]</mo>
+              </mrow>
+            </mstyle>
+          </math>
+        MATHML
+        latex = <<~LATEX
+          \\[out_{k} = \\frac{1}{s}\\left(k == 0 ? 1 : \\sqrt{2}\\right)\\sum_{n = 0}^{s - 1}in_{n} \\cdot \\cos{\\left( \\frac{\\pi k}{s}\\left( n + \\frac{1}{2} \\right) \\right)}\\]
+        LATEX
+        expect(formula.to_latex.gsub(/\s+/, "")).to eql(latex.gsub(/\s+/, ""))
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains example #46" do
+      let(:string) do
+        <<~LATEX
+          \\[out_k = \\frac{1}{s} (k == 0 ? 1 : \\sqrt{2}) \\sum_{n = 0}^{s - 1}{in_{n} \\cdot
+            \\cos( \\frac{\\pi k}{s} ( n + \\frac{1}{2} ) )}\\]
+        LATEX
+      end
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mrow>
+                <mo>\\[</mo>
+                <mi>o</mi>
+                <mi>u</mi>
+                <msub>
+                  <mi>t</mi>
+                  <mi>k</mi>
+                </msub>
+                <mo>=</mo>
+                <mfrac>
+                  <mn>1</mn>
+                  <mi>s</mi>
+                </mfrac>
+                <mrow>
+                  <mo>(</mo>
+                  <mi>k</mi>
+                  <mo>=</mo>
+                  <mo>=</mo>
+                  <mn>0</mn>
+                  <mi>?</mi>
+                  <mn>1</mn>
+                  <mo>:</mo>
+                  <msqrt>
+                    <mn>2</mn>
+                  </msqrt>
+                  <mo>)</mo>
+                </mrow>
+                <munderover>
+                  <mo>&#x2211;</mo>
+                  <mrow>
+                    <mi>n</mi>
+                    <mo>=</mo>
+                    <mn>0</mn>
+                  </mrow>
+                  <mrow>
+                    <mi>s</mi>
+                    <mo>&#x2212;</mo>
+                    <mn>1</mn>
+                  </mrow>
+                </munderover>
+                <mrow>
+                  <mi>i</mi>
+                  <msub>
+                    <mi>n</mi>
+                    <mi>n</mi>
+                  </msub>
+                  <mo>&#x22c5;</mo>
+                  <mrow>
+                    <mi>cos</mi>
+                    <mrow>
+                      <mo>(</mo>
                       <mfrac>
                         <mrow>
                           <mi>&#x3c0;</mi>
@@ -2309,27 +2426,27 @@ RSpec.describe Plurimath::Latex do
                         </mrow>
                         <mi>s</mi>
                       </mfrac>
-                      <mo>(</mo>
                       <mrow>
+                        <mo>(</mo>
                         <mi>n</mi>
                         <mo>+</mo>
                         <mfrac>
                           <mn>1</mn>
                           <mn>2</mn>
                         </mfrac>
+                        <mo>)</mo>
                       </mrow>
                       <mo>)</mo>
                     </mrow>
-                    <mo>)</mo>
                   </mrow>
                 </mrow>
+                <mo>\\]</mo>
               </mrow>
-              <mo>]</mo>
             </mstyle>
           </math>
         MATHML
         latex = <<~LATEX
-          [out_{k} = \\frac{1}{s}\\left(k == 0 ? 1 : \\sqrt{2}\\right)\\sum_{n = 0}^{s - 1}in_{n} \\cdot \\cos{\\left( \\frac{\\pi k}{s}\\left( n + \\frac{1}{2} \\right) \\right)}]
+          \\[out_{k} = \\frac{1}{s}(k == 0 ? 1 : \\sqrt{2})\\sum_{n = 0}^{s - 1}in_{n} \\cdot \\cos{( \\frac{\\pi k}{s}( n + \\frac{1}{2} ) )}\\]
         LATEX
         expect(formula.to_latex.gsub(/\s+/, "")).to eql(latex.gsub(/\s+/, ""))
         expect(formula.to_mathml).to be_equivalent_to(mathml)

--- a/spec/plurimath/latex_spec.rb
+++ b/spec/plurimath/latex_spec.rb
@@ -2180,7 +2180,7 @@ RSpec.describe Plurimath::Latex do
       end
     end
 
-    context "contains example #44" do
+    context "contains example #45" do
       let(:string) do
         <<~LATEX
           V = \\frac{1}{2} \\: {\\bf u}^t \\:
@@ -2258,7 +2258,7 @@ RSpec.describe Plurimath::Latex do
       end
     end
 
-    context "contains example #45" do
+    context "contains example #46" do
       let(:string) do
         <<~LATEX
             \\[out_k = \\frac{1}{s}\\left(k == 0 ? 1 : \\sqrt{2}\\right)\\sum_{n = 0}^{s - 1}{in_{n} \\cdot \\cos\\left( \\frac{\\pi k}{s}\\left( n + \\frac{1}{2} \\right) \\right)}\\]
@@ -2356,7 +2356,7 @@ RSpec.describe Plurimath::Latex do
       end
     end
 
-    context "contains example #46" do
+    context "contains example #47" do
       let(:string) do
         <<~LATEX
           \\[out_k = \\frac{1}{s} (k == 0 ? 1 : \\sqrt{2}) \\sum_{n = 0}^{s - 1}{in_{n} \\cdot

--- a/spec/plurimath/math/formula/latex_spec.rb
+++ b/spec/plurimath/math/formula/latex_spec.rb
@@ -13301,7 +13301,7 @@ RSpec.describe Plurimath::Math::Formula do
           )
         ])
       }
-      let(:expected_value) { "a_{\\left\\{\\left.\\begin{matrix}{a}11\\end{matrix}\\right.\\right\\}}^{4terms}" }
+      let(:expected_value) { "a_{\\{\\left.\\begin{matrix}{a}11\\end{matrix}\\right.\\}}^{4terms}" }
       it "returns formula" do
         expect(formula).to eq(expected_value.gsub(/\s/, ""))
       end

--- a/spec/plurimath/math/function/fenced_spec.rb
+++ b/spec/plurimath/math/function/fenced_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe Plurimath::Math::Function::Fenced do
       let(:third_value) { Plurimath::Math::Symbol.new(")") }
 
       it "returns mathml string" do
-        expect(formula).to eql(" \\left ( n \\right ) ")
+        expect(formula).to eql("( n )")
       end
     end
 
@@ -159,7 +159,7 @@ RSpec.describe Plurimath::Math::Function::Fenced do
       let(:third_value) { Plurimath::Math::Symbol.new("}") }
 
       it "returns mathml string" do
-        expect(formula).to eql(" \\left \\{ 70 \\right \\} ")
+        expect(formula).to eql("\\{ 70 \\}")
       end
     end
 
@@ -178,7 +178,7 @@ RSpec.describe Plurimath::Math::Function::Fenced do
       let(:third_value) { Plurimath::Math::Symbol.new("]") }
 
       it "returns mathml string" do
-        expect(formula).to eql(" \\left [ \\sum_{&}^{\\text{so}} \\right ] ")
+        expect(formula).to eql("[ \\sum_{&}^{\\text{so}} ]")
       end
     end
   end


### PR DESCRIPTION
This PR adds the following features/fixes.
1. Adds more Left and Right delimiters `\left( ... \right)`.
a. closes #151 
2. Fixes parenthesis misplacement in MathML conversion from LaTex.
a. closes #145 