### PR TITLE
Fenced object with nil value to MathML conversion fix

### DIFF
--- a/lib/plurimath/math/function/fenced.rb
+++ b/lib/plurimath/math/function/fenced.rb
@@ -31,7 +31,7 @@ module Plurimath
         def to_mathml_without_math_tag(intent)
           first_value = ox_element("mo", attributes: options&.dig(:open_paren)) << (mathml_paren(parameter_one, intent) || "")
           third_value = ox_element("mo", attributes: options&.dig(:close_paren)) << (mathml_paren(parameter_three, intent) || "")
-          mrow_value = mathml_value(intent).insert(0, first_value) << third_value
+          mrow_value = Array(mathml_value(intent)).insert(0, first_value) << third_value
           fenced = Utility.update_nodes(ox_element("mrow"), mrow_value)
           intentify(
             fenced,
@@ -254,7 +254,7 @@ module Plurimath
         end
 
         def binomial_coefficient?(value)
-          parameter_two.first.is_a?(Frac) &&
+          parameter_two&.first&.is_a?(Frac) &&
             parameter_two&.first&.options&.dig(:choose)
         end
 

--- a/spec/plurimath/asciimath_spec.rb
+++ b/spec/plurimath/asciimath_spec.rb
@@ -6410,6 +6410,29 @@ RSpec.describe Plurimath::Asciimath do
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
+
+    context "contains example from plrimath/issue#276 example #120" do
+      let(:string) { '"Pr"[]' }
+
+      it 'matches LaTeX, AsciiMath, and MathML' do
+        latex = '\text{Pr} [  ]'
+        asciimath = '"Pr" []'
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mtext>Pr</mtext>
+              <mrow>
+                <mo>[</mo>
+                <mo>]</mo>
+              </mrow>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
+      end
+    end
   end
 
   describe ".to_omml" do


### PR DESCRIPTION
This PR fixes **Plurimath Fenced** object with `nil` value to **MathML** conversion.

closes #276 