### PR TITLE
Spaces before Unitsml in MathML

### DIFF
--- a/lib/plurimath/asciimath/parse.rb
+++ b/lib/plurimath/asciimath/parse.rb
@@ -69,7 +69,7 @@ module Plurimath
       end
 
       rule(:quoted_text) do
-        (str('"') >> str("unitsml(") >> match("[^\)\"]").repeat.as(:unitsml) >> str(')"')) |
+        (str('"') >> str("unitsml(") >> (str(')"').absent? >> any).repeat.as(:unitsml) >> str(')"')) |
           (str('"') >> match("[^\"]").repeat.as(:text) >> str('"')) |
           (str('"') >> str("").as(:text))
       end

--- a/lib/plurimath/asciimath/transform.rb
+++ b/lib/plurimath/asciimath/transform.rb
@@ -29,9 +29,7 @@ module Plurimath
       rule(mod: simple(:mod), expr: simple(:expr)) { [mod, expr] }
 
       rule(unitsml: simple(:unitsml)) do
-        Utility.filter_values(
-          Unitsml.new(unitsml.to_s).to_formula.value,
-        )
+        Unitsml.new(unitsml.to_s).to_formula
       end
 
       rule(bold_fonts: simple(:font)) do
@@ -881,9 +879,7 @@ module Plurimath
       rule(unary_class: simple(:function),
            unitsml: simple(:unitsml)) do
         Utility.get_class(function).new(
-          Utility.filter_values(
-            Unitsml.new(unitsml.to_s).to_formula.value,
-          ),
+          Unitsml.new(unitsml.to_s).to_formula,
         )
       end
 

--- a/lib/plurimath/math/formula.rb
+++ b/lib/plurimath/math/formula.rb
@@ -281,7 +281,7 @@ module Plurimath
           if node.is_a?(Ox::Element) && node.attributes&.dig(:unitsml)
             previous = nodes[index-1]
             if previous && ["mi", "mn"].include?(previous.name)
