### PR TITLE
Fonts support in MathML OMML

### DIFF
--- a/lib/plurimath/math/function/font_style.rb
+++ b/lib/plurimath/math/function/font_style.rb
@@ -57,6 +57,7 @@ module Plurimath
             r_tag,
             Array(parameter_one.font_style_t_tag(display_style)),
           )
+          [r_tag]
         end
       end
     end

--- a/lib/plurimath/omml/parser.rb
+++ b/lib/plurimath/omml/parser.rb
@@ -11,6 +11,22 @@ module Plurimath
         mr
         r
       ].freeze
+      SUPPORTED_FONTS = {
+        "sans-serif-bi": "sans-serif-bold-italic",
+        "double-struck": "double-struck",
+        "sans-serif-i": "sans-serif-italic",
+        "sans-serif-b": "bold-sans-serif",
+        "sans-serif-p": "sans-serif",
+        "fraktur-p": "fraktur",
+        "fraktur-b": "bold-fraktur",
+        "script-b": "bold-script",
+        "script-p": "script",
+        monospace: "monospace",
+        bi: "bold-italic",
+        p: "normal",
+        i: "italic",
+        b: "bold",
+      }.freeze
 
       def initialize(text)
         @text = text

--- a/lib/plurimath/omml/transform.rb
+++ b/lib/plurimath/omml/transform.rb
@@ -116,7 +116,7 @@ module Plurimath
           font = flatten_mtd.shift
           font.new(
             Utility.filter_values(flatten_mtd),
-            Utility::OMML_FONTS.invert[font].to_s,
+            Utility::FONT_STYLES.rassoc(font).first.to_s,
           )
         else
           flatten_mtd

--- a/lib/plurimath/omml/transform.rb
+++ b/lib/plurimath/omml/transform.rb
@@ -72,7 +72,7 @@ module Plurimath
           font = flatten_row.shift
           font.new(
             Utility.filter_values(flatten_row),
-            Utility::OMML_FONTS.invert[font].to_s,
+            Utility::FONT_STYLES.key(font).to_s,
           )
         else
           Utility.filter_values(flatten_row)
@@ -133,7 +133,11 @@ module Plurimath
 
       rule(rPr: subtree(:rpr)) do
         if rpr.is_a?(Array)
-          Utility::OMML_FONTS[rpr.join("-").to_sym]
+          Utility::FONT_STYLES[
+            Omml::Parser::SUPPORTED_FONTS[
+              rpr&.join("-")&.to_sym,
+            ]&.to_sym,
+          ]
         end
       end
 

--- a/lib/plurimath/utility.rb
+++ b/lib/plurimath/utility.rb
@@ -4,24 +4,30 @@ module Plurimath
   class Utility
     FONT_STYLES = {
       "double-struck": Math::Function::FontStyle::DoubleStruck,
+      "sans-serif-bold-italic": Math::Function::FontStyle::SansSerifBoldItalic,
+      "sans-serif-italic": Math::Function::FontStyle::SansSerifItalic,
+      "bold-sans-serif": Math::Function::FontStyle::BoldSansSerif,
       "sans-serif": Math::Function::FontStyle::SansSerif,
+      "bold-fraktur": Math::Function::FontStyle::BoldFraktur,
+      "bold-italic": Math::Function::FontStyle::BoldItalic,
+      "bold-script": Math::Function::FontStyle::BoldScript,
       monospace: Math::Function::FontStyle::Monospace,
-      fraktur: Math::Function::FontStyle::Fraktur,
-      script: Math::Function::FontStyle::Script,
-      normal: Math::Function::FontStyle::Normal,
-      bold: Math::Function::FontStyle::Bold,
       mathfrak: Math::Function::FontStyle::Fraktur,
       mathcal: Math::Function::FontStyle::Script,
+      fraktur: Math::Function::FontStyle::Fraktur,
       mathbb: Math::Function::FontStyle::DoubleStruck,
       mathtt: Math::Function::FontStyle::Monospace,
       mathsf: Math::Function::FontStyle::SansSerif,
       mathrm: Math::Function::FontStyle::Normal,
       textrm: Math::Function::FontStyle::Normal,
+      italic: Math::Function::FontStyle::Italic,
       mathbf: Math::Function::FontStyle::Bold,
       textbf: Math::Function::FontStyle::Bold,
+      script: Math::Function::FontStyle::Script,
+      normal: Math::Function::FontStyle::Normal,
+      bold: Math::Function::FontStyle::Bold,
       bbb: Math::Function::FontStyle::DoubleStruck,
       cal: Math::Function::FontStyle::Script,
-      bf: Math::Function::FontStyle::Bold,
       sf: Math::Function::FontStyle::SansSerif,
       tt: Math::Function::FontStyle::Monospace,
       fr: Math::Function::FontStyle::Fraktur,
@@ -29,6 +35,7 @@ module Plurimath
       cc: Math::Function::FontStyle::Script,
       ii: Math::Function::FontStyle::Italic,
       bb: Math::Function::FontStyle::Bold,
+      bf: Math::Function::FontStyle::Bold,
     }.freeze
     ALIGNMENT_LETTERS = {
       c: "center",
@@ -72,22 +79,6 @@ module Plurimath
       max
       min
     ].freeze
