### PR TITLE
Added exception for non-numeric exponent value

### DIFF
--- a/lib/plurimath/unitsml.rb
+++ b/lib/plurimath/unitsml.rb
@@ -7,10 +7,20 @@ module Plurimath
 
     def initialize(text)
       @text = text
+      raise Math::ParseError.new(error_message) if text.match?(/\^(\([^\d-])|[^\d-]\)/)
     end
 
     def to_formula
       ::Unitsml.parse(text).to_plurimath
+    end
+
+    def error_message
+      <<~MESSAGE
+       [plurimath] Invalid formula `#{@text}`.
+       [plurimath] The use of a variable as an exponent is not valid.
+       [plurimath] If this is a bug, please report the formula at our issue tracker at:
+       [plurimath] https://github.com/plurimath/plurimath/issues
+      MESSAGE
     end
   end
 end

--- a/spec/plurimath/unitsml_spec.rb
+++ b/spec/plurimath/unitsml_spec.rb
@@ -2,13 +2,53 @@ require "spec_helper"
 
 RSpec.describe Plurimath::Unitsml do
 
-  it 'returns instance of Unitsml' do
-    unitsml = Plurimath::Unitsml.new('⎣2.5⎦')
-    expect(unitsml).to be_a(Plurimath::Unitsml)
-  end
+  describe ".initialize" do
+    let(:unitsml) { described_class.new(input_text) }
 
-  it 'returns Latex instance' do
-    unitsml = Plurimath::Unitsml.new('⎣2.5⎦')
-    expect(unitsml.text).to eql('⎣2.5⎦')
+    context "contains valid equation" do
+      let(:input_text) { 'mm^3' }
+
+      it 'matches instance of Unitsml and input text' do
+        expect(unitsml).to be_a(described_class)
+        expect(unitsml.text).to eql('mm^3')
+      end
+
+      it 'expects to not raise an error' do
+        expect{unitsml}.not_to raise_error
+      end
+    end
+
+    context "contains positive exponent variable invalid equation" do
+      let(:input_text) { 'mm^(b)' }
+
+      it 'expects error message indicating invalid exponent value' do
+        message = "The use of a variable as an exponent is not valid."
+        expect{unitsml}.to raise_error(
+          Plurimath::Math::ParseError, Regexp.compile(message)
+        )
+      end
+    end
+
+    context "contains negative exponent variable invalid equation" do
+      let(:input_text) { 'mm^(-b)' }
+
+      it 'expects error message indicating invalid exponent value' do
+        message = "The use of a variable as an exponent is not valid."
+        expect{unitsml}.to raise_error(
+          Plurimath::Math::ParseError, Regexp.compile(message)
+        )
+      end
+    end
+
+    context "contains negative exponent alphanumeric variable invalid equation" do
+      let(:input_text) { 'mm^(-2b)' }
+
+      it 'expects error message indicating invalid exponent value' do
+        message = "The use of a variable as an exponent is not valid."
+        expect{unitsml}.to raise_error(
+          Plurimath::Math::ParseError, Regexp.compile(message)
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR adds error raising check for UnitsML equations containing non-numeric values in exponent.

closes #208 