### PR TITLE
Fixed MathML conversion for dot class and increased code coverage

### DIFF
--- a/lib/plurimath/asciimath/transform.rb
+++ b/lib/plurimath/asciimath/transform.rb
@@ -615,17 +615,6 @@ module Plurimath
         )
       end
 
-      rule(binary_class: simple(:function),
-           base_value: sequence(:base)) do
-        binary = Utility.get_class(function).new(
-          Utility.unfenced_value(base.shift),
-          Utility.unfenced_value(base.shift),
-        )
-        new_arr = [binary]
-        new_arr += base.flatten.compact unless base.empty?
-        new_arr
-      end
-
       rule(d: simple(:d),
            x: simple(:x)) do
         Math::Formula.new(
@@ -633,52 +622,6 @@ module Plurimath
             Utility.symbol_object(d),
             Utility.symbol_object(x),
           ],
-        )
-      end
-
-      rule(symbol: simple(:symbol),
-           power: simple(:power)) do
-        Math::Function::Power.new(
-          Utility.symbol_object(
-            (Constants::SYMBOLS[symbol.to_sym] || symbol).to_s,
-          ),
-          Utility.unfenced_value(power),
-        )
-      end
-
-      rule(symbol: simple(:symbol),
-           power: sequence(:power)) do
-        Math::Function::Power.new(
-          Utility.symbol_object(
-            (Constants::SYMBOLS[symbol.to_sym] || symbol).to_s,
-          ),
-          Utility.unfenced_value(power),
-        )
-      end
-
-      rule(symbol: simple(:sym),
-           expr: sequence(:expr)) do
-        symbol = Utility.symbol_object(
-          (Constants::SYMBOLS[sym.to_sym] || sym).to_s,
-        )
-        expr.flatten.compact.insert(0, symbol)
-      end
-
-      rule(symbol: simple(:sym),
-           expr: simple(:expr)) do
-        symbol = Utility.symbol_object(
-          (Constants::SYMBOLS[sym.to_sym] || sym).to_s,
-        )
-        [symbol, expr]
-      end
-
-      rule(symbol: simple(:symbol),
-           base: simple(:base)) do
-        Math::Function::Base.new(
-          Utility.symbol_object(
-            (Constants::SYMBOLS[symbol.to_sym] || symbol).to_s,
-          ),
-          Utility.unfenced_value(base),
         )
       end
 
@@ -813,92 +756,6 @@ module Plurimath
         Math::Function::Mod.new(
           dividend,
           divisor,
-        )
-      end
-
-      rule(text: simple(:text),
-           base_value: simple(:base),
-           power_value: simple(:power)) do
-        Math::Function::PowerBase.new(
-          Math::Function::Text.new(text),
-          Utility.unfenced_value(base),
-          Utility.unfenced_value(power),
-        )
-      end
-
-      rule(number: simple(:number),
-           base_value: simple(:base),
-           power_value: simple(:power)) do
-        Math::Function::PowerBase.new(
-          Math::Number.new(number),
-          Utility.unfenced_value(base),
-          Utility.unfenced_value(power),
-        )
-      end
-
-      rule(unary: simple(:unary),
-           base_value: simple(:base),
-           power_value: simple(:power)) do
-        Math::Function::PowerBase.new(
-          unary,
-          Utility.unfenced_value(base),
-          Utility.unfenced_value(power),
-        )
-      end
-
-      rule(unary: sequence(:unary),
-           base_value: simple(:base),
-           power_value: simple(:power)) do
-        unary.first.new(
-          unary.last.new(
-            Utility.unfenced_value(base),
-            Utility.unfenced_value(power),
-          ),
-        )
-      end
-
-      rule(intermediate_exp: simple(:int_exp),
-           base_value: simple(:base),
-           power_value: simple(:power)) do
-        Math::Function::PowerBase.new(
-          int_exp,
-          Utility.unfenced_value(base),
-          Utility.unfenced_value(power),
-        )
-      end
-
-      rule(intermediate_exp: simple(:int_exp),
-           base_value: simple(:base),
-           power_value: sequence(:power)) do
-        Math::Function::PowerBase.new(
-          int_exp,
-          Utility.unfenced_value(base),
-          Utility.filter_values(power),
-        )
-      end
-
-      rule(symbol: simple(:symbol),
-           base_value: simple(:base),
-           power_value: simple(:power)) do
-        Math::Function::PowerBase.new(
-          Utility.symbol_object(
-            (Constants::SYMBOLS[symbol.to_sym] || symbol).to_s,
-          ),
-          Utility.unfenced_value(base),
-          Utility.unfenced_value(power),
-        )
-      end
-
-      rule(symbol: simple(:symbol),
-           base_value: simple(:base),
-           power_value: sequence(:power)) do
-        symbol_object = Utility.symbol_object(
-          (Constants::SYMBOLS[symbol.to_sym] || symbol).to_s,
-        )
-        Math::Function::PowerBase.new(
-          symbol_object,
-          Utility.unfenced_value(base),
-          Utility.filter_values(power),
         )
       end
 