-    OMML_FONTS = {
-      "sans-serif-bi": Math::Function::FontStyle::SansSerifBoldItalic,
-      "sans-serif-i": Math::Function::FontStyle::SansSerifItalic,
-      "sans-serif-b": Math::Function::FontStyle::BoldSansSerif,
-      "double-struck": Math::Function::FontStyle::DoubleStruck,
-      "sans-serif-p": Math::Function::FontStyle::SansSerif,
-      "fraktur-p": Math::Function::FontStyle::Fraktur,
-      "fraktur-b": Math::Function::FontStyle::BoldFraktur,
-      "script-b": Math::Function::FontStyle::BoldScript,
-      "script-p": Math::Function::FontStyle::Script,
-      monospace: Math::Function::FontStyle::Monospace,
-      bi: Math::Function::FontStyle::BoldItalic,
-      p: Math::Function::FontStyle::Normal,
-      i: Math::Function::FontStyle::Italic,
-      b: Math::Function::FontStyle::Bold,
-    }.freeze
     PARENTHESIS = {
       "&#x2329;": "&#x232a;",
       "&#x230a;": "&#x230b;",

--- a/spec/plurimath/fixtures/expected_values.rb
+++ b/spec/plurimath/fixtures/expected_values.rb
@@ -1024,7 +1024,7 @@ module ExpectedValues
       Plurimath::Math::Function::Text.new("over"),
       Plurimath::Math::Function::FontStyle::Normal.new(
         Plurimath::Math::Symbol.new("‾"),
-        "p",
+        "mathrm",
       ),
     )
   ])
@@ -1039,7 +1039,7 @@ module ExpectedValues
       Plurimath::Math::Function::Text.new("A"),
       Plurimath::Math::Function::FontStyle::Normal.new(
         Plurimath::Math::Symbol.new("‾"),
-        "p",
+        "mathrm",
       ),
     )
   ])
@@ -1048,7 +1048,7 @@ module ExpectedValues
       Plurimath::Math::Function::Text.new("ABC"),
       Plurimath::Math::Function::FontStyle::Normal.new(
         Plurimath::Math::Symbol.new("‾"),
-        "p",
+        "mathrm",
       ),
     )
   ])
@@ -1057,7 +1057,7 @@ module ExpectedValues
       Plurimath::Math::Function::Text.new("x⊕y"),
       Plurimath::Math::Function::FontStyle::Normal.new(
         Plurimath::Math::Symbol.new("‾"),
-        "p",
+        "mathrm",
       ),
     )
   ])
