### PR TITLE
Added support to allow user to input 'displaystyle' attribute value

### DIFF
--- a/lib/plurimath/math/formula.rb
+++ b/lib/plurimath/math/formula.rb
@@ -3,12 +3,17 @@
 module Plurimath
   module Math
     class Formula < Core
-      attr_accessor :value, :left_right_wrapper
+      attr_accessor :value, :left_right_wrapper, :displaystyle
 
-      def initialize(value = [], left_right_wrapper = true)
+      def initialize(
+        value = [],
+        left_right_wrapper = true,
+        displaystyle: true
+      )
         @value = value.is_a?(Array) ? value : [value]
         left_right_wrapper = false if @value.first.is_a?(Function::Left)
         @left_right_wrapper = left_right_wrapper
+        @displaystyle = displaystyle
       end
 
       def ==(object)
@@ -20,12 +25,12 @@ module Plurimath
         value.map(&:to_asciimath).join(" ")
       end
 
-      def to_mathml
+      def to_mathml(display_style: displaystyle)
         math_attrs = {
           xmlns: "http://www.w3.org/1998/Math/MathML",
           display: "block",
         }
-        style_attrs = { displaystyle: "true" }
+        style_attrs = { displaystyle: display_style }
         math  = Utility.ox_element("math", attributes: math_attrs)
         style = Utility.ox_element("mstyle", attributes: style_attrs)
         Utility.update_nodes(style, mathml_content)

--- a/lib/plurimath/mathml/parser.rb
+++ b/lib/plurimath/mathml/parser.rb
@@ -21,10 +21,12 @@ module Plurimath
       end
 
       def parse
-        ox_nodes = Ox.load(text, strip_namespace: true).nodes
-        nodes = parse_nodes(ox_nodes)
+        ox_nodes = Ox.load(text, strip_namespace: true)
+        display_style = ox_nodes&.locate("*/mstyle/@displaystyle")&.first
+        nodes = parse_nodes(ox_nodes.nodes)
         Math::Formula.new(
           Transform.new.apply(nodes).flatten.compact,
+          displaystyle: display_style
         )
       end
 

--- a/spec/plurimath/math/formula/mathml_spec.rb
+++ b/spec/plurimath/math/formula/mathml_spec.rb
@@ -2,7 +2,8 @@ require "./spec/spec_helper"
 
 RSpec.describe Plurimath::Math::Formula do
   describe ".to_mathml" do
-    subject(:formula) { exp.to_mathml }
+    subject(:formula) { exp.to_mathml(display_style: display_style) }
+    let(:display_style) { true }
 
     context "contains mathml string of sin formula" do
       let(:exp) {
@@ -877,11 +878,12 @@ RSpec.describe Plurimath::Math::Formula do
           Plurimath::Math::Number.new("1")
         ])
       }
+      let(:display_style) { false }
       it "returns string of bold text" do
         expected_value =
         <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
-            <mstyle displaystyle="true">
+            <mstyle displaystyle="false">
               <mi>n</mi>
               <mo>&lt;</mo>
               <mn>1</mn>

--- a/spec/plurimath/mathml_spec.rb
+++ b/spec/plurimath/mathml_spec.rb
@@ -178,14 +178,14 @@ RSpec.describe Plurimath::Mathml do
           <math>
             <semantics>
               <mrow>
-              <mstyle displaystyle='true'>
-                <mrow>
-                  <msubsup>
-                    <mo>∫</mo>
-                    <mrow>
-                      <msub>
-                        <mi>t</mi>
-                        <mn>2</mn>
+                <mstyle displaystyle='true'>
+                  <mrow>
+                    <msubsup>
+                      <mo>∫</mo>
+                      <mrow>
+                        <msub>
+                          <mi>t</mi>
+                          <mn>2</mn>
                         </msub>
                       </mrow>
                       <mrow>


### PR DESCRIPTION
This PR implements the changes to allow users to explicitly set `displaystyle` attribute's value in **MathML**.

closes #168 