### PR TITLE
Updated OMML conversion methods for underover

### DIFF
--- a/lib/plurimath/math/core.rb
+++ b/lib/plurimath/math/core.rb
@@ -15,6 +15,10 @@ module Plurimath
         "subsup"
       end
 
+      def omml_tag_name
+        "subSup"
+      end
+
       def nary_attr_value
         ""
       end

--- a/lib/plurimath/math/formula.rb
+++ b/lib/plurimath/math/formula.rb
@@ -126,10 +126,6 @@ module Plurimath
         [nary_tag]
       end
 
-      def class_name
-        self.class.name.split("::").last.downcase
-      end
-
       def extract_class_from_text
         return false unless (value.length < 2 && value&.first&.is_a?(Function::Text))
 

--- a/lib/plurimath/math/function/binary_function.rb
+++ b/lib/plurimath/math/function/binary_function.rb
@@ -85,6 +85,16 @@ module Plurimath
         def all_values_exist?
           !parameter_one.nil? && !parameter_two.nil?
         end
+
+        def underover
+          return r_element(class_name, rpr_tag: false) unless all_values_exist?
+
+          first_value = Symbol.new(class_name)
+          overset = Overset.new(first_value, parameter_two)
+          return Array(overset.to_omml_without_math_tag) unless parameter_one
+
+          Array(Underset.new(overset, parameter_one)&.to_omml_without_math_tag)
+        end
       end
     end
   end

--- a/lib/plurimath/math/function/binary_function.rb
+++ b/lib/plurimath/math/function/binary_function.rb
@@ -83,7 +83,7 @@ module Plurimath
         end
 
         def all_values_exist?
-          !parameter_one.nil? && !parameter_two.nil?
+          !(parameter_one.nil? && parameter_two.nil?)
         end
 
         def underover

--- a/lib/plurimath/math/function/inf.rb
+++ b/lib/plurimath/math/function/inf.rb
@@ -31,13 +31,7 @@ module Plurimath
         end
 
         def to_omml_without_math_tag
-          return r_element("inf", rpr_tag: false) unless all_values_exist?
-
-          inf = Symbol.new("inf")
-          overset = Overset.new(inf, parameter_two)
-          return Array(overset.to_omml_without_math_tag) unless parameter_one
-
-          Array(Underset.new(overset, parameter_one)&.to_omml_without_math_tag)
+          underover
         end
       end
     end

--- a/lib/plurimath/math/function/inf.rb
+++ b/lib/plurimath/math/function/inf.rb
@@ -14,7 +14,7 @@ module Plurimath
 
         def to_mathml_without_math_tag
           first_value = Utility.ox_element("mo") << class_name
-          return first_value if all_values_exist?
+          return first_value unless all_values_exist?
 
           value_array = [first_value]
           value_array << parameter_one&.to_mathml_without_math_tag

--- a/lib/plurimath/math/function/lim.rb
+++ b/lib/plurimath/math/function/lim.rb
@@ -40,13 +40,7 @@ module Plurimath
         end
 
         def to_omml_without_math_tag
-          return r_element("lim", rpr_tag: false) unless all_values_exist?
-
-          lim = Symbol.new("lim")
-          overset = Overset.new(lim, parameter_two)
-          return overset.to_omml_without_math_tag unless parameter_one
-
-          Underset.new(overset, parameter_one)&.to_omml_without_math_tag
+          underover
         end
       end
     end

--- a/lib/plurimath/math/function/oint.rb
+++ b/lib/plurimath/math/function/oint.rb
@@ -22,17 +22,16 @@ module Plurimath
           mo_tag = Utility.ox_element("mo") << invert_unicode_symbols.to_s
           return mo_tag unless all_values_exist?
 
