### PR TITLE
Reverting empty tags in MathML

### DIFF
--- a/lib/plurimath/math/core.rb
+++ b/lib/plurimath/math/core.rb
@@ -127,7 +127,7 @@ module Plurimath
       end
 
       def validate_mathml_fields(field)
-        field.nil? ? ox_element("mi") : field.to_mathml_without_math_tag
+        field&.to_mathml_without_math_tag
       end
 
       def common_math_zone_conversion(field, options = {})

--- a/spec/plurimath/fixtures/mathml/line_break/line-break-019.mathml
+++ b/spec/plurimath/fixtures/mathml/line_break/line-break-019.mathml
@@ -12,7 +12,6 @@
 <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
   <mstyle displaystyle="true">
     <mover>
-      <mi/>
       <mrow>
         <mi>d</mi>
         <mi>f</mi>

--- a/spec/plurimath/fixtures/mathml/line_break/line-break-024.mathml
+++ b/spec/plurimath/fixtures/mathml/line_break/line-break-024.mathml
@@ -12,7 +12,6 @@
 <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
   <mstyle displaystyle="true">
     <munderover>
-      <mi/>
       <mrow>
         <mi>d</mi>
         <mi>f</mi>

--- a/spec/plurimath/fixtures/mathml/line_break/line-break-029.mathml
+++ b/spec/plurimath/fixtures/mathml/line_break/line-break-029.mathml
@@ -11,7 +11,6 @@
 <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
   <mstyle displaystyle="true">
     <munderover>
-      <mi/>
       <mrow>
         <mi>a</mi>
         <mi>&#x3c3;</mi>

--- a/spec/plurimath/fixtures/mathml/line_break/line-break-059.mathml
+++ b/spec/plurimath/fixtures/mathml/line_break/line-break-059.mathml
@@ -4,8 +4,6 @@
       <mrow>
         <mi>&#x3b1;</mi>
       </mrow>
-      <mi/>
-      <mi/>
     </munderover>
   </mstyle>
 </math>
@@ -16,15 +14,12 @@
         <mo>=</mo>
         <mi>&#x3b1;</mi>
       </mrow>
-      <mi/>
-      <mi/>
     </munderover>
   </mstyle>
 </math>
 <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
   <mstyle displaystyle="true">
     <munderover>
-      <mi/>
       <mrow>
         <mo>=</mo>
         <mi>&#x3b3;</mi>

--- a/spec/plurimath/fixtures/mathml/line_break/line-break-061.mathml
+++ b/spec/plurimath/fixtures/mathml/line_break/line-break-061.mathml
@@ -5,7 +5,6 @@
       <mrow>
         <mi>&#x3b8;</mi>
       </mrow>
-      <mi/>
     </msubsup>
   </mstyle>
 </math>

--- a/spec/plurimath/fixtures/mathml/line_break/line-break-073.mathml
+++ b/spec/plurimath/fixtures/mathml/line_break/line-break-073.mathml
@@ -4,8 +4,6 @@
       <mrow>
         <mo>&#x2211;</mo>
       </mrow>
-      <mi/>
-      <mi/>
     </msubsup>
   </mstyle>
 </math>
@@ -16,7 +14,6 @@
       <mrow>
         <mi>&#x2222;</mi>
       </mrow>
-      <mi/>
     </msubsup>
   </mstyle>
 </math>
@@ -24,7 +21,6 @@
   <mstyle displaystyle="true">
     <mrow>
       <msubsup>
-        <mi/>
         <mi>&#xd3;</mi>
         <mrow>
           <mi>&#x2422;</mi>

--- a/spec/plurimath/fixtures/mathml/line_break/line-break-074.mathml
+++ b/spec/plurimath/fixtures/mathml/line_break/line-break-074.mathml
@@ -4,7 +4,6 @@
       <mrow>
         <mi>&#x3b8;</mi>
       </mrow>
-      <mi/>
     </msub>
   </mstyle>
 </math>
@@ -21,7 +20,6 @@
 <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
   <mstyle displaystyle="true">
     <msub>
-      <mi/>
       <mi>&#xd3;</mi>
     </msub>
   </mstyle>