@@ -1924,19 +1924,19 @@ module ExpectedValues
   EX_184 = Plurimath::Math::Formula.new([
     Plurimath::Math::Function::FontStyle::Normal.new(
       Plurimath::Math::Number.new("100"),
-      "p"
+      "mathrm"
     ),
     Plurimath::Math::Function::FontStyle::Bold.new(
       Plurimath::Math::Function::Text.new("a"),
-      "b"
+      "mathbf"
     ),
     Plurimath::Math::Function::FontStyle::Italic.new(
       Plurimath::Math::Function::Text.new("a"),
-      "i"
+      "italic"
     ),
     Plurimath::Math::Function::FontStyle::BoldItalic.new(
       Plurimath::Math::Function::Text.new("a"),
-      "bi"
+      "bold-italic"
     ),
     Plurimath::Math::Function::FontStyle::DoubleStruck.new(
       Plurimath::Math::Function::Text.new("a"),
@@ -1944,35 +1944,35 @@ module ExpectedValues
     ),
     Plurimath::Math::Function::FontStyle::BoldFraktur.new(
       Plurimath::Math::Function::Text.new("a"),
-      "fraktur-b"
+      "bold-fraktur"
     ),
     Plurimath::Math::Function::FontStyle::Script.new(
       Plurimath::Math::Function::Text.new("a"),
-      "script-p"
+      "mathcal"
     ),
     Plurimath::Math::Function::FontStyle::BoldScript.new(
       Plurimath::Math::Function::Text.new("a"),
-      "script-b"
+      "bold-script"
     ),
     Plurimath::Math::Function::FontStyle::Fraktur.new(
       Plurimath::Math::Function::Text.new("a"),
-      "fraktur-p"
+      "mathfrak"
     ),
     Plurimath::Math::Function::FontStyle::SansSerif.new(
       Plurimath::Math::Function::Text.new("a"),
-      "sans-serif-p"
+      "sans-serif"
     ),
     Plurimath::Math::Function::FontStyle::BoldSansSerif.new(
       Plurimath::Math::Function::Text.new("a"),
-      "sans-serif-b"
+      "bold-sans-serif"
     ),
     Plurimath::Math::Function::FontStyle::SansSerifItalic.new(
       Plurimath::Math::Function::Text.new("a"),
-      "sans-serif-i"
+      "sans-serif-italic"
     ),
     Plurimath::Math::Function::FontStyle::SansSerifBoldItalic.new(
       Plurimath::Math::Function::Text.new("a"),
-      "sans-serif-bi"
+      "sans-serif-bold-italic"
     ),
     Plurimath::Math::Function::FontStyle::Monospace.new(
       Plurimath::Math::Function::Text.new("a"),

--- a/spec/plurimath/fixtures/expected_values.rb
+++ b/spec/plurimath/fixtures/expected_values.rb
@@ -1997,7 +1997,7 @@ module ExpectedValues
       Plurimath::Math::Function::Ln.new,
       Plurimath::Math::Function::FontStyle::Italic.new(
         Plurimath::Math::Function::Text.new("R"),
-        "i"
+        "italic"
       ),
       Plurimath::Math::Symbol.new("="),
       Plurimath::Math::Function::Fenced.new(
@@ -2011,26 +2011,26 @@ module ExpectedValues
                   Plurimath::Math::Function::Base.new(
                     Plurimath::Math::Function::FontStyle::Italic.new(
                       Plurimath::Math::Function::Text.new("N"),
-                      "i",
+                      "italic",
                     ),
                     Plurimath::Math::Function::Text.new("tot")
                   ),
                   Plurimath::Math::Function::FontStyle::Italic.new(
                     Plurimath::Math::Symbol.new("τ"),
-                    "i"
+                    "italic"
                   )
                 ]),
                 Plurimath::Math::Function::Td.new([
                   Plurimath::Math::Function::Text.new("for "),
                   Plurimath::Math::Function::FontStyle::Italic.new(
                     Plurimath::Math::Symbol.new("τ"),
-                    "i"
+                    "italic"
                   ),
                   Plurimath::Math::Symbol.new("<"),
                   Plurimath::Math::Function::Base.new(
                     Plurimath::Math::Function::FontStyle::Italic.new(
                       Plurimath::Math::Symbol.new("τ"),
-                      "i"
+                      "italic"
                     ),
                     Plurimath::Math::Function::Text.new("o")
                   )
@@ -2042,20 +2042,20 @@ module ExpectedValues
                   Plurimath::Math::Function::Base.new(
                     Plurimath::Math::Function::FontStyle::Italic.new(
                       Plurimath::Math::Function::Text.new("N"),
-                      "i"
+                      "italic"
                     ),
                     Plurimath::Math::Function::Text.new("tot")
                   ),
                   Plurimath::Math::Function::FontStyle::Italic.new(
                     Plurimath::Math::Symbol.new("τ"),
-                    "i"
+                    "italic"
                   ),
                   Plurimath::Math::Symbol.new("-"),
                   Plurimath::Math::Number.new("4"),
                   Plurimath::Math::Function::Base.new(
                     Plurimath::Math::Function::FontStyle::Italic.new(
                       Plurimath::Math::Function::Text.new("N"),
-                      "i"
+                      "italic"
                     ),
                     Plurimath::Math::Function::Text.new("pair")
                   ),
@@ -2064,13 +2064,13 @@ module ExpectedValues
                     [
                       Plurimath::Math::Function::FontStyle::Italic.new(
                         Plurimath::Math::Symbol.new("τ"),
-                        "i"
+                        "italic"
                       ),
                       Plurimath::Math::Symbol.new("-"),
                       Plurimath::Math::Function::Base.new(
                         Plurimath::Math::Function::FontStyle::Italic.new(
                           Plurimath::Math::Symbol.new("τ"),
-                          "i"
+                          "italic"
                         ),
                         Plurimath::Math::Function::Text.new("o"),
                       )
@@ -2082,13 +2082,13 @@ module ExpectedValues
                   Plurimath::Math::Symbol.new("'' "),
                   Plurimath::Math::Function::FontStyle::Italic.new(
                     Plurimath::Math::Symbol.new("τ"),
-                    "i"
+                    "italic"
                   ),
                   Plurimath::Math::Symbol.new(">"),
                   Plurimath::Math::Function::Base.new(
                     Plurimath::Math::Function::FontStyle::Italic.new(
                       Plurimath::Math::Symbol.new("τ"),
-                      "i"
+                      "italic"
                     ),
                     Plurimath::Math::Function::Text.new("o")
                   )

--- a/spec/plurimath/mathml/parser_spec.rb
+++ b/spec/plurimath/mathml/parser_spec.rb
@@ -1415,11 +1415,15 @@ RSpec.describe Plurimath::Mathml::Parser do
         </math>
       MATHML
     }
+
     it "returns formula of decimal values" do
       expected_value = Plurimath::Math::Formula.new([
         Plurimath::Math::Formula.new([
           Plurimath::Math::Function::Base.new(
-            Plurimath::Math::Symbol.new("T"),
+            Plurimath::Math::Function::FontStyle::Italic.new(
+              Plurimath::Math::Symbol.new("T"),
+              "italic",
+            ),
             Plurimath::Math::Number.new("90"),
           ),
           Plurimath::Math::Symbol.new("/"),
@@ -1429,7 +1433,10 @@ RSpec.describe Plurimath::Mathml::Parser do
           ),
           Plurimath::Math::Symbol.new("="),
           Plurimath::Math::Function::Base.new(
-            Plurimath::Math::Symbol.new("A"),
+            Plurimath::Math::Function::FontStyle::Italic.new(
+              Plurimath::Math::Symbol.new("A"),
+              "italic",
+            ),
             Plurimath::Math::Number.new("0"),
           ),
           Plurimath::Math::Symbol.new("+"),
@@ -1442,7 +1449,10 @@ RSpec.describe Plurimath::Mathml::Parser do
             Plurimath::Math::Number.new("9"),
           ),
           Plurimath::Math::Function::Base.new(
-            Plurimath::Math::Symbol.new("A"),
+            Plurimath::Math::Function::FontStyle::Italic.new(
+              Plurimath::Math::Symbol.new("A"),
+              "italic",
+            ),
             Plurimath::Math::Symbol.new("i"),
           ),
           Plurimath::Math::Function::Power.new(
@@ -1471,13 +1481,19 @@ RSpec.describe Plurimath::Mathml::Parser do
                           ),
                         ),
                         Plurimath::Math::Symbol.new("&#x2014;"),
-                        Plurimath::Math::Symbol.new("B")
+                        Plurimath::Math::Function::FontStyle::Italic.new(
+                          Plurimath::Math::Symbol.new("B"),
+                          "italic",
+                        ),
                       ])
                     ],
                     Plurimath::Math::Symbol.new(")")
                   ),
                   Plurimath::Math::Symbol.new("/"),
-                  Plurimath::Math::Symbol.new("C")
+                  Plurimath::Math::Function::FontStyle::Italic.new(
+                    Plurimath::Math::Symbol.new("C"),
+                    "italic",
+                  ),
                 ])
               ],
               Plurimath::Math::Symbol.new("]")
