### PR TITLE
Fixes failing MathML and AsciiMath expression

### DIFF
--- a/lib/plurimath/asciimath/transform.rb
+++ b/lib/plurimath/asciimath/transform.rb
@@ -897,6 +897,11 @@ module Plurimath
       end
 
       rule(table: simple(:table),
+           left_right: simple(:left_right)) do
+        Math::Formula.new([table, left_right])
+      end
+
+      rule(table: simple(:table),
            expr: simple(:expr)) do
         formula_array = [table]
         formula_array << expr unless expr.to_s.strip.empty?

--- a/lib/plurimath/math/formula.rb
+++ b/lib/plurimath/math/formula.rb
@@ -288,26 +288,19 @@ module Plurimath
 
       def unitsml_post_processing(nodes)
         nodes.each.with_index do |node, index|
-          if node.is_a?(Ox::Element) && node.attributes&.dig(:unitsml)
-            previous = nodes[index-1]
-            if previous && ["mi", "mn"].include?(previous.name)
-              if text_in_tag?(node.nodes)
-                nodes.insert(index, space_element(attributes: true))
-              else
-                nodes.insert(index, space_element)
-              end
-            end
-
-            node.attributes.delete_if {|k, v| k == :unitsml }
+          if node.is_a?(Ox::Element) && node&.attributes&.dig(:unitsml)
+            pre_index = index - 1
+            pre_node = nodes[pre_index] if pre_index.zero? || pre_index.positive?
+            nodes.insert(index, space_element(node)) if valid_previous?(pre_node)
+            node.attributes.delete_if { |k, _| k == :unitsml }
           end
-
-          unitsml_post_processing(node.nodes) if !node.nodes.any?(String)
+          unitsml_post_processing(node.nodes) if node.nodes.none?(String)
         end
       end
 
-      def space_element(attributes: false)
+      def space_element(node)
         element = (ox_element("mo") << "&#x2062;")
-        element.attributes[:rspace] = "thickmathspace" if attributes
+        element.attributes[:rspace] = "thickmathspace" if text_in_tag?(node.nodes)
         element
       end
 
@@ -326,6 +319,17 @@ module Plurimath
 
       def unicodemath_value
         (negated_value? || mini_sized?) ? value&.map(&:to_unicodemath)&.join : value&.map(&:to_unicodemath)&.join(" ")
+      end
+
+      def valid_previous?(previous)
+        return unless previous
+
+        ["mi", "mn"].include?(previous.name) ||
+          inside_tag?(previous)
+      end
+
+      def inside_tag?(previous)
+        previous&.nodes&.any? { |node| valid_previous?(node) if node.is_a?(Ox::Element) }
       end
     end
   end

--- a/lib/plurimath/mathml/transform.rb
+++ b/lib/plurimath/mathml/transform.rb
@@ -191,8 +191,12 @@ module Plurimath
         elsif flatten_mrow&.first&.is_nary_function? && flatten_mrow.length == 2
           nary_function = flatten_mrow.first
           if nary_function.is_ternary_function? && nary_function.all_values_exist?
-            flatten_mrow[0] = nary_function.new_nary_function(flatten_mrow.delete_at(1))
-            flatten_mrow
+            if nary_function.respond_to?(:new_nary_function)
+              flatten_mrow[0] = nary_function.new_nary_function(flatten_mrow.delete_at(1))
+              flatten_mrow
+            else
+              Utility.filter_values(flatten_mrow)
+            end
           elsif nary_function.is_binary_function? && nary_function.any_value_exist?
             flatten_mrow[0] = nary_function.new_nary_function(flatten_mrow.delete_at(1))
             flatten_mrow

--- a/spec/plurimath/asciimath_spec.rb
+++ b/spec/plurimath/asciimath_spec.rb
@@ -5762,7 +5762,7 @@ RSpec.describe Plurimath::Asciimath do
     context "contains example #1 from plurimath/plurimath/pull/238 example #109" do
       let(:string) { 's_{"p"}^2 = {sum_{i=1}^{ii(N)} ii(nu)_i s_i^2}/{sum_{i=1}^{ii(N)} ii(nu)_i}' }
 
-      it 'returns parsed Asciimath to Formula' do
+      it 'prevention of conversion from ternary functions to nary-and function' do
         latex = 's_{\text{p}}^{2} = \frac{\sum_{i = 1}^{\mathit{N}} \mathit{\nu}_{i} s_{i}^{2}}{\sum_{i = 1}^{\mathit{N}} \mathit{\nu}_{i}}'
         asciimath = 's_("p")^(2) = frac(sum_(i = 1)^(ii(N)) ii(nu)_(i) s_(i)^(2))(sum_(i = 1)^(ii(N)) ii(nu)_(i))'
         mathml = <<~MATHML