--- a/lib/plurimath/latex/transform.rb
+++ b/lib/plurimath/latex/transform.rb
@@ -310,8 +310,13 @@ module Plurimath
 
       rule(unary_functions: simple(:unary),
            supscript: simple(:supscript)) do
+        unary_function = if unary.is_a?(Parslet::Slice)
+                           Utility.get_class(unary).new
+                         else
+                           unary
+                         end
         Math::Function::Power.new(
-          unary,
+          unary_function,
           supscript,
         )
       end
@@ -319,8 +324,13 @@ module Plurimath
       rule(unary_functions: simple(:unary),
            subscript: simple(:subscript),
            supscript: simple(:supscript)) do
+        unary_function = if unary.is_a?(Parslet::Slice)
+                           Utility.get_class(unary).new
+                         else
+                           unary
+                         end
         Math::Function::PowerBase.new(
-          unary,
+          unary_function,
           subscript,
           supscript,
         )
@@ -551,14 +561,6 @@ module Plurimath
         Math::Function::Base.new(
           expression,
           subscript,
-        )
-      end
-
-      rule(rparen: simple(:rparen),
-           supscript: simple(:supscript)) do
-        Math::Function::Power.new(
-          Math::Symbol.new(rparen),
-          supscript,
         )
       end
 

--- a/lib/plurimath/math/function/dot.rb
+++ b/lib/plurimath/math/function/dot.rb
@@ -6,6 +6,18 @@ module Plurimath
   module Math
     module Function
       class Dot < UnaryFunction
+        def to_mathml_without_math_tag
+          first_value = parameter_one&.to_mathml_without_math_tag
+          dot_tag = (Utility.ox_element("mo") << ".")
+          over_tag = Utility.ox_element("mover")
+          Utility.update_nodes(
+            over_tag,
+            [
+              first_value,
+              dot_tag,
+            ],
+          )
+        end
       end
     end
   end

--- a/spec/plurimath/asciimath/parser_spec.rb
+++ b/spec/plurimath/asciimath/parser_spec.rb
@@ -1683,5 +1683,28 @@ RSpec.describe Plurimath::Asciimath::Parser do
         expect(formula).to eq(expected_value)
       end
     end
+
+    context "when contains example extracted from metanorma/site #3" do
+      let(:string) { "hat ii(V)_(\"cal\",i)" }
+
+      it "returns formula" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Base.new(
+            Plurimath::Math::Function::Hat.new(
+              Plurimath::Math::Function::FontStyle::Italic.new(
+                Plurimath::Math::Symbol.new("V"),
+                "ii"
+              ),
+            ),
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Function::Text.new("cal"),
+              Plurimath::Math::Symbol.new(","),
+              Plurimath::Math::Symbol.new("i")
+            ])
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
   end
 end