@@ -1607,7 +1623,10 @@ RSpec.describe Plurimath::Mathml::Parser do
     it "returns formula of decimal values" do
       expected_value = Plurimath::Math::Formula.new([
         Plurimath::Math::Function::Base.new(
-          Plurimath::Math::Symbol.new("D"),
+          Plurimath::Math::Function::FontStyle::Italic.new(
+            Plurimath::Math::Symbol.new("D"),
+            "italic",
+          ),
           Plurimath::Math::Symbol.new("i"),
         ),
         Plurimath::Math::Symbol.new("="),
@@ -1700,14 +1719,20 @@ RSpec.describe Plurimath::Mathml::Parser do
       expected_value = Plurimath::Math::Formula.new([
         Plurimath::Math::Formula.new([
           Plurimath::Math::Function::Base.new(
-            Plurimath::Math::Symbol.new("W"),
+            Plurimath::Math::Function::FontStyle::Italic.new(
+              Plurimath::Math::Symbol.new("W"),
+              "italic",
+            ),
             Plurimath::Math::Symbol.new("t"),
           ),
           Plurimath::Math::Function::Fenced.new(
             Plurimath::Math::Symbol.new("("),
             [
               Plurimath::Math::Function::Base.new(
-                Plurimath::Math::Symbol.new("T"),
+                Plurimath::Math::Function::FontStyle::Italic.new(
+                  Plurimath::Math::Symbol.new("T"),
+                  "italic",
+                ),
                 Plurimath::Math::Number.new("90"),
               )
             ],

--- a/spec/plurimath/mathml_spec.rb
+++ b/spec/plurimath/mathml_spec.rb
@@ -1242,17 +1242,23 @@ RSpec.describe Plurimath::Mathml do
         <<~OMML
           <m:oMathPara xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:mo="http://schemas.microsoft.com/office/mac/office/2008/main" xmlns:mv="urn:schemas-microsoft-com:mac:vml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w10="urn:schemas-microsoft-com:office:word" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml" xmlns:wne="http://schemas.microsoft.com/office/word/2006/wordml" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns:wp14="http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing" xmlns:wpc="http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas" xmlns:wpg="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup" xmlns:wpi="http://schemas.microsoft.com/office/word/2010/wordprocessingInk" xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape">
             <m:oMath>
-              <m:nary>
-                <m:naryPr>
-                  <m:chr m:val="N"/>
-                  <m:limLoc m:val="subSup"/>
+              <m:sSubSup>
+                <m:sSubSupPr>
                   <m:ctrlPr>
                     <w:rPr>
                       <w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/>
                       <w:i/>
                     </w:rPr>
                   </m:ctrlPr>
-                </m:naryPr>
+                </m:sSubSupPr>
+                <m:e>
+                  <m:r>
+                    <m:rPr>
+                      <m:sty m:val="i"/>
+                    </m:rPr>
+                    <m:t>N</m:t>
+                  </m:r>
+                </m:e>
                 <m:sub>
                   <m:r>
                     <m:t>s</m:t>
@@ -1263,23 +1269,30 @@ RSpec.describe Plurimath::Mathml do
                     <m:t>2</m:t>
                   </m:r>
                 </m:sup>
-                <m:e>
-                  <m:r>
-                    <m:t>T</m:t>
-                  </m:r>
-                </m:e>
-              </m:nary>
-              <m:nary>
-                <m:naryPr>
-                  <m:chr m:val="N"/>
-                  <m:limLoc m:val="subSup"/>
+              </m:sSubSup>
+              <m:r>
+                <m:rPr>
+                  <m:sty m:val="i"/>
+                </m:rPr>
+                <m:t>T</m:t>
+              </m:r>
+              <m:sSubSup>
+                <m:sSubSupPr>
                   <m:ctrlPr>
                     <w:rPr>
                       <w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/>
                       <w:i/>
                     </w:rPr>
                   </m:ctrlPr>
-                </m:naryPr>
+                </m:sSubSupPr>
+                <m:e>
+                  <m:r>
+                    <m:rPr>
+                      <m:sty m:val="i"/>
+                    </m:rPr>
+                    <m:t>N</m:t>
+                  </m:r>
+                </m:e>
                 <m:sub>
                   <m:r>
                     <m:t>s</m:t>
@@ -1290,23 +1303,30 @@ RSpec.describe Plurimath::Mathml do
                     <m:t>2</m:t>
                   </m:r>
                 </m:sup>
-                <m:e>
-                  <m:r>
-                    <m:t>100</m:t>
-                  </m:r>
-                </m:e>
-              </m:nary>
-              <m:nary>
-                <m:naryPr>
-                  <m:chr m:val="N"/>
-                  <m:limLoc m:val="subSup"/>
+              </m:sSubSup>
+              <m:r>
+                <m:rPr>
+                  <m:sty m:val="i"/>
+                </m:rPr>
+                <m:t>100</m:t>
+              </m:r>
+              <m:sSubSup>
+                <m:sSubSupPr>
                   <m:ctrlPr>
                     <w:rPr>
                       <w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/>
                       <w:i/>
                     </w:rPr>
                   </m:ctrlPr>
-                </m:naryPr>
+                </m:sSubSupPr>
+                <m:e>
+                  <m:r>
+                    <m:rPr>
+                      <m:sty m:val="i"/>
+                    </m:rPr>
+                    <m:t>N</m:t>
+                  </m:r>
+                </m:e>
                 <m:sub>
                   <m:r>
                     <m:t>s</m:t>
@@ -1317,29 +1337,32 @@ RSpec.describe Plurimath::Mathml do
                     <m:t>2</m:t>
                   </m:r>
                 </m:sup>
-                <m:e>
-                  <m:f>
-                    <m:fPr>
-                      <m:ctrlPr>
-                        <w:rPr>
-                          <w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/>
-                          <w:i/>
-                        </w:rPr>
-                      </m:ctrlPr>
-                    </m:fPr>
-                    <m:num>
-                      <m:r>
-                        <m:t>f</m:t>
-                      </m:r>
-                    </m:num>
-                    <m:den>
-                      <m:r>
-                        <m:t>100</m:t>
-                      </m:r>
-                    </m:den>
-                  </m:f>
-                </m:e>
-              </m:nary>
+              </m:sSubSup>
+              <m:r>
+                <m:rPr>
+                  <m:sty m:val="i"/>
+                </m:rPr>
+                <m:f>
+                  <m:fPr>
+                    <m:ctrlPr>
+                      <w:rPr>
+                        <w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/>
+                        <w:i/>
+                      </w:rPr>
+                    </m:ctrlPr>
+                  </m:fPr>
+                  <m:num>
+                    <m:r>
+                      <m:t>f</m:t>
+                    </m:r>
+                  </m:num>
+                  <m:den>
+                    <m:r>
+                      <m:t>100</m:t>
+                    </m:r>
+                  </m:den>
+                </m:f>
+              </m:r>
             </m:oMath>
           </m:oMathPara>
         OMML


### PR DESCRIPTION
This PR updates support of fonts for MathML and OMML.

closes #185 