--- a/spec/plurimath/asciimath_spec.rb
+++ b/spec/plurimath/asciimath_spec.rb
@@ -5758,6 +5758,77 @@ RSpec.describe Plurimath::Asciimath do
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
+
+    context "contains example #1 from plurimath/plurimath/pull/238 example #109" do
+      let(:string) { 's_{"p"}^2 = {sum_{i=1}^{ii(N)} ii(nu)_i s_i^2}/{sum_{i=1}^{ii(N)} ii(nu)_i}' }
+
+      it 'returns parsed Asciimath to Formula' do
+        latex = 's_{\text{p}}^{2} = \frac{\sum_{i = 1}^{\mathit{N}} \mathit{\nu}_{i} s_{i}^{2}}{\sum_{i = 1}^{\mathit{N}} \mathit{\nu}_{i}}'
+        asciimath = 's_("p")^(2) = frac(sum_(i = 1)^(ii(N)) ii(nu)_(i) s_(i)^(2))(sum_(i = 1)^(ii(N)) ii(nu)_(i))'
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <msubsup>
+                <mi>s</mi>
+                <mtext>p</mtext>
+                <mn>2</mn>
+              </msubsup>
+              <mo>=</mo>
+              <mfrac>
+                <mrow>
+                  <mrow>
+                    <munderover>
+                      <mo>&#x2211;</mo>
+                      <mrow>
+                        <mi>i</mi>
+                        <mo>=</mo>
+                        <mn>1</mn>
+                      </mrow>
+                      <mstyle mathvariant="italic">
+                        <mi>N</mi>
+                      </mstyle>
+                    </munderover>
+                    <msub>
+                      <mstyle mathvariant="italic">
+                        <mi>&#x3bd;</mi>
+                      </mstyle>
+                      <mi>i</mi>
+                    </msub>
+                  </mrow>
+                  <msubsup>
+                    <mi>s</mi>
+                    <mi>i</mi>
+                    <mn>2</mn>
+                  </msubsup>
+                </mrow>
+                <mrow>
+                  <munderover>
+                    <mo>&#x2211;</mo>
+                    <mrow>
+                      <mi>i</mi>
+                      <mo>=</mo>
+                      <mn>1</mn>
+                    </mrow>
+                    <mstyle mathvariant="italic">
+                      <mi>N</mi>
+                    </mstyle>
+                  </munderover>
+                  <msub>
+                    <mstyle mathvariant="italic">
+                      <mi>&#x3bd;</mi>
+                    </mstyle>
+                    <mi>i</mi>
+                  </msub>
+                </mrow>
+              </mfrac>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
+      end
+    end
   end
 
   describe ".to_omml" do

--- a/spec/plurimath/asciimath_spec.rb
+++ b/spec/plurimath/asciimath_spec.rb
@@ -771,6 +771,7 @@ RSpec.describe Plurimath::Asciimath do
                 <mn>10</mn>
                 <mn>12</mn>
               </msup>
+              <mo rspace="thickmathspace">&#x2062;</mo>
               <mrow>
                 <mstyle mathvariant="normal">
                   <mi>Hz</mi>
@@ -4778,6 +4779,7 @@ RSpec.describe Plurimath::Asciimath do
                 <mn>4</mn>
                 <mo>)</mo>
               </mrow>
+              <mo rspace="thickmathspace">&#x2062;</mo>
               <mrow>
                 <mstyle mathvariant="normal">
                   <mi>MHz</mi>
@@ -5576,6 +5578,7 @@ RSpec.describe Plurimath::Asciimath do
                 <mn>10</mn>
                 <mn>12</mn>
               </msup>
+              <mo rspace="thickmathspace">&#x2062;</mo>
               <mrow>
                 <mstyle mathvariant="normal">
                   <mi>Hz</mi>
@@ -5759,7 +5762,7 @@ RSpec.describe Plurimath::Asciimath do
       end
     end
 
-    context "contains example #1 from plurimath/plurimath/pull/238 example #109" do
+    context "contains example from plurimath/pull/238 example #109" do
       let(:string) { 's_{"p"}^2 = {sum_{i=1}^{ii(N)} ii(nu)_i s_i^2}/{sum_{i=1}^{ii(N)} ii(nu)_i}' }
 
       it 'prevention of conversion from ternary functions to nary-and function' do
@@ -5821,6 +5824,188 @@ RSpec.describe Plurimath::Asciimath do
                   </msub>
                 </mrow>
               </mfrac>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