-          msubsup_tag = Utility.ox_element("msubsup")
-          first_value = parameter_one&.to_mathml_without_math_tag if parameter_one
-          second_value = parameter_two&.to_mathml_without_math_tag if parameter_two
-          Utility.update_nodes(
-            msubsup_tag,
-            [
-              mo_tag,
-              first_value,
-              second_value,
-            ],
-          )
+          value_array = [mo_tag]
+          value_array << parameter_one&.to_mathml_without_math_tag
+          value_array << parameter_two&.to_mathml_without_math_tag
+          tag_name = if parameter_one && parameter_two
+                       "subsup"
+                     else
+                       parameter_one ? "sub" : "sup"
+                     end
+          msubsup_tag = Utility.ox_element("m#{tag_name}")
+          Utility.update_nodes(msubsup_tag, value_array)
           return msubsup_tag if parameter_three.nil?
 
           Utility.update_nodes(
@@ -40,7 +39,7 @@ module Plurimath
             [
               msubsup_tag,
               parameter_three&.to_mathml_without_math_tag,
-            ].flatten.compact,
+            ].compact,
           )
         end
 

--- a/lib/plurimath/math/function/power_base.rb
+++ b/lib/plurimath/math/function/power_base.rb
@@ -35,7 +35,7 @@ module Plurimath
           narypr << Utility.ox_element(
             "limLoc",
             namespace: "m",
-            attributes: { "m:val": "subSup" },
+            attributes: { "m:val": parameter_one.omml_tag_name },
           )
           hide_tags(narypr)
           narypr << Utility.pr_element("ctrl", true, namespace: "m")
@@ -47,6 +47,8 @@ module Plurimath
         end
 
         def to_omml_without_math_tag