--- a/spec/plurimath/fixtures/mathml/line_break/line-break-075.mathml
+++ b/spec/plurimath/fixtures/mathml/line_break/line-break-075.mathml
@@ -4,7 +4,6 @@
       <mrow>
         <mi>&#x3b8;</mi>
       </mrow>
-      <mi/>
     </msup>
   </mstyle>
 </math>

--- a/spec/plurimath/fixtures/mathml/line_break/line-break-076.mathml
+++ b/spec/plurimath/fixtures/mathml/line_break/line-break-076.mathml
@@ -4,8 +4,6 @@
       <mrow>
         <mi>&#x3b8;</mi>
       </mrow>
-      <mi/>
-      <mi/>
     </munderover>
   </mstyle>
 </math>
@@ -16,14 +14,12 @@
       <mrow>
         <mi>&#x2222;</mi>
       </mrow>
-      <mi/>
     </munderover>
   </mstyle>
 </math>
 <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
   <mstyle displaystyle="true">
     <munderover>
-      <mi/>
       <mi>&#xd3;</mi>
       <mrow>
         <mo>&#x2211;</mo>

--- a/spec/plurimath/fixtures/mathml/line_break/line-break-079.mathml
+++ b/spec/plurimath/fixtures/mathml/line_break/line-break-079.mathml
@@ -4,7 +4,6 @@
       <mrow>
         <mi>&#x2222;</mi>
       </mrow>
-      <mi/>
     </mover>
   </mstyle>
 </math>

--- a/spec/plurimath/fixtures/mathml/line_break/line-break-081.mathml
+++ b/spec/plurimath/fixtures/mathml/line_break/line-break-081.mathml
@@ -1,7 +1,6 @@
 <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
   <mstyle displaystyle="true">
     <munder>
-      <mi/>
       <mrow>
         <mo>&#x2211;</mo>
       </mrow>
@@ -22,7 +21,6 @@
   <mstyle displaystyle="true">
     <munder>
       <mi>&#x6f;</mi>
-      <mi/>
     </munder>
   </mstyle>
 </math>

--- a/spec/plurimath/fixtures/mathml/line_break/line-break-082.mathml
+++ b/spec/plurimath/fixtures/mathml/line_break/line-break-082.mathml
@@ -4,8 +4,6 @@
       <mrow>
         <mi>&#x3b1;</mi>
       </mrow>
-      <mi/>
-      <mi/>
     </msubsup>
   </mstyle>
 </math>
@@ -19,14 +17,12 @@
       <mrow>
         <mi>&#x3b3;</mi>
       </mrow>
-      <mi/>
     </msubsup>
   </mstyle>
 </math>
 <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
   <mstyle displaystyle="true">
     <msubsup>
-      <mi/>
       <mrow>
         <mo>=</mo>
         <mi>&#x3b4;</mi>

--- a/spec/plurimath/fixtures/mathml/line_break/line-break-083.mathml
+++ b/spec/plurimath/fixtures/mathml/line_break/line-break-083.mathml
@@ -4,8 +4,6 @@
       <mrow>
         <mi>&#x3b1;</mi>
       </mrow>
-      <mi/>
-      <mi/>
     </mmultiscript>
   </mstyle>
 </math>
@@ -19,14 +17,12 @@
       <mrow>
         <mi>&#x3b3;</mi>
       </mrow>
-      <mi/>
     </mmultiscript>
   </mstyle>
 </math>
 <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
   <mstyle displaystyle="true">
     <mmultiscript>
-      <mi/>
       <mrow>
         <mo>=</mo>
         <mi>&#x3b3;</mi>

--- a/spec/plurimath/latex_spec.rb
+++ b/spec/plurimath/latex_spec.rb
@@ -964,7 +964,6 @@ RSpec.describe Plurimath::Latex do
             <mstyle displaystyle="true">
               <msub>
                 <mn>1</mn>
-                <mi/>
               </msub>
             </mstyle>
           </math>
@@ -1209,7 +1208,6 @@ RSpec.describe Plurimath::Latex do
               <msubsup>
                 <mi>log</mi>
                 <mn>2</mn>
-                <mi/>
               </msubsup>
               <mi>x</mi>
             </mstyle>


### PR DESCRIPTION
This PR reverts empty tags used in MathML for nil fields.

closes #210 