+      end
+    end
+
+    context "contains example from plurimath/pull/240 example #110" do
+      let(:string) { '1 "unitsml(A)" = (e/(1.602176634 xx 10^(-19))) "unitsml(s^(-1))"' }
+
+      it 'returns parsed Asciimath to Formula' do
+        latex = '1 \mathrm{A} = ( \frac{e}{1.602176634 \times 10^{- 19}} ) \mathrm{s}^{- 1}'
+        asciimath = '1 rm(A) = (frac(e)(1.602176634 xx 10^(- 19))) rm(s)^(- 1)'
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mn>1</mn>
+              <mo rspace="thickmathspace">&#x2062;</mo>
+              <mrow>
+                <mstyle mathvariant="normal">
+                  <mi>A</mi>
+                </mstyle>
+              </mrow>
+              <mo>=</mo>
+              <mrow>
+                <mo>(</mo>
+                <mfrac>
+                  <mi>e</mi>
+                  <mrow>
+                    <mn>1.602176634</mn>
+                    <mo>&#xd7;</mo>
+                    <msup>
+                      <mn>10</mn>
+                      <mrow>
+                        <mo>&#x2212;</mo>
+                        <mn>19</mn>
+                      </mrow>
+                    </msup>
+                  </mrow>
+                </mfrac>
+                <mo>)</mo>
+              </mrow>
+              <mo rspace="thickmathspace">&#x2062;</mo>
+              <mrow>
+                <msup>
+                  <mstyle mathvariant="normal">
+                    <mi>s</mi>
+                  </mstyle>
+                  <mrow>
+                    <mo>&#x2212;</mo>
+                    <mn>1</mn>
+                  </mrow>
+                </msup>
+              </mrow>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
+      end
+    end
+
+    context "contains example from plurimath/issues/232 example #110" do
+      let(:string) { '((E_H^s),(E_V^s)) = e^(jkR)/R ([S_(HH),S_(HV)], [S_(VH), S_(VV)])((E_H^j), (E_V^j))' }
+
+      it 'matches LaTeX, AsciiMath, and MathML' do
+        latex = '\left (\begin{matrix}E_{H}^{s} \\\\ E_{V}^{s}\end{matrix}\right ) = \frac{e^{j k R}}{R} \left (\begin{matrix}S_{H H} & S_{H V} \\\\ S_{V H} & S_{V V}\end{matrix}\right ) \left (\begin{matrix}E_{H}^{j} \\\\ E_{V}^{j}\end{matrix}\right )'
+        asciimath = '([E_(H)^(s)], [E_(V)^(s)]) = frac(e^(j k R))(R) ([S_(H H), S_(H V)], [S_(V H), S_(V V)]) ([E_(H)^(j)], [E_(V)^(j)])'
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mrow>
+                <mo>(</mo>
+                <mtable>
+                  <mtr>
+                    <mtd>
+                      <msubsup>
+                        <mi>E</mi>
+                        <mi>H</mi>
+                        <mi>s</mi>
+                      </msubsup>
+                    </mtd>
+                  </mtr>
+                  <mtr>
+                    <mtd>
+                      <msubsup>
+                        <mi>E</mi>
+                        <mi>V</mi>
+                        <mi>s</mi>
+                      </msubsup>
+                    </mtd>
+                  </mtr>
+                </mtable>
+                <mo>)</mo>
+              </mrow>
+              <mo>=</mo>
+              <mfrac>
+                <msup>
+                  <mi>e</mi>
+                  <mrow>
+                    <mi>j</mi>
+                    <mi>k</mi>
+                    <mi>R</mi>
+                  </mrow>
+                </msup>
+                <mi>R</mi>
+              </mfrac>
+              <mrow>
+                <mrow>
+                  <mo>(</mo>
+                  <mtable>
+                    <mtr>
+                      <mtd>
+                        <msub>
+                          <mi>S</mi>
+                          <mrow>
+                            <mi>H</mi>
+                            <mi>H</mi>
+                          </mrow>
+                        </msub>
+                      </mtd>
+                      <mtd>
+                        <msub>
+                          <mi>S</mi>
+                          <mrow>
+                            <mi>H</mi>
+                            <mi>V</mi>
+                          </mrow>
+                        </msub>
+                      </mtd>
+                    </mtr>
+                    <mtr>
+                      <mtd>
+                        <msub>
+                          <mi>S</mi>
+                          <mrow>
+                            <mi>V</mi>
+                            <mi>H</mi>
+                          </mrow>
+                        </msub>
+                      </mtd>
+                      <mtd>
+                        <msub>
+                          <mi>S</mi>
+                          <mrow>
+                            <mi>V</mi>
+                            <mi>V</mi>
+                          </mrow>
+                        </msub>
+                      </mtd>
+                    </mtr>
+                  </mtable>
+                  <mo>)</mo>
+                </mrow>
+                <mrow>
+                  <mo>(</mo>
+                  <mtable>
+                    <mtr>
+                      <mtd>
+                        <msubsup>
+                          <mi>E</mi>
+                          <mi>H</mi>
+                          <mi>j</mi>
+                        </msubsup>
+                      </mtd>
+                    </mtr>
+                    <mtr>
+                      <mtd>
+                        <msubsup>
+                          <mi>E</mi>
+                          <mi>V</mi>
+                          <mi>j</mi>
+                        </msubsup>
+                      </mtd>
+                    </mtr>
+                  </mtable>
+                  <mo>)</mo>
+                </mrow>
+              </mrow>
             </mstyle>
           </math>
         MATHML