--- a/spec/plurimath/asciimath_spec.rb
+++ b/spec/plurimath/asciimath_spec.rb
@@ -4219,5 +4219,304 @@ RSpec.describe Plurimath::Asciimath do
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
+
+    context "contains ubrace only example #80" do
+      let(:string) { 'ubrace' }
+
+      it 'returns parsed Asciimath to Formula' do
+        latex = '\underbrace'
+        asciimath = 'ubrace'
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mo>&#x23df;</mo>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
+      end
+    end
+
+    context "contains obrace only example #81" do
+      let(:string) { 'obrace' }
+
+      it 'returns parsed Asciimath to Formula' do
+        latex = '\overbrace'
+        asciimath = 'obrace'
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mo>&#x23de;</mo>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
+      end
+    end
+
+    context "contains SanSerif and Monospace font styles example #82" do
+      let(:string) { 'mathtt(d)mathsf(e)' }
+
+      it 'returns parsed Asciimath to Formula' do
+        latex = '\mathtt{d} \mathsf{e}'
+        asciimath = 'mathtt(d) mathsf(e)'
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mstyle mathvariant="monospace">
+                <mi>d</mi>
+              </mstyle>
+              <mstyle mathvariant="sans-serif">
+                <mi>e</mi>
+              </mstyle>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
+      end
+    end
+
+    context "contains right paren power and single expression example #83" do
+      let(:string) { ')^e v' }
+
+      it 'returns parsed Asciimath to Formula' do
+        latex = ')^{e} v'
+        asciimath = ')^(e) v'
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <msup>
+                <mo>)</mo>
+                <mi>e</mi>
+              </msup>
+              <mi>v</mi>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
+      end
+    end
+
+    context "contains right paren power comma and single expression example #84" do
+      let(:string) { ')^e,v' }
+
+      it 'returns parsed Asciimath to Formula' do
+        latex = ')^{e} , v'
+        asciimath = ')^(e) , v'
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <msup>
+                <mo>)</mo>
+                <mi>e</mi>
+              </msup>
+              <mo>,</mo>
+              <mi>v</mi>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
+      end
+    end
+
+    context "contains right paren power comma and sequence of expression example #85" do
+      let(:string) { ')^e dv' }
+
+      it 'returns parsed Asciimath to Formula' do
+        latex = ')^{e} d v'
+        asciimath = ')^(e) d v'
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <msup>
+                <mo>)</mo>
+                <mi>e</mi>
+              </msup>
+              <mi>d</mi>
+              <mi>v</mi>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
+      end
+    end
+
+    context "contains right power base binary class and expression(sequence and simple) example #86" do
+      let(:string) { 'sum_(d)^(3) prod_(dd)^(dd)' }
+
+      it 'returns parsed Asciimath to Formula' do
+        latex = '\sum_{d}^{3} \prod_{d d}^{d d}'
+        asciimath = 'sum_(d)^(3) prod_(d d)^(d d)'
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <munderover>
+                <mo>&#x2211;</mo>
+                <mi>d</mi>
+                <mn>3</mn>
+              </munderover>
+              <munderover>
+                <mo>&#x220f;</mo>
+                <mrow>
+                  <mi>d</mi>
+                  <mi>d</mi>
+                </mrow>
+                <mrow>
+                  <mi>d</mi>
+                  <mi>d</mi>
+                </mrow>
+              </munderover>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
+      end
+    end
+
+    context "contains dot with random value example #87" do
+      let(:string) { 'dot(x)' }
+
+      it 'returns parsed Asciimath to Formula' do
+        latex = '\dot{x}'
+        asciimath = 'dot(x)'
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mover>
+                <mi>x</mi>
+                <mo>.</mo>
+              </mover>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
+      end
+    end
+  end
+
+  describe ".to_omml" do
+    subject(:formula) { Plurimath::Asciimath.new(string).to_formula.to_omml }
+
+    context "contains example #01" do
+      let(:string) { '(d2)' }
+
+      it 'returns parsed Asciimath to Formula' do
+        omml = <<~OMML
+          <m:oMathPara
+            xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math"
+            xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+            xmlns:mo="http://schemas.microsoft.com/office/mac/office/2008/main"
+            xmlns:mv="urn:schemas-microsoft-com:mac:vml"
+            xmlns:o="urn:schemas-microsoft-com:office:office"
+            xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+            xmlns:v="urn:schemas-microsoft-com:vml"
+            xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+            xmlns:w10="urn:schemas-microsoft-com:office:word"
+            xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"
+            xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml"
+            xmlns:wne="http://schemas.microsoft.com/office/word/2006/wordml"
+            xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+            xmlns:wp14="http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing"
+            xmlns:wpc="http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas"
+            xmlns:wpg="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup"
+            xmlns:wpi="http://schemas.microsoft.com/office/word/2010/wordprocessingInk"
+            xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape">
+            <m:oMath>
+              <m:d>
+                <m:dPr>
+                  <m:begChr m:val="("/>
+                  <m:endChr m:val=")"/>
+                  <m:ctrlPr>
+                    <w:rPr>
+                      <w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/>
+                      <w:i/>
+                    </w:rPr>
+                  </m:ctrlPr>
+                </m:dPr>
+                <m:e>
+                  <m:r>
+                    <m:t>d</m:t>
+                  </m:r>
+                </m:e>
+                <m:e>
+                  <m:r>
+                    <m:t>2</m:t>
+                  </m:r>
+                </m:e>
+              </m:d>
+            </m:oMath>
+          </m:oMathPara>
+        OMML
+        expect(formula).to be_equivalent_to(omml)
+      end
+    end
+
+    context "contains example #02" do
+      let(:string) { 'log_(d)^(d)' }
+
+      it 'returns parsed Asciimath to Formula' do
+        omml = <<~OMML
+          <m:oMathPara
+            xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math"
+            xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+            xmlns:mo="http://schemas.microsoft.com/office/mac/office/2008/main"
+            xmlns:mv="urn:schemas-microsoft-com:mac:vml"
+            xmlns:o="urn:schemas-microsoft-com:office:office"
+            xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+            xmlns:v="urn:schemas-microsoft-com:vml"
+            xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+            xmlns:w10="urn:schemas-microsoft-com:office:word"
+            xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"
+            xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml"
+            xmlns:wne="http://schemas.microsoft.com/office/word/2006/wordml"
+            xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+            xmlns:wp14="http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing"
+            xmlns:wpc="http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas"
+            xmlns:wpg="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup"
+            xmlns:wpi="http://schemas.microsoft.com/office/word/2010/wordprocessingInk"
+            xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape">
+            <m:oMath>
+              <m:func>
+                <m:funcPr>
+                  <m:ctrlPr>
+                    <w:rPr>
+                      <w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/>
+                      <w:i/>
+                    </w:rPr>
+                  </m:ctrlPr>
+                </m:funcPr>
+                <m:fName>
+                  <m:r>
+                    <w:rPr>
+                      <w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/>
+                    </w:rPr>
+                    <m:t>log</m:t>
+                  </m:r>
+                </m:fName>
+                <m:e>d</m:e>
+                <m:e>d</m:e>
+              </m:func>
+            </m:oMath>
+          </m:oMathPara>
+        OMML
+        expect(formula).to be_equivalent_to(omml)
+      end
+    end
   end
 end