+          return underover if parameter_one.omml_tag_name == "undOvr"
+
           ssubsup   = Utility.ox_element("sSubSup", namespace: "m")
           ssubsuppr = Utility.ox_element("sSubSupPr", namespace: "m")
           ssubsuppr << hide_tags(

--- a/lib/plurimath/math/function/prod.rb
+++ b/lib/plurimath/math/function/prod.rb
@@ -74,6 +74,10 @@ module Plurimath
             [r_tag]
           end
         end
+
+        def nary_attr_value
+          "∏"
+        end
       end
     end
   end

--- a/lib/plurimath/math/function/sum.rb
+++ b/lib/plurimath/math/function/sum.rb
@@ -74,6 +74,14 @@ module Plurimath
             [r_tag]
           end
         end
+
+        def omml_tag_name
+          "undOvr"
+        end
+
+        def nary_attr_value
+          "∑"
+        end
       end
     end
   end

--- a/lib/plurimath/math/function/table.rb
+++ b/lib/plurimath/math/function/table.rb
@@ -77,10 +77,6 @@ module Plurimath
           end
         end
 
-        def class_name
-          self.class.name.split("::").last.downcase
-        end
-
         protected
 
         def present?(field)

--- a/lib/plurimath/math/function/ternary_function.rb
+++ b/lib/plurimath/math/function/ternary_function.rb
@@ -131,6 +131,13 @@ module Plurimath
 
           Array(parameter.to_mathml_without_math_tag)
         end
+
+        def underover
+          overset = Overset.new(parameter_one, parameter_three)
+          return overset unless parameter_two
+
+          Underset.new(overset, parameter_two)&.to_omml_without_math_tag
+        end
       end
     end
   end

--- a/lib/plurimath/math/function/ubrace.rb
+++ b/lib/plurimath/math/function/ubrace.rb
@@ -26,6 +26,10 @@ module Plurimath
           "underover"
         end
 
+        def omml_tag_name
+          "undOvr"
+        end
+
         def validate_function_formula
           false
         end

--- a/lib/plurimath/math/function/underover.rb
+++ b/lib/plurimath/math/function/underover.rb
@@ -36,10 +36,7 @@ module Plurimath
         end
 
         def to_omml_without_math_tag
-          overset = Overset.new(parameter_one, parameter_three)
-          return overset unless parameter_two
-
-          Underset.new(overset, parameter_two)&.to_omml_without_math_tag
+          underover
         end
 
         def omml_nary_tag
@@ -86,7 +83,7 @@ module Plurimath
         end
 
         def first_value(pr_element)
-          first_value = parameter_one.is_a?(Number) ? parameter_one.value : parameter_one.to_omml_without_math_tag
+          first_value = parameter_one.nary_attr_value
           first_value = Utility.html_entity_to_unicode(first_value)
           unless first_value == "∫"
             pr_element << Utility.ox_element(

--- a/lib/plurimath/math/symbol.rb
+++ b/lib/plurimath/math/symbol.rb
@@ -72,6 +72,14 @@ module Plurimath
         ["&#x22c0;", "&#x22c1;", "&#x22c2;", "&#x22c3;"].include?(value) ? "underover" : "subsup"
       end
 
+      def omml_tag_name
+        if ["&#x22c0;", "&#x22c1;", "&#x22c2;", "&#x22c3;", "&#x22c3;", "&#x2211;", "&#x220f;"].include?(value)
+          return "undOvr"
+        end
+
+        "subSup"
+      end
+
       def nary_attr_value
         value
       end

--- a/spec/plurimath/asciimath_spec.rb
+++ b/spec/plurimath/asciimath_spec.rb
@@ -6093,5 +6093,113 @@ RSpec.describe Plurimath::Asciimath do
         expect(formula).to be_equivalent_to(omml)
       end
     end
+
+    context "contains ubrace and bigwedge power base values examples #16" do
+      let(:string) { 'ubrace_d^2 bigwedge_2^d' }
+
+      it 'returns parsed Asciimath to Formula' do
+        omml = <<~OMML
+          <m:oMathPara xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:mo="http://schemas.microsoft.com/office/mac/office/2008/main" xmlns:mv="urn:schemas-microsoft-com:mac:vml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w10="urn:schemas-microsoft-com:office:word" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml" xmlns:wne="http://schemas.microsoft.com/office/word/2006/wordml" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns:wp14="http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing" xmlns:wpc="http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas" xmlns:wpg="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup" xmlns:wpi="http://schemas.microsoft.com/office/word/2010/wordprocessingInk" xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape">
+            <m:oMath>
+              <m:limLow>
+                <m:limLowPr>
+                  <m:ctrlPr>
+                    <w:rPr>
+                      <w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/>
+                      <w:i/>
+                    </w:rPr>
+                  </m:ctrlPr>
+                </m:limLowPr>
+                <m:e>
+                  <m:limUpp>
+                    <m:limUppPr>
+                      <m:ctrlPr>
+                        <w:rPr>
+                          <w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/>
+                          <w:i/>
+                        </w:rPr>
+                      </m:ctrlPr>
+                    </m:limUppPr>
+                    <m:e>
+                      <m:limLow>
+                        <m:limLowPr>
+                          <m:ctrlPr>
+                            <w:rPr>
+                              <w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/>
+                              <w:i/>
+                            </w:rPr>
+                          </m:ctrlPr>
+                        </m:limLowPr>
+                        <m:e>
+                          <m:r>
+                            <m:t>&#8203;</m:t>
+                          </m:r>
+                        </m:e>
+                        <m:lim>
+                          <m:r>
+                            <m:rPr>
+                              <m:sty m:val="p"/>
+                            </m:rPr>
+                            <m:t>⏟</m:t>
+                          </m:r>
+                        </m:lim>
+                      </m:limLow>
+                    </m:e>
+                    <m:lim>
+                      <m:r>
+                        <m:t>2</m:t>
+                      </m:r>
+                    </m:lim>
+                  </m:limUpp>
+                </m:e>
+                <m:lim>
+                  <m:r>
+                    <m:t>d</m:t>
+                  </m:r>
+                </m:lim>
+              </m:limLow>
+              <m:limLow>
+                <m:limLowPr>
+                  <m:ctrlPr>
+                    <w:rPr>
+                      <w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/>
+                      <w:i/>
+                    </w:rPr>
+                  </m:ctrlPr>
+                </m:limLowPr>
+                <m:e>
+                  <m:limUpp>
+                    <m:limUppPr>
+                      <m:ctrlPr>
+                        <w:rPr>
+                          <w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/>
+                          <w:i/>
+                        </w:rPr>
+                      </m:ctrlPr>
+                    </m:limUppPr>
+                    <m:e>
+                      <m:r>
+                        <m:t>&#x22c0;</m:t>
+                      </m:r>
+                    </m:e>
+                    <m:lim>
+                      <m:r>
+                        <m:t>d</m:t>
+                      </m:r>
+                    </m:lim>
+                  </m:limUpp>
+                </m:e>
+                <m:lim>
+                  <m:r>
+                    <m:t>2</m:t>
+                  </m:r>
+                </m:lim>
+              </m:limLow>
+            </m:oMath>
+          </m:oMathPara>
+        OMML
+        expect(formula).to be_equivalent_to(omml)
+      end
+    end
   end
 end

--- a/spec/plurimath/fixtures/036.omml
+++ b/spec/plurimath/fixtures/036.omml
@@ -3,7 +3,7 @@
     <m:nary>
       <m:naryPr>
         <m:chr m:val="∑"/>
-        <m:limLoc m:val="subSup"/>
+        <m:limLoc m:val="undOvr"/>
         <m:ctrlPr>
           <w:rPr>
             <w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/>

--- a/spec/plurimath/fixtures/038.omml
+++ b/spec/plurimath/fixtures/038.omml
@@ -3,7 +3,7 @@
     <m:nary>
       <m:naryPr>
         <m:chr m:val="∑"/>
-        <m:limLoc m:val="subSup"/>
+        <m:limLoc m:val="undOvr"/>
         <m:supHide m:val="1"/>
         <m:ctrlPr>
           <w:rPr>

--- a/spec/plurimath/fixtures/039.omml
+++ b/spec/plurimath/fixtures/039.omml
@@ -3,7 +3,7 @@
     <m:nary>
       <m:naryPr>
         <m:chr m:val="∏"/>
-        <m:limLoc m:val="subSup"/>
+        <m:limLoc m:val="undOvr"/>
         <m:ctrlPr>
           <w:rPr>
             <w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/>

--- a/spec/plurimath/fixtures/042.omml
+++ b/spec/plurimath/fixtures/042.omml
@@ -3,7 +3,7 @@
     <m:nary>
       <m:naryPr>
         <m:chr m:val="⋂"/>
-        <m:limLoc m:val="subSup"/>
+        <m:limLoc m:val="undOvr"/>
         <m:ctrlPr>
           <w:rPr>
             <w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/>

--- a/spec/plurimath/fixtures/043.omml
+++ b/spec/plurimath/fixtures/043.omml
@@ -3,7 +3,7 @@
     <m:nary>
       <m:naryPr>
         <m:chr m:val="⋁"/>
-        <m:limLoc m:val="subSup"/>
+        <m:limLoc m:val="undOvr"/>
         <m:supHide m:val="1"/>
         <m:ctrlPr>
           <w:rPr>

--- a/spec/plurimath/fixtures/044.omml
+++ b/spec/plurimath/fixtures/044.omml
@@ -3,7 +3,7 @@
     <m:nary>
       <m:naryPr>
         <m:chr m:val="⋀"/>
-        <m:limLoc m:val="subSup"/>
+        <m:limLoc m:val="undOvr"/>
         <m:ctrlPr>
           <w:rPr>
             <w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/>

--- a/spec/plurimath/fixtures/045.omml
+++ b/spec/plurimath/fixtures/045.omml
@@ -3,7 +3,7 @@
     <m:nary>
       <m:naryPr>
         <m:chr m:val="∑"/>
-        <m:limLoc m:val="subSup"/>
+        <m:limLoc m:val="undOvr"/>
         <m:supHide m:val="1"/>
         <m:ctrlPr>
           <w:rPr>

--- a/spec/plurimath/fixtures/046.omml
+++ b/spec/plurimath/fixtures/046.omml
@@ -3,7 +3,7 @@
     <m:nary>
       <m:naryPr>
         <m:chr m:val="∑"/>
-        <m:limLoc m:val="subSup"/>
+        <m:limLoc m:val="undOvr"/>
         <m:ctrlPr>
           <w:rPr>
             <w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/>

--- a/spec/plurimath/fixtures/048.omml
+++ b/spec/plurimath/fixtures/048.omml
@@ -3,7 +3,7 @@
     <m:nary>
       <m:naryPr>
         <m:chr m:val="∏"/>
-        <m:limLoc m:val="subSup"/>
+        <m:limLoc m:val="undOvr"/>
         <m:ctrlPr>
           <w:rPr>
             <w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/>

--- a/spec/plurimath/fixtures/049.omml
+++ b/spec/plurimath/fixtures/049.omml
@@ -3,7 +3,7 @@
     <m:nary>
       <m:naryPr>
         <m:chr m:val="⋃"/>
-        <m:limLoc m:val="subSup"/>
+        <m:limLoc m:val="undOvr"/>
         <m:ctrlPr>
           <w:rPr>
             <w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/>

--- a/spec/plurimath/fixtures/181.omml
+++ b/spec/plurimath/fixtures/181.omml
@@ -1,64 +1,47 @@
 <m:oMathPara xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:mo="http://schemas.microsoft.com/office/mac/office/2008/main" xmlns:mv="urn:schemas-microsoft-com:mac:vml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w10="urn:schemas-microsoft-com:office:word" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml" xmlns:wne="http://schemas.microsoft.com/office/word/2006/wordml" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns:wp14="http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing" xmlns:wpc="http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas" xmlns:wpg="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup" xmlns:wpi="http://schemas.microsoft.com/office/word/2010/wordprocessingInk" xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape">
   <m:oMath>
-    <m:nary>
-      <m:naryPr>
-        <m:chr m:val="∑"/>
-        <m:limLoc m:val="undOvr"/>
-        <m:supHide m:val="1"/>
+    <m:limLow>
+      <m:limLowPr>
         <m:ctrlPr>
           <w:rPr>
             <w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/>
             <w:i/>
           </w:rPr>
         </m:ctrlPr>
-      </m:naryPr>
-      <m:sub>
-        <m:eqArr>
-          <m:eqArrPr>
-            <m:ctrlPr>
-              <w:rPr>
-                <w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/>
-                <w:i/>
-              </w:rPr>
-            </m:ctrlPr>
-          </m:eqArrPr>
-          <m:e>
-            <m:r>
-              <m:t>0&le; i &le; m</m:t>
-            </m:r>
-          </m:e>
-          <m:e>
-            <m:r>
-              <m:t>0&lt;j&lt;n </m:t>
-            </m:r>
-          </m:e>
-        </m:eqArr>
-      </m:sub>
-      <m:sup>
-        <m:r>
-          <m:t>&#8203;</m:t>
-        </m:r>
-      </m:sup>
+      </m:limLowPr>
       <m:e>
-        <m:r>
-          <m:t>P</m:t>
-        </m:r>
-        <m:d>
-          <m:dPr>
+        <m:limUpp>
+          <m:limUppPr>
             <m:ctrlPr>
               <w:rPr>
                 <w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/>
                 <w:i/>
               </w:rPr>
             </m:ctrlPr>
-          </m:dPr>
+          </m:limUppPr>
           <m:e>
             <m:r>
-              <m:t>i,j</m:t>
+              <m:t>&#x22c2;</m:t>
             </m:r>
           </m:e>
-        </m:d>
+          <m:lim>
+            <m:r>
+              <m:t>n</m:t>
+            </m:r>
+          </m:lim>
+        </m:limUpp>
       </m:e>
-    </m:nary>
+      <m:lim>
+        <m:r>
+          <m:t>i</m:t>
+        </m:r>
+        <m:r>
+          <m:t>&#x2208;</m:t>
+        </m:r>
+        <m:r>
+          <m:t>I</m:t>
+        </m:r>
+      </m:lim>
+    </m:limLow>
   </m:oMath>
 </m:oMathPara>

--- a/spec/plurimath/fixtures/182.omml
+++ b/spec/plurimath/fixtures/182.omml
@@ -2,9 +2,8 @@
   <m:oMath>
     <m:nary>
       <m:naryPr>
-        <m:chr m:val="∑"/>
-        <m:limLoc m:val="undOvr"/>
-        <m:supHide m:val="1"/>
+        <m:chr m:val="∏"/>
+        <m:limLoc m:val="subSup"/>
         <m:ctrlPr>
           <w:rPr>
             <w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/>
@@ -13,51 +12,19 @@
         </m:ctrlPr>
       </m:naryPr>
       <m:sub>
-        <m:eqArr>
-          <m:eqArrPr>
-            <m:ctrlPr>
-              <w:rPr>
-                <w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/>
-                <w:i/>
-              </w:rPr>
-            </m:ctrlPr>
-          </m:eqArrPr>
-          <m:e>
-            <m:r>
-              <m:t>0&le; i &le; m</m:t>
-            </m:r>
-          </m:e>
-          <m:e>
-            <m:r>
-              <m:t>0&lt;j&lt;n </m:t>
-            </m:r>
-          </m:e>
-        </m:eqArr>
+        <m:r>
+          <m:t>d</m:t>
+        </m:r>
       </m:sub>
       <m:sup>
         <m:r>
-          <m:t>&#8203;</m:t>
+          <m:t>1</m:t>
         </m:r>
       </m:sup>
       <m:e>
         <m:r>
-          <m:t>P</m:t>
+          <m:t>c</m:t>
         </m:r>
-        <m:d>
-          <m:dPr>
-            <m:ctrlPr>
-              <w:rPr>
-                <w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/>
-                <w:i/>
-              </w:rPr>
-            </m:ctrlPr>
-          </m:dPr>
-          <m:e>
-            <m:r>
-              <m:t>i,j</m:t>
-            </m:r>
-          </m:e>
-        </m:d>
       </m:e>
     </m:nary>
   </m:oMath>

--- a/spec/plurimath/fixtures/183.omml
+++ b/spec/plurimath/fixtures/183.omml
@@ -4,7 +4,6 @@
       <m:naryPr>
         <m:chr m:val="∑"/>
         <m:limLoc m:val="undOvr"/>
-        <m:supHide m:val="1"/>
         <m:ctrlPr>
           <w:rPr>
             <w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/>
@@ -13,51 +12,19 @@
         </m:ctrlPr>
       </m:naryPr>
       <m:sub>
-        <m:eqArr>
-          <m:eqArrPr>
-            <m:ctrlPr>
-              <w:rPr>
-                <w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/>
-                <w:i/>
-              </w:rPr>
-            </m:ctrlPr>
-          </m:eqArrPr>
-          <m:e>
-            <m:r>
-              <m:t>0&le; i &le; m</m:t>
-            </m:r>
-          </m:e>
-          <m:e>
-            <m:r>
-              <m:t>0&lt;j&lt;n </m:t>
-            </m:r>
-          </m:e>
-        </m:eqArr>
+        <m:r>
+          <m:t>d</m:t>
+        </m:r>
       </m:sub>
       <m:sup>
         <m:r>
-          <m:t>&#8203;</m:t>
+          <m:t>1</m:t>
         </m:r>
       </m:sup>
       <m:e>
         <m:r>
-          <m:t>P</m:t>
+          <m:t>c</m:t>
         </m:r>
-        <m:d>
-          <m:dPr>
-            <m:ctrlPr>
-              <w:rPr>
-                <w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/>
-                <w:i/>
-              </w:rPr>
-            </m:ctrlPr>
-          </m:dPr>
-          <m:e>
-            <m:r>
-              <m:t>i,j</m:t>
-            </m:r>
-          </m:e>
-        </m:d>
       </m:e>
     </m:nary>
   </m:oMath>

--- a/spec/plurimath/fixtures/expected_values.rb
+++ b/spec/plurimath/fixtures/expected_values.rb
@@ -414,7 +414,7 @@ module ExpectedValues
   ])
   EX_036 = Plurimath::Math::Formula.new([
     Plurimath::Math::Formula.new([
-      Plurimath::Math::Function::PowerBase.new(
+      Plurimath::Math::Function::Underover.new(
         Plurimath::Math::Symbol.new("&#x2211;"),
         Plurimath::Math::Formula.new([
           Plurimath::Math::Number.new("3"),
@@ -444,7 +444,7 @@ module ExpectedValues
   ])
   EX_038 = Plurimath::Math::Formula.new([
     Plurimath::Math::Formula.new([
-      Plurimath::Math::Function::PowerBase.new(
+      Plurimath::Math::Function::Underover.new(
         Plurimath::Math::Symbol.new("&#x2211;"),
         Plurimath::Math::Formula.new([
           Plurimath::Math::Number.new("1"),
@@ -458,7 +458,7 @@ module ExpectedValues
   ])
   EX_039 = Plurimath::Math::Formula.new([
     Plurimath::Math::Formula.new([
-      Plurimath::Math::Function::PowerBase.new(
+      Plurimath::Math::Function::Underover.new(
         Plurimath::Math::Symbol.new("&#x220f;"),
         Plurimath::Math::Formula.new([
           Plurimath::Math::Number.new("3"),
@@ -506,7 +506,7 @@ module ExpectedValues
   ])
   EX_042 = Plurimath::Math::Formula.new([
     Plurimath::Math::Formula.new([
-      Plurimath::Math::Function::PowerBase.new(
+      Plurimath::Math::Function::Underover.new(
         Plurimath::Math::Symbol.new("&#x22c2;"),
         Plurimath::Math::Formula.new([
           Plurimath::Math::Number.new("3"),
@@ -522,7 +522,7 @@ module ExpectedValues
   ])
   EX_043 = Plurimath::Math::Formula.new([
     Plurimath::Math::Formula.new([
-      Plurimath::Math::Function::PowerBase.new(
+      Plurimath::Math::Function::Underover.new(
         Plurimath::Math::Symbol.new("&#x22c1;"),
         Plurimath::Math::Formula.new([
           Plurimath::Math::Number.new("1"),
@@ -536,7 +536,7 @@ module ExpectedValues
   ])
   EX_044 = Plurimath::Math::Formula.new([
     Plurimath::Math::Formula.new([
-      Plurimath::Math::Function::PowerBase.new(
+      Plurimath::Math::Function::Underover.new(
         Plurimath::Math::Symbol.new("&#x22c0;"),
         Plurimath::Math::Formula.new([
           Plurimath::Math::Number.new("1"),
@@ -552,7 +552,7 @@ module ExpectedValues
   ])
   EX_045 = Plurimath::Math::Formula.new([
     Plurimath::Math::Formula.new([
-      Plurimath::Math::Function::PowerBase.new(
+      Plurimath::Math::Function::Underover.new(
         Plurimath::Math::Symbol.new("&#x2211;"),
         Plurimath::Math::Formula.new([
           Plurimath::Math::Function::Text.new("k"),
@@ -577,7 +577,7 @@ module ExpectedValues
   ])
   EX_046 = Plurimath::Math::Formula.new([
     Plurimath::Math::Formula.new([
-      Plurimath::Math::Function::PowerBase.new(
+      Plurimath::Math::Function::Underover.new(
         Plurimath::Math::Symbol.new("&#x2211;"),
         Plurimath::Math::Formula.new([
           Plurimath::Math::Function::Text.new("i=0"),
@@ -593,7 +593,7 @@ module ExpectedValues
   ])
   EX_047 = Plurimath::Math::Formula.new([
     Plurimath::Math::Formula.new([
-      Plurimath::Math::Function::PowerBase.new(
+      Plurimath::Math::Function::Underover.new(
         Plurimath::Math::Symbol.new("&#x2211;"),
         Plurimath::Math::Function::Table.new(
           [
@@ -631,7 +631,7 @@ module ExpectedValues
   ])
   EX_048 = Plurimath::Math::Formula.new([
     Plurimath::Math::Formula.new([
-      Plurimath::Math::Function::PowerBase.new(
+      Plurimath::Math::Function::Underover.new(
         Plurimath::Math::Symbol.new("&#x220f;"),
         Plurimath::Math::Formula.new([
           Plurimath::Math::Function::Text.new("k=1"),
@@ -652,7 +652,7 @@ module ExpectedValues
   ])
   EX_049 = Plurimath::Math::Formula.new([
     Plurimath::Math::Formula.new([
-      Plurimath::Math::Function::PowerBase.new(
+      Plurimath::Math::Function::Underover.new(
         Plurimath::Math::Symbol.new("&#x22c3;"),
         Plurimath::Math::Formula.new([
           Plurimath::Math::Function::Text.new("n=1"),
@@ -2585,6 +2585,37 @@ module ExpectedValues
         )
       )
     ),
+  ])
+  EX_181 = Plurimath::Math::Formula.new([
+    Plurimath::Math::Function::Underover.new(
+      Plurimath::Math::Symbol.new("&#x22c2;"),
+      Plurimath::Math::Formula.new([
+        Plurimath::Math::Symbol.new("i"),
+        Plurimath::Math::Symbol.new("&#x2208;"),
+        Plurimath::Math::Symbol.new("I")
+      ]),
+      Plurimath::Math::Symbol.new("n"),
+    )
+  ])
+  EX_182 = Plurimath::Math::Formula.new([
+    Plurimath::Math::Formula.new([
+      Plurimath::Math::Function::PowerBase.new(
+        Plurimath::Math::Function::Prod.new,
+        Plurimath::Math::Symbol.new("d"),
+        Plurimath::Math::Number.new("1"),
+      ),
+      Plurimath::Math::Symbol.new("c"),
+    ]),
+  ])
+  EX_183 = Plurimath::Math::Formula.new([
+    Plurimath::Math::Formula.new([
+      Plurimath::Math::Function::PowerBase.new(
+        Plurimath::Math::Function::Sum.new,
+        Plurimath::Math::Symbol.new("d"),
+        Plurimath::Math::Number.new("1"),
+      ),
+      Plurimath::Math::Symbol.new("c"),
+    ]),
   ])
   EXIssue158 = Plurimath::Math::Formula.new([
     Plurimath::Math::Formula.new([

--- a/spec/plurimath/latex_spec.rb
+++ b/spec/plurimath/latex_spec.rb
@@ -2591,6 +2591,39 @@ RSpec.describe Plurimath::Latex do
         expect(formula.to_mathml).to be_equivalent_to(mathml)
       end
     end
+
+    context "contains inf with power base values example #53" do
+      let(:string) do
+        <<~LATEX
+          \\inf_{\\oint_{\\lg{\\sigma}}}^{200}
+        LATEX
+      end
+
+      it 'returns parsed Latex to MathML' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <munderover>
+                <mo>inf</mo>
+                <msub>
+                  <mo>&#x222e;</mo>
+                  <mrow>
+                    <mi>lg</mi>
+                    <mi>&#x3c3;</mi>
+                  </mrow>
+                </msub>
+                <mn>200</mn>
+              </munderover>
+            </mstyle>
+          </math>
+        MATHML
+        latex = "\\inf_{\\oint_{\\lg{\\sigma}}}^{200}"
+        asciimath = "inf(oint_(lgsigma))(200)"
+        expect(formula.to_asciimath).to eql(asciimath)
+        expect(formula.to_latex.gsub(/\s+/, "")).to eql(latex.gsub(/\s+/, ""))
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+      end
+    end
   end
 
   describe ".to_asciimath" do

--- a/spec/plurimath/math/formula/omml_spec.rb
+++ b/spec/plurimath/math/formula/omml_spec.rb
@@ -1805,6 +1805,36 @@ RSpec.describe Plurimath::Math::Formula do
       end
     end
 
+    context "contains #181.omml" do
+      let(:file_name) { "spec/plurimath/fixtures/181.omml" }
+      let(:exp) { ExpectedValues::EX_181 }
+
+      it "matches open and close tag" do
+        expected_value = File.read(file_name)
+        expect(formula).to be_equivalent_to(expected_value)
+      end
+    end
+
+    context "contains #182.omml" do
+      let(:file_name) { "spec/plurimath/fixtures/182.omml" }
+      let(:exp) { ExpectedValues::EX_182 }
+
+      it "matches open and close tag" do
+        expected_value = File.read(file_name)
+        expect(formula).to be_equivalent_to(expected_value)
+      end
+    end
+
+    context "contains #183.omml" do
+      let(:file_name) { "spec/plurimath/fixtures/183.omml" }
+      let(:exp) { ExpectedValues::EX_183 }
+
+      it "matches open and close tag" do
+        expected_value = File.read(file_name)
+        expect(formula).to be_equivalent_to(expected_value)
+      end
+    end
+
     context "contains #issue-158.omml" do
       let(:file_name) { "spec/plurimath/fixtures/issue-158.omml" }
       let(:exp) { ExpectedValues::EXIssue158 }


### PR DESCRIPTION
This PR updates **OMML** conversion methods of classes requiring **underover** presentation.