### PR TITLE
Bigdecimal dependency

### DIFF
--- a/plurimath.gemspec
+++ b/plurimath.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'parslet'
   spec.add_dependency 'thor'
   spec.add_dependency 'ox'
+  spec.add_dependency 'bigdecimal'
 end


### PR DESCRIPTION
This pull request adds a dependency on **BigDecimal**, as it's a bundled gem starting with `ruby-3.4.0-preview1`.

closes #272 