--- a/spec/plurimath/latex/parser_spec.rb
+++ b/spec/plurimath/latex/parser_spec.rb
@@ -14179,5 +14179,53 @@ RSpec.describe Plurimath::Latex::Parser do
         expect(formula).to eq(expected_value)
       end
     end
+
+    context "contains latex equation #173" do
+      let(:string) {
+        <<~LATEX
+          a_i = \\lambda ^ i \\hat{a}_i
+        LATEX
+      }
+      it "returns formula" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Base.new(
+            Plurimath::Math::Symbol.new("a"),
+            Plurimath::Math::Symbol.new("i")
+          ),
+          Plurimath::Math::Symbol.new("="),
+          Plurimath::Math::Function::Power.new(
+            Plurimath::Math::Symbol.new("&#x3bb;"),
+            Plurimath::Math::Symbol.new("i")
+          ),
+          Plurimath::Math::Function::Base.new(
+            Plurimath::Math::Function::Hat.new(
+              Plurimath::Math::Symbol.new("a"),
+            ),
+            Plurimath::Math::Symbol.new("i")
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains latex equation unary function with power and base values #174" do
+      let(:string) {
+        <<~LATEX
+          \\sin{10}_{d}^{e}
+        LATEX
+      }
+      it "returns formula" do
+        expected_value = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::PowerBase.new(
+            Plurimath::Math::Function::Sin.new(
+              Plurimath::Math::Number.new("10"),
+            ),
+            Plurimath::Math::Symbol.new("d"),
+            Plurimath::Math::Symbol.new("e"),
+          )
+        ])
+        expect(formula).to eq(expected_value)
+      end
+    end
   end
 end