-              if dump_ox_nodes(node.nodes).match?(/>(&#x[0-9a-fA-F]+;)*(\w+|\d+)</)
+              if text_in_tag?(node.nodes)
                 nodes.insert(index, space_element(attributes: true))
               else
                 nodes.insert(index, space_element)
@@ -299,6 +299,15 @@ module Plurimath
         element = (ox_element("mo") << "&#x2062;")
         element.attributes[:rspace] = "thickmathspace" if attributes
         element
+      end
+
+      def text_in_tag?(nodes)
+        next_nodes = nodes.first.nodes
+        if next_nodes.all?(String)
+          Utility.html_entity_to_unicode(next_nodes.first).match?(/\p{L}|\p{N}/)
+        else
+          text_in_tag?(next_nodes)
+        end
       end
     end
   end

--- a/lib/plurimath/unitsml.rb
+++ b/lib/plurimath/unitsml.rb
@@ -7,7 +7,7 @@ module Plurimath
 
     def initialize(text)
       @text = text
-      raise Math::ParseError.new(error_message) if text.match?(/\^(\(([^\d-]|[^\d-])\))/)
+      raise Math::ParseError.new(error_message) if text.match?(/\^(([^\s].*?[a-z]+)|(\([^-\d]+\)|[^\(\d-]+))/)
     end
 
     def to_formula

--- a/lib/plurimath/unitsml.rb
+++ b/lib/plurimath/unitsml.rb
@@ -7,11 +7,14 @@ module Plurimath
 
     def initialize(text)
       @text = text
-      raise Math::ParseError.new(error_message) if text.match?(/\^(\([^\d-])|[^\d-]\)/)
+      raise Math::ParseError.new(error_message) if text.match?(/\^(\(([^\d-]|[^\d-])\))/)
     end
 
     def to_formula
-      ::Unitsml.parse(text).to_plurimath
+      formula = ::Unitsml.parse(text).to_plurimath
+      formula.unitsml = true
+      formula.input_string = text
+      formula
     end
 
     def error_message

--- a/spec/plurimath/asciimath/metanorma/mn_samples_bipm_spec.rb
+++ b/spec/plurimath/asciimath/metanorma/mn_samples_bipm_spec.rb
@@ -279,10 +279,12 @@ RSpec.describe Plurimath::Asciimath::Parser do
       it "returns formula" do
         expected_value = Plurimath::Math::Formula.new([
           Plurimath::Math::Number.new("1"),
-          Plurimath::Math::Function::FontStyle::Normal.new(
-            Plurimath::Math::Symbol.new("A"),
-            "normal",
-          ),
+          Plurimath::Math::Formula.new([
+            Plurimath::Math::Function::FontStyle::Normal.new(
+              Plurimath::Math::Symbol.new("A"),
+              "normal",
+            ),
+          ]),
           Plurimath::Math::Symbol.new("="),
           Plurimath::Math::Function::Power.new(
             Plurimath::Math::Function::Fenced.new(
@@ -440,13 +442,15 @@ RSpec.describe Plurimath::Asciimath::Parser do
 
       it "returns formula" do
         expected_value = Plurimath::Math::Formula.new([
-          Plurimath::Math::Function::Power.new(
-            Plurimath::Math::Function::FontStyle::Normal.new(
-              Plurimath::Math::Symbol.new("dm"),
-              "normal"
+          Plurimath::Math::Formula.new([
+            Plurimath::Math::Function::Power.new(
+              Plurimath::Math::Function::FontStyle::Normal.new(
+                Plurimath::Math::Symbol.new("dm"),
+                "normal"
+              ),
+              Plurimath::Math::Number.new("3")
             ),
-            Plurimath::Math::Number.new("3")
-          ),
+          ]),
           Plurimath::Math::Symbol.new(")"),
           Plurimath::Math::Symbol.new("&#x2208;"),
           Plurimath::Math::Symbol.new("s"),
@@ -458,10 +462,12 @@ RSpec.describe Plurimath::Asciimath::Parser do
             Plurimath::Math::Symbol.new("["),
             [
               Plurimath::Math::Number.new("15"),
-              Plurimath::Math::Function::FontStyle::Normal.new(
-                Plurimath::Math::Symbol.new("ml"),
-                "normal"
-              )
+              Plurimath::Math::Formula.new([
+                Plurimath::Math::Function::FontStyle::Normal.new(
+                  Plurimath::Math::Symbol.new("ml"),
+                  "normal"
+                )
+              ]),
             ],
             Plurimath::Math::Symbol.new("")
           )

--- a/spec/plurimath/asciimath/metanorma/mn_samples_jcgm_spec.rb
+++ b/spec/plurimath/asciimath/metanorma/mn_samples_jcgm_spec.rb
@@ -1806,14 +1806,14 @@ RSpec.describe Plurimath::Asciimath::Parser do
             ],
             Plurimath::Math::Symbol.new(")")
           ),
-          Plurimath::Math::Symbol.new("/"),
+          Plurimath::Math::Symbol.new("/"), 
           Plurimath::Math::Function::Base.new(
             Plurimath::Math::Function::FontStyle::Italic.new(
               Plurimath::Math::Symbol.new("T"),
               "ii"
             ),
             Plurimath::Math::Formula.new([
-              Plurimath::Math::Number.new("1"),
+              Plurimath::Math::Number.new("1"), 
               Plurimath::Math::Symbol.new("/"),
               Plurimath::Math::Number.new("2")
             ])
@@ -1828,7 +1828,18 @@ RSpec.describe Plurimath::Asciimath::Parser do
               Plurimath::Math::Number.new("4")
             ])
           ),
-          Plurimath::Math::Function::Text.new("unitsml(min^(-1))")
+          Plurimath::Math::Formula.new([
+            Plurimath::Math::Function::Power.new(
+              Plurimath::Math::Function::FontStyle::Normal.new(
+                Plurimath::Math::Function::Min.new,
+                "normal"
+              ),
+              Plurimath::Math::Formula.new([
+                Plurimath::Math::Symbol.new("&#x2212;"),
+                Plurimath::Math::Number.new("1")
+              ])
+            )
+          ])
         ])
         expect(formula).to eq(expected_value)
       end

--- a/spec/plurimath/asciimath/parser_spec.rb
+++ b/spec/plurimath/asciimath/parser_spec.rb
@@ -1714,10 +1714,12 @@ RSpec.describe Plurimath::Asciimath::Parser do
             Plurimath::Math::Number.new("10"),
             Plurimath::Math::Number.new("12"),
           ),
-          Plurimath::Math::Function::FontStyle::Normal.new(
-            Plurimath::Math::Symbol.new("Hz"),
-            "normal",
-          ),
+          Plurimath::Math::Formula.new([
+            Plurimath::Math::Function::FontStyle::Normal.new(
+              Plurimath::Math::Symbol.new("Hz"),
+              "normal",
+            ),
+          ]),
           Plurimath::Math::Symbol.new(", "),
           Plurimath::Math::Function::Text.new(" "),
           Plurimath::Math::Function::Base.new(

--- a/spec/plurimath/asciimath_spec.rb
+++ b/spec/plurimath/asciimath_spec.rb
@@ -5708,6 +5708,56 @@ RSpec.describe Plurimath::Asciimath do
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
+
+    context "contains unitsml example #1 plurimath/plurimath/pull/221 example #107" do
+      let(:string) { '1 "unitsml(Aring)"' }
+
+      it 'returns parsed Asciimath to Formula' do
+        latex = '1 \mathrm{&#xc5;}'
+        asciimath = "1 rm(&#xc5;)"
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mn>1</mn>
+              <mo rspace="thickmathspace">&#x2062;</mo>
+              <mrow>
+                <mstyle mathvariant="normal">
+                  <mi>&#xc5;</mi>
+                </mstyle>
+              </mrow>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
+      end
+    end
+
+    context "contains unitsml example #2 plurimath/plurimath/pull/221 example #108" do
+      let(:string) { '1 "unitsml(deg)"' }
+
+      it 'returns parsed Asciimath to Formula' do
+        latex = '1 \mathrm{&#xb0;}'
+        asciimath = "1 rm(&#xb0;)"
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mn>1</mn>
+              <mo>&#x2062;</mo>
+              <mrow>
+                <mstyle mathvariant="normal">
+                  <mi>&#xb0;</mi>
+                </mstyle>
+              </mrow>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
+      end
+    end
   end
 
   describe ".to_omml" do

--- a/spec/plurimath/asciimath_spec.rb
+++ b/spec/plurimath/asciimath_spec.rb
@@ -771,9 +771,11 @@ RSpec.describe Plurimath::Asciimath do
                 <mn>10</mn>
                 <mn>12</mn>
               </msup>
-              <mstyle mathvariant="normal">
-                <mi>Hz</mi>
-              </mstyle>
+              <mrow>
+                <mstyle mathvariant="normal">
+                  <mi>Hz</mi>
+                </mstyle>
+              </mrow>
               <mo>, </mo>
               <mtext> </mtext>
               <msub>
@@ -2041,9 +2043,12 @@ RSpec.describe Plurimath::Asciimath do
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
             <mstyle displaystyle="true">
               <mn>1</mn>
-              <mstyle mathvariant="normal">
-                <mi>A</mi>
-              </mstyle>
+              <mo rspace="thickmathspace">&#x2062;</mo>
+              <mrow>
+                <mstyle mathvariant="normal">
+                  <mi>A</mi>
+                </mstyle>
+              </mrow>
               <mo>=</mo>
               <msup>
                 <mrow>
@@ -3957,9 +3962,12 @@ RSpec.describe Plurimath::Asciimath do
               </msub>
               <mo>=</mo>
               <mn>1128575290808154.8</mn>
-              <mstyle mathvariant="normal">
-                <mi>Hz</mi>
-              </mstyle>
+              <mo rspace="thickmathspace">&#x2062;</mo>
+              <mrow>
+                <mstyle mathvariant="normal">
+                  <mi>Hz</mi>
+                </mstyle>
+              </mrow>
             </mstyle>
           </math>
         MATHML
@@ -4770,9 +4778,11 @@ RSpec.describe Plurimath::Asciimath do
                 <mn>4</mn>
                 <mo>)</mo>
               </mrow>
-              <mstyle mathvariant="normal">
-                <mi>MHz</mi>
-              </mstyle>
+              <mrow>
+                <mstyle mathvariant="normal">
+                  <mi>MHz</mi>
+                </mstyle>
+              </mrow>
             </mstyle>
           </math>
         MATHML
@@ -5437,6 +5447,7 @@ RSpec.describe Plurimath::Asciimath do
             <mstyle displaystyle="true">
               <mrow>
                 <mi>sin</mi>
+                <mo rspace="thickmathspace">&#x2062;</mo>
                 <mrow>
                   <mstyle mathvariant="normal">
                     <mi>mm</mi>
@@ -5452,6 +5463,242 @@ RSpec.describe Plurimath::Asciimath do
                     </mrow>
                   </msup>
                 </mrow>
+              </mrow>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
+      end
+    end
+
+    context "contains unitsml example #1 plurimath/asciimath2unitsml example #100" do
+      let(:string) { '1 "unitsml(mm*s^-2)"' }
+
+      it 'returns parsed Asciimath to Formula' do
+        latex = '1 \\mathrm{mm} \\cdot \\mathrm{s}^{- 2}'
+        asciimath = '1 rm(mm) * rm(s)^(- 2)'
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mn>1</mn>
+              <mo rspace="thickmathspace">&#x2062;</mo>
+              <mrow>
+                <mstyle mathvariant="normal">
+                  <mi>mm</mi>
+                </mstyle>
+                <mo>&#x22c5;</mo>
+                <msup>
+                  <mstyle mathvariant="normal">
+                    <mi>s</mi>
+                  </mstyle>
+                  <mrow>
+                    <mo>&#x2212;</mo>
+                    <mn>2</mn>
+                  </mrow>
+                </msup>
+              </mrow>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
+      end
+    end
+
+    context "contains unitsml example #2 plurimath/asciimath2unitsml example #101" do
+      let(:string) { '1 "unitsml(um)"' }
+
+      it 'returns parsed Asciimath to Formula' do
+        latex = '1 \\mathrm{&#xb5;m}'
+        asciimath = '1 rm(&#xb5;m)'
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mn>1</mn>
+              <mo rspace="thickmathspace">&#x2062;</mo>
+              <mrow>
+                <mstyle mathvariant="normal">
+                  <mi>&#xb5;m</mi>
+                </mstyle>
+              </mrow>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
+      end
+    end
+
+    context "contains unitsml example #3 plurimath/asciimath2unitsml example #102" do
+      let(:string) { '1 "unitsml(degK)" + 1 "unitsml(prime)" + ii(theta) = s//r "unitsml(rad)" + 10^(12) "unitsml(Hz)"' }
+
+      it 'returns parsed Asciimath to Formula' do
+        latex = '1 \\mathrm{&#xb0;K} + 1 \\mathrm{\\prime} + \\mathit{\\theta} = s / r \\mathrm{rad} + 10^{12} \\mathrm{Hz}'
+        asciimath = "1 rm(&#xb0;K) + 1 rm(') + ii(theta) = s // r rm(rad) + 10^(12) rm(Hz)"
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mn>1</mn>
+              <mo rspace="thickmathspace">&#x2062;</mo>
+              <mrow>
+                <mstyle mathvariant="normal">
+                  <mi>&#xb0;K</mi>
+                </mstyle>
+              </mrow>
+              <mo>+</mo>
+              <mn>1</mn>
+              <mo>&#x2062;</mo>
+              <mrow>
+                <mstyle mathvariant="normal">
+                  <mo>&#x2032;</mo>
+                </mstyle>
+              </mrow>
+              <mo>+</mo>
+              <mstyle mathvariant="italic">
+                <mi>&#x3b8;</mi>
+              </mstyle>
+              <mo>=</mo>
+              <mi>s</mi>
+              <mo>/</mo>
+              <mi>r</mi>
+              <mo rspace="thickmathspace">&#x2062;</mo>
+              <mrow>
+                <mstyle mathvariant="normal">
+                  <mi>rad</mi>
+                </mstyle>
+              </mrow>
+              <mo>+</mo>
+              <msup>
+                <mn>10</mn>
+                <mn>12</mn>
+              </msup>
+              <mrow>
+                <mstyle mathvariant="normal">
+                  <mi>Hz</mi>
+                </mstyle>
+              </mrow>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
+      end
+    end
+
+    context "contains unitsml example #4 plurimath/asciimath2unitsml example #103" do
+      let(:string) { '8 "unitsml(kg)" cdot "unitsml(m)"' }
+
+      it 'returns parsed Asciimath to Formula' do
+        latex = '8 \\mathrm{kg} \\cdot \\mathrm{m}'
+        asciimath = "8 rm(kg) * rm(m)"
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mn>8</mn>
+              <mo rspace="thickmathspace">&#x2062;</mo>
+              <mrow>
+                <mstyle mathvariant="normal">
+                  <mi>kg</mi>
+                </mstyle>
+              </mrow>
+              <mo>&#x22c5;</mo>
+              <mrow>
+                <mstyle mathvariant="normal">
+                  <mi>m</mi>
+                </mstyle>
+              </mrow>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
+      end
+    end
+
+    context "contains unitsml example #5 plurimath/asciimath2unitsml example #104" do
+      let(:string) { '1 "unitsml(sqrt(Hz))"' }
+
+      it 'returns parsed Asciimath to Formula' do
+        latex = '1 \\mathrm{Hz}^{0.5}'
+        asciimath = "1 rm(Hz)^(0.5)"
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mn>1</mn>
+              <mo rspace="thickmathspace">&#x2062;</mo>
+              <mrow>
+                <msup>
+                  <mstyle mathvariant="normal">
+                    <mi>Hz</mi>
+                  </mstyle>
+                  <mn>0.5</mn>
+                </msup>
+              </mrow>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
+      end
+    end
+
+    context "contains unitsml example #6 plurimath/asciimath2unitsml example #105" do
+      let(:string) { '1 "unitsml(kg)" + 1 "unitsml(g)"' }
+
+      it 'returns parsed Asciimath to Formula' do
+        latex = '1 \mathrm{kg} + 1 \mathrm{g}'
+        asciimath = "1 rm(kg) + 1 rm(g)"
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mn>1</mn>
+              <mo rspace="thickmathspace">&#x2062;</mo>
+              <mrow>
+                <mstyle mathvariant="normal">
+                  <mi>kg</mi>
+                </mstyle>
+              </mrow>
+              <mo>+</mo>
+              <mn>1</mn>
+              <mo rspace="thickmathspace">&#x2062;</mo>
+              <mrow>
+                <mstyle mathvariant="normal">
+                  <mi>g</mi>
+                </mstyle>
+              </mrow>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
+      end
+    end
+
+    context "contains unitsml example #7 plurimath/asciimath2unitsml example #106" do
+      let(:string) { '"unitsml(u-)" + "unitsml(um)"' }
+
+      it 'returns parsed Asciimath to Formula' do
+        latex = 'u + \mathrm{&#xb5;m}'
+        asciimath = "u + rm(&#xb5;m)"
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mrow>
+                <mi>u</mi>
+              </mrow>
+              <mo>+</mo>
+              <mrow>
+                <mstyle mathvariant="normal">
+                  <mi>&#xb5;m</mi>
+                </mstyle>
               </mrow>
             </mstyle>
           </math>


### PR DESCRIPTION
This PR adds spaces between normal **MathML** tags and  **Unitsml** generated **MathML** as instructed [here](https://github.com/metanorma/bipm-si-brochure/issues/222#issuecomment-1966110260).

closes #222 