### PR TITLE
Intent attribute support in MathML input

### DIFF
--- a/lib/plurimath/mathml/parser.rb
+++ b/lib/plurimath/mathml/parser.rb
@@ -19,6 +19,7 @@ module Plurimath
         notation
         bevelled
         rowlines
+        intent
         accent
         height
         frame

--- a/lib/plurimath/mathml/transform.rb
+++ b/lib/plurimath/mathml/transform.rb
@@ -383,6 +383,7 @@ module Plurimath
                        height
                        accent
                        height
+                       intent
                        width
                        index
                        depth

--- a/lib/plurimath/utility.rb
+++ b/lib/plurimath/utility.rb
@@ -482,7 +482,12 @@ module Plurimath
       end
 
       def join_attr_value(attrs, value, unicode_only: false, lang: :mathml)
-        if value.any?(String)
+        if attrs&.key?(:intent)
+          Math::Function::Intent.new(
+            join_attr_value(nil, value, unicode_only: unicode_only, lang: lang)&.first,
+            Math::Function::Text.new(attrs[:intent]),
+          )
+        elsif value.any?(String)
           new_value = mathml_unary_classes(value, unicode_only: unicode_only, lang: lang)
           array_value = Array(new_value)
           attrs.nil? ? array_value : join_attr_value(attrs, array_value, unicode_only: unicode_only)

--- a/lib/plurimath/utility.rb
+++ b/lib/plurimath/utility.rb
@@ -482,11 +482,13 @@ module Plurimath
       end
 
       def join_attr_value(attrs, value, unicode_only: false, lang: :mathml)
-        if attrs&.key?(:intent)
-          Math::Function::Intent.new(
-            join_attr_value(nil, value, unicode_only: unicode_only, lang: lang)&.first,
-            Math::Function::Text.new(attrs[:intent]),
-          )
+        if attrs&.is_a?(Hash) && attrs.key?(:intent)
+          [
+            Math::Function::Intent.new(
+              filter_values(join_attr_value(nil, value, unicode_only: unicode_only, lang: lang)),
+              Math::Function::Text.new(attrs[:intent]),
+            )
+          ]
         elsif value.any?(String)
           new_value = mathml_unary_classes(value, unicode_only: unicode_only, lang: lang)
           array_value = Array(new_value)

--- a/spec/plurimath/mathml/parser_spec.rb
+++ b/spec/plurimath/mathml/parser_spec.rb
@@ -1747,4 +1747,31 @@ RSpec.describe Plurimath::Mathml::Parser do
       expect(formula).to eq(expected_value)
     end
   end
+  
+  context "contains mathml equation with intent attribute as input" do
+    let(:exp) {
+      <<~MATHML
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <mrow intent="plus(x, y)">
+            <mi>x</mi>
+            <mo>+</mo>
+            <mi>y</mi>
+          </mrow>
+        </math>
+      MATHML
+    }
+    it "returns formula of decimal values" do
+      expected_value = Plurimath::Math::Formula.new([
+        Plurimath::Math::Function::Intent.new(
+          Plurimath::Math::Formula.new([
+            Plurimath::Math::Symbols::Symbol.new("x"),
+            Plurimath::Math::Symbols::Plus.new,
+            Plurimath::Math::Symbols::Symbol.new("y"),
+          ]),
+          Plurimath::Math::Function::Text.new("plus(x, y)"),
+        )
+      ])
+      expect(formula).to eq(expected_value)
+    end
+  end
 end


### PR DESCRIPTION
This PR supports the `intent` attribute from **MathML** elements as input.