--- a/spec/plurimath/latex_spec.rb
+++ b/spec/plurimath/latex_spec.rb
@@ -2452,5 +2452,119 @@ RSpec.describe Plurimath::Latex do
         expect(formula.to_mathml).to be_equivalent_to(mathml)
       end
     end
+
+    context "contains power base values for unary function example #48" do
+      let(:string) do
+        <<~LATEX
+          \\sin_d^e
+        LATEX
+      end
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <msubsup>
+                <mrow>
+                  <mi>sin</mi>
+                </mrow>
+                <mi>d</mi>
+                <mi>e</mi>
+              </msubsup>
+            </mstyle>
+          </math>
+        MATHML
+        latex = <<~LATEX
+          \\sin_{d}^{e}
+        LATEX
+        expect(formula.to_latex.gsub(/\s+/, "")).to eql(latex.gsub(/\s+/, ""))
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains power values for unary function example #49" do
+      let(:string) do
+        <<~LATEX
+          \\sin^e
+        LATEX
+      end
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <msup>
+                <mrow>
+                  <mi>sin</mi>
+                </mrow>
+                <mi>e</mi>
+              </msup>
+            </mstyle>
+          </math>
+        MATHML
+        latex = <<~LATEX
+          \\sin^{e}
+        LATEX
+        expect(formula.to_latex.gsub(/\s+/, "")).to eql(latex.gsub(/\s+/, ""))
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains power values for unary function example #50" do
+      let(:string) do
+        <<~LATEX
+          \\left. sin_e \\right .
+        LATEX
+      end
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mo/>
+              <mrow>
+                <mi>s</mi>
+                <mi>i</mi>
+                <msub>
+                  <mi>n</mi>
+                  <mi>e</mi>
+                </msub>
+              </mrow>
+              <mo/>
+            </mstyle>
+          </math>
+        MATHML
+        latex = <<~LATEX
+          \\left . s i n_{e} \\right .
+        LATEX
+        expect(formula.to_latex.gsub(/\s+/, "")).to eql(latex.gsub(/\s+/, ""))
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
+
+    context "contains power values for unary function example #51" do
+      let(:string) do
+        <<~LATEX
+          \\left. e \\right .
+        LATEX
+      end
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mo/>
+              <mi>e</mi>
+              <mo/>
+            </mstyle>
+          </math>
+        MATHML
+        latex = <<~LATEX
+          \\left . e \\right .
+        LATEX
+        expect(formula.to_latex.gsub(/\s+/, "")).to eql(latex.gsub(/\s+/, ""))
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
   end
 end

--- a/spec/plurimath/math/function/dot_spec.rb
+++ b/spec/plurimath/math/function/dot_spec.rb
@@ -62,11 +62,10 @@ RSpec.describe Plurimath::Math::Function::Dot do
 
       it "returns mathml string" do
         expected_value = <<~MATHML
