### PR TITLE
Fixes broken word rendering

### DIFF
--- a/lib/plurimath/math/function/log.rb
+++ b/lib/plurimath/math/function/log.rb
@@ -35,7 +35,7 @@ module Plurimath
 
           ssubsup   = Utility.ox_element("sSubSup", namespace: "m")
           ssubsuppr = Utility.ox_element("sSubSupPr", namespace: "m")
-          ssubsuppr << hide_tags(Utility.pr_element("ctrl", true, namespace: "m"))
+          ssubsuppr << Utility.pr_element("ctrl", true, namespace: "m")
           Utility.update_nodes(
             ssubsup,
             [
@@ -80,25 +80,6 @@ module Plurimath
           return e_tag if hide_function_name
 
           e_tag << rpr_tag
-        end
-
-        def hide_tags(nar)
-          attr = { "m:val": "1" }
-          if parameter_one.nil?
-            nar << Utility.ox_element(
-              "subHide",
-              namespace: "m",
-              attributes: attr,
-            )
-          end
-          if parameter_two.nil?
-            nar << Utility.ox_element(
-              "supHide",
-              namespace: "m",
-              attributes: attr,
-            )
-          end
-          nar
         end
 
         def rpr_tag

--- a/lib/plurimath/math/function/power_base.rb
+++ b/lib/plurimath/math/function/power_base.rb
@@ -43,9 +43,7 @@ module Plurimath
 
           ssubsup   = Utility.ox_element("sSubSup", namespace: "m")
           ssubsuppr = Utility.ox_element("sSubSupPr", namespace: "m")
-          ssubsuppr << hide_tags(
-            Utility.pr_element("ctrl", true, namespace: "m"),
-          )
+          ssubsuppr << Utility.pr_element("ctrl", true, namespace: "m")
           Utility.update_nodes(
             ssubsup,
             [
@@ -92,27 +90,6 @@ module Plurimath
             validate_mathml_fields(parameter_two),
             validate_mathml_fields(parameter_three),
           ]
-        end
-
-        protected
-
-        def hide_tags(nar)
-          attr = { "m:val": "1" }
-          if parameter_two.nil?
-            nar << Utility.ox_element(
-              "subHide",
-              namespace: "m",
-              attributes: attr,
-            )
-          end
-          if parameter_three.nil?
-            nar << Utility.ox_element(
-              "supHide",
-              namespace: "m",
-              attributes: attr,
-            )
-          end
-          nar
         end
       end
     end

--- a/spec/plurimath/asciimath_spec.rb
+++ b/spec/plurimath/asciimath_spec.rb
@@ -5863,7 +5863,6 @@ RSpec.describe Plurimath::Asciimath do
                       <w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/>
                       <w:i/>
                     </w:rPr>
-                    <m:subHide m:val="1"/>
                   </m:ctrlPr>
                 </m:sSubSupPr>
                 <m:e>

--- a/spec/plurimath/fixtures/omml/128.omml
+++ b/spec/plurimath/fixtures/omml/128.omml
@@ -7,7 +7,6 @@
             <w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/>
             <w:i/>
           </w:rPr>
-          <m:supHide m:val="1"/>
         </m:ctrlPr>
       </m:sSubSupPr>
       <m:e>

--- a/spec/plurimath/fixtures/omml/line_break/line-break-061.omml
+++ b/spec/plurimath/fixtures/omml/line_break/line-break-061.omml
@@ -7,7 +7,6 @@
             <w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/>
             <w:i/>
           </w:rPr>
-          <m:supHide m:val="1"/>
         </m:ctrlPr>
       </m:sSubSupPr>
       <m:e>

--- a/spec/plurimath/fixtures/omml/line_break/line-break-082.omml
+++ b/spec/plurimath/fixtures/omml/line_break/line-break-082.omml
@@ -7,8 +7,6 @@
             <w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/>
             <w:i/>
           </w:rPr>
-          <m:subHide m:val="1"/>
-          <m:supHide m:val="1"/>
         </m:ctrlPr>
       </m:sSubSupPr>
       <m:e>
@@ -39,7 +37,6 @@
             <w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/>
             <w:i/>
           </w:rPr>
-          <m:supHide m:val="1"/>
         </m:ctrlPr>
       </m:sSubSupPr>
       <m:e>

--- a/spec/plurimath/fixtures/omml/line_break/line-break-090.omml
+++ b/spec/plurimath/fixtures/omml/line_break/line-break-090.omml
@@ -9,8 +9,6 @@
                 <w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/>
                 <w:i/>
               </w:rPr>
-              <m:subHide m:val="1"/>
-              <m:supHide m:val="1"/>
             </m:ctrlPr>
           </m:sSubSupPr>
           <m:e>


### PR DESCRIPTION
This PR removes the **`sub/sup hide`** tags from each tag(**`log`**, **`power_base`**) other than **`nary`**.
Following links explains that the **`SubSupPr`** tags doesn't include **`sub/sup hide`** tags but **`naryPr`** does.
1. **Nary_PR**
a. https://schemas.liquid-technologies.com/officeopenxml/2006/?page=ct_narypr.html
b. http://www.datypic.com/sc/ooxml/e-m_naryPr-1.html
2. **SubSup**
a. https://schemas.liquid-technologies.com/officeopenxml/2006/?page=ct_ssubsup.html
b. http://www.datypic.com/sc/ooxml/e-m_sSubSupPr-1.html

closes #228 