### PR TITLE
Updates AsciiMath transformation rules

### DIFF
--- a/lib/plurimath/asciimath/transform.rb
+++ b/lib/plurimath/asciimath/transform.rb
@@ -766,6 +766,18 @@ module Plurimath
         )
       end
 
+      rule(ternary_class: simple(:function),
+           base_value: simple(:base),
+           power_value: simple(:power),
+           third_value: sequence(:third)) do
+        third_value = third.is_a?(Slice) ? nil : third
+        Utility.get_class(function).new(
+          Utility.unfenced_value(base),
+          Utility.unfenced_value(power),
+          Utility.filter_values(third_value),
+        )
+      end
+
       rule(unary_class: simple(:function),
            intermediate_exp: simple(:int_exp)) do
         first_value = if Utility::UNARY_CLASSES.include?(function)
@@ -819,6 +831,11 @@ module Plurimath
       rule(ternary: simple(:ternary),
            expr: sequence(:expr)) do
         expr.insert(0, ternary)
+      end
+
+      rule(ternary: simple(:ternary),
+           left_right: simple(:left_right)) do
+        [ternary, left_right]
       end
 
       rule(unary_class: simple(:function),

--- a/lib/plurimath/math.rb
+++ b/lib/plurimath/math.rb
@@ -42,7 +42,9 @@ module Plurimath
 
       begin
         klass = klass_from_type(type)
-        klass.new(text).to_formula
+        formula = klass.new(text).to_formula
+        formula.input_string = text
+        formula
       rescue => ee
         parse_error!(text, type.to_sym)
       end

--- a/lib/plurimath/mathml/parser.rb
+++ b/lib/plurimath/mathml/parser.rb
@@ -22,11 +22,11 @@ module Plurimath
 
       def parse
         ox_nodes = Ox.load(text, strip_namespace: true)
-        display_style = ox_nodes&.locate("*/mstyle/@displaystyle")&.first
+        display_style = ox_nodes&.locate("*/mstyle/@displaystyle")&.first || true
         nodes = parse_nodes(ox_nodes.nodes)
         Math::Formula.new(
           Transform.new.apply(nodes).flatten.compact,
-          displaystyle: display_style
+          displaystyle: display_style,
         )
       end
 

--- a/spec/plurimath/asciimath_spec.rb
+++ b/spec/plurimath/asciimath_spec.rb
@@ -5010,6 +5010,166 @@ RSpec.describe Plurimath::Asciimath do
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
+
+    context "contains concatenated expressions example 1 example #96" do
+      let(:string) { 'ii(M)_(12) = 11 - sum_(j=2)^(10) 2^j ((12),(j)) ii(B)_j = ... = -2" "073' }
+
+      it 'returns parsed Asciimath to Formula' do
+        latex = '\mathit{M}_{12} = 11 - \sum_{j = 2}^{10} 2^{j} \left (\begin{matrix}12 \\\\ j\end{matrix}\right ) \mathit{B}_{j} = \ldots = - 2 \text{ } 073'
+        asciimath = 'ii(M)_(12) = 11 - sum_(j = 2)^(10) 2^(j) ([12], [j]) ii(B)_(j) = ... = - 2 " " 073'
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <msub>
+                <mstyle mathvariant="italic">
+                  <mi>M</mi>
+                </mstyle>
+                <mn>12</mn>
+              </msub>
+              <mo>=</mo>
+              <mn>11</mn>
+              <mo>&#x2212;</mo>
+              <mrow>
+                <munderover>
+                  <mo>&#x2211;</mo>
+                  <mrow>
+                    <mi>j</mi>
+                    <mo>=</mo>
+                    <mn>2</mn>
+                  </mrow>
+                  <mn>10</mn>
+                </munderover>
+                <msup>
+                  <mn>2</mn>
+                  <mi>j</mi>
+                </msup>
+              </mrow>
+              <mrow>
+                <mrow>
+                  <mo>(</mo>
+                  <mtable>
+                    <mtr>
+                      <mtd>
+                        <mn>12</mn>
+                      </mtd>
+                    </mtr>
+                    <mtr>
+                      <mtd>
+                        <mi>j</mi>
+                      </mtd>
+                    </mtr>
+                  </mtable>
+                  <mo>)</mo>
+                </mrow>
+                <msub>
+                  <mstyle mathvariant="italic">
+                    <mi>B</mi>
+                  </mstyle>
+                  <mi>j</mi>
+                </msub>
+                <mo>=</mo>
+                <mo>&#x2026;</mo>
+                <mo>=</mo>
+                <mo>&#x2212;</mo>
+                <mn>2</mn>
+                <mtext> </mtext>
+                <mn>073</mn>
+              </mrow>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
+      end
+    end
+
+    context "contains concatenated expressions example 2 example #97" do
+      let(:string) { 'bar(x) = 1/n sum_{i=1}^n x_i, " " s^2 = 1/{n - 1} sum_{i=1}^n (x_i - bar(x))^2,' }
+
+      it 'returns parsed Asciimath to Formula' do
+        latex = '\overline{x} = \frac{1}{n} \sum_{i = 1}^{n} x_{i} ,  \text{ } s^{2} = \frac{1}{n - 1} \sum_{i = 1}^{n} ( x_{i} - \overline{x} )^{2} ,'
+        asciimath = 'bar(x) = frac(1)(n) sum_(i = 1)^(n) x_(i) ,  " " s^(2) = frac(1)(n - 1) sum_(i = 1)^(n) (x_(i) - bar(x))^(2) ,'
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mover>
+                <mi>x</mi>
+                <mo>&#xaf;</mo>
+              </mover>
+              <mo>=</mo>
+              <mfrac>
+                <mn>1</mn>
+                <mi>n</mi>
+              </mfrac>
+              <mrow>
+                <munderover>
+                  <mo>&#x2211;</mo>
+                  <mrow>
+                    <mi>i</mi>
+                    <mo>=</mo>
+                    <mn>1</mn>
+                  </mrow>
+                  <mi>n</mi>
+                </munderover>
+                <msub>
+                  <mi>x</mi>
+                  <mi>i</mi>
+                </msub>
+              </mrow>
+              <mo>, </mo>
+              <mtext> </mtext>
+              <msup>
+                <mi>s</mi>
+                <mn>2</mn>
+              </msup>
+              <mo>=</mo>
+              <mfrac>
+                <mn>1</mn>
+                <mrow>
+                  <mi>n</mi>
+                  <mo>&#x2212;</mo>
+                  <mn>1</mn>
+                </mrow>
+              </mfrac>
+              <mrow>
+                <munderover>
+                  <mo>&#x2211;</mo>
+                  <mrow>
+                    <mi>i</mi>
+                    <mo>=</mo>
+                    <mn>1</mn>
+                  </mrow>
+                  <mi>n</mi>
+                </munderover>
+                <mrow>
+                  <msup>
+                    <mrow>
+                      <mo>(</mo>
+                      <msub>
+                        <mi>x</mi>
+                        <mi>i</mi>
+                      </msub>
+                      <mo>&#x2212;</mo>
+                      <mover>
+                        <mi>x</mi>
+                        <mo>&#xaf;</mo>
+                      </mover>
+                      <mo>)</mo>
+                    </mrow>
+                    <mn>2</mn>
+                  </msup>
+                  <mo>,</mo>
+                </mrow>
+              </mrow>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
+      end
+    end
   end
 
   describe ".to_omml" do

--- a/spec/plurimath/math_spec.rb
+++ b/spec/plurimath/math_spec.rb
@@ -24,5 +24,19 @@ RSpec.describe Plurimath::Math do
         )
       end
     end
+
+    context "contains correct input string and custom invalid formula" do
+
+      it "raises error on wrong text input" do
+        formula = Plurimath::Math::Formula.new([
+          Plurimath::Math::Function::Sin.new("d"),
+        ])
+        expect{formula.to_html}.to raise_error(Plurimath::Math::ParseError)
+        expect{formula.to_omml}.to raise_error(Plurimath::Math::ParseError)
+        expect{formula.to_latex}.to raise_error(Plurimath::Math::ParseError)
+        expect{formula.to_mathml}.to raise_error(Plurimath::Math::ParseError)
+        expect{formula.to_asciimath}.to raise_error(Plurimath::Math::ParseError)
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR updates **AsciiMath** transformation rules and specs to fix crash on MathML conversion.

closes #175 