--- a/spec/plurimath/mathml_spec.rb
+++ b/spec/plurimath/mathml_spec.rb
@@ -1487,6 +1487,139 @@ RSpec.describe Plurimath::Mathml do
         expect(formula.to_asciimath).to eq(asciimath)
       end
     end
+
+    context "contains string from plurimath/issue#238" do
+      let(:string)  do
+        <<~MATHML
+          <math>
+            <mstyle displaystyle="true">
+              <msubsup>
+                <mi>s</mi>
+                <mtext>p</mtext>
+                <mn>2</mn>
+              </msubsup>
+              <mo>=</mo>
+              <mfrac>
+                <mrow>
+                  <mrow>
+                    <munderover>
+                      <mo>&#8721;</mo>
+                      <mrow>
+                        <mi>i</mi>
+                        <mo>=</mo>
+                        <mn>1</mn>
+                      </mrow>
+                      <mstyle mathvariant="italic">
+                        <mi>N</mi>
+                      </mstyle>
+                    </munderover>
+                    <msub>
+                      <mstyle mathvariant="italic">
+                        <mi>&#957;</mi>
+                      </mstyle>
+                      <mi>i</mi>
+                    </msub>
+                  </mrow>
+                  <msubsup>
+                    <mi>s</mi>
+                    <mi>i</mi>
+                    <mn>2</mn>
+                  </msubsup>
+                </mrow>
+                <mrow>
+                  <munderover>
+                    <mo>&#8721;</mo>
+                    <mrow>
+                      <mi>i</mi>
+                      <mo>=</mo>
+                      <mn>1</mn>
+                    </mrow>
+                    <mstyle mathvariant="italic">
+                      <mi>N</mi>
+                    </mstyle>
+                  </munderover>
+                  <msub>
+                    <mstyle mathvariant="italic">
+                      <mi>&#957;</mi>
+                    </mstyle>
+                    <mi>i</mi>
+                  </msub>
+                </mrow>
+              </mfrac>
+            </mstyle>
+          </math>
+        MATHML
+      end
+
+      it 'compares MathML, LaTeX, and AsciiMath string' do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mrow>
+                <msubsup>
+                  <mi>s</mi>
+                  <mtext>p</mtext>
+                  <mn>2</mn>
+                </msubsup>
+                <mo>=</mo>
+                <mfrac>
+                  <mrow>
+                    <mrow>
+                      <munderover>
+                        <mo>&#x2211;</mo>
+                        <mrow>
+                          <mi>i</mi>
+                          <mo>=</mo>
+                          <mn>1</mn>
+                        </mrow>
+                        <mstyle mathvariant="italic">
+                          <mi>N</mi>
+                        </mstyle>
+                      </munderover>
+                      <msub>
+                        <mstyle mathvariant="italic">
+                          <mi>&#x3bd;</mi>
+                        </mstyle>
+                        <mi>i</mi>
+                      </msub>
+                    </mrow>
+                    <msubsup>
+                      <mi>s</mi>
+                      <mi>i</mi>
+                      <mn>2</mn>
+                    </msubsup>
+                  </mrow>
+                  <mrow>
+                    <munderover>
+                      <mo>&#x2211;</mo>
+                      <mrow>
+                        <mi>i</mi>
+                        <mo>=</mo>
+                        <mn>1</mn>
+                      </mrow>
+                      <mstyle mathvariant="italic">
+                        <mi>N</mi>
+                      </mstyle>
+                    </munderover>
+                    <msub>
+                      <mstyle mathvariant="italic">
+                        <mi>&#x3bd;</mi>
+                      </mstyle>
+                      <mi>i</mi>
+                    </msub>
+                  </mrow>
+                </mfrac>
+              </mrow>
+            </mstyle>
+          </math>
+        MATHML
+        latex = 's_{\text{p}}^{2} = \frac{\sum_{i = 1}^{\mathit{N}} \mathit{\nu}_{i} s_{i}^{2}}{\sum_{i = 1}^{\mathit{N}} \mathit{\nu}_{i}}'
+        asciimath = 's_("p")^(2) = frac(sum_(i = 1)^(ii(N)) ii(nu)_(i) s_(i)^(2))(sum_(i = 1)^(ii(N)) ii(nu)_(i))'
+        expect(formula.to_latex).to eq(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eq(asciimath)
+      end
+    end
   end
 
   describe ".to_omml" do


### PR DESCRIPTION
This PR updates **MathML** transform rules and Added specs for **AsciiMath** and **MathML**.

closes #238 