-
-          <mrow>
-            <mo>dot</mo>
+          <mover>
             <mi>n</mi>
-          </mrow>
+            <mo>.</mo>
+          </mover>
         MATHML
         expect(formula).to be_equivalent_to(expected_value)
       end
@@ -77,10 +76,10 @@ RSpec.describe Plurimath::Math::Function::Dot do
 
       it "returns mathml string" do
         expected_value = <<~MATHML
-          <mrow>
-            <mo>dot</mo>
+          <mover>
             <mn>70</mn>
-          </mrow>
+            <mo>.</mo>
+          </mover>
         MATHML
         expect(formula).to be_equivalent_to(expected_value)
       end
@@ -97,8 +96,7 @@ RSpec.describe Plurimath::Math::Function::Dot do
       end
       it "returns mathml string" do
         expected_value = <<~MATHML
-          <mrow>
-            <mo>dot</mo>
+          <mover>
             <mrow>
               <munderover>
                 <mo>&#x2211;</mo>
@@ -106,7 +104,8 @@ RSpec.describe Plurimath::Math::Function::Dot do
                 <mtext>so</mtext>
               </munderover>
             </mrow>
-          </mrow>
+            <mo>.</mo>
+          </mover>
         MATHML
         expect(formula).to be_equivalent_to(expected_value)
       end

--- a/spec/plurimath/mathml/parser_spec.rb
+++ b/spec/plurimath/mathml/parser_spec.rb
@@ -1729,4 +1729,73 @@ RSpec.describe Plurimath::Mathml::Parser do
       expect(formula).to eq(expected_value)
     end
   end
+
+  context "contains metanorma mathml string Exp #1" do
+    let(:exp) {
+      <<~MATHML
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <mathml:mstyle scriptminsize="6pt">
+            <msub>
+              <mrow>
+                <mstyle mathvariant="italic">
+                  <mi>W</mi>
+                </mstyle>
+              </mrow>
+              <mrow>
+                <mi>t</mi>
+              </mrow>
+            </msub>
+            <mathml:mo rspace="-0.35em"/>
+            <mfenced open="(" close=")" separators="">
+              <mathml:mspace width="-0.15em"/>
+              <mrow>
+                <msub>
+                  <mrow>
+                    <mstyle mathvariant="italic">
+                      <mi>T</mi>
+                    </mstyle>
+                  </mrow>
+                  <mrow>
+                    <mn>90</mn>
+                  </mrow>
+                </msub>
+              </mrow>
+              <mathml:mspace width="-0.1em"/>
+            </mfenced>
+          </mathml:mstyle>
+        </math>
+      MATHML
+    }
+    it "returns formula of decimal values" do
+      expected_value = Plurimath::Math::Formula.new([
+        Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Base.new(
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Symbol.new("W")
+            ]),
+            Plurimath::Math::Formula.new([
+              Plurimath::Math::Symbol.new("t")
+            ])
+          ),
+          Plurimath::Math::Function::Fenced.new(
+            Plurimath::Math::Symbol.new("("),
+            [
+              Plurimath::Math::Formula.new([
+                Plurimath::Math::Function::Base.new(
+                  Plurimath::Math::Formula.new([
+                    Plurimath::Math::Symbol.new("T")
+                  ]),
+                  Plurimath::Math::Formula.new([
+                    Plurimath::Math::Number.new("90")
+                  ])
+                )
+              ])
+            ],
+            Plurimath::Math::Symbol.new(")"),
+          )
+        ])
+      ])
+      expect(formula).to eq(expected_value)
+    end
+  end
 end


### PR DESCRIPTION
This pull request aims to
1. Enhance the **MathML** conversion process for the **dot** class, ensuring the accurate rendering of **dot** symbols in **MathML** format.
2. It focuses on increasing the code coverage.

closes #155 