### PR TITLE
Unicodemath input wrapper symbols parsed as text 

### DIFF
--- a/lib/plurimath/unicode_math/parse.rb
+++ b/lib/plurimath/unicode_math/parse.rb
@@ -226,6 +226,7 @@ module Plurimath
           element_exp_script_validation? >> space? >> exp_script |
           unary_arg_functions |
           combined_symbols |
+          wrapper_symbols |
           operand |
           char |
           alphanumeric |

--- a/lib/plurimath/unicode_math/parsing_rules/common_rules.rb
+++ b/lib/plurimath/unicode_math/parsing_rules/common_rules.rb
@@ -80,6 +80,7 @@ module Plurimath
             accents |
             negatable_symbols |
             fonts.as(:fonts) |
+            wrapper_symbols |
             ((parsing_text | factor.as(:factor)) >> operand.as(:operand).maybe)
         end
 

--- a/lib/plurimath/unicode_math/parsing_rules/sub_sup.rb
+++ b/lib/plurimath/unicode_math/parsing_rules/sub_sup.rb
@@ -184,6 +184,7 @@ module Plurimath
             an_math |
             other |
             exp_bracket |
+            wrapper_symbols |
             parsing_text |
             negatable_symbols |
             soperand |

--- a/lib/plurimath/unicode_math/transform.rb
+++ b/lib/plurimath/unicode_math/transform.rb
@@ -82,6 +82,7 @@ module Plurimath
       rule(sup_recursion: simple(:recursion)) { recursion }
       rule(nary_sub_sup: simple(:subsup_exp)) { subsup_exp }
       rule(open_paren: sequence(:open_paren)) { open_paren }
+      rule(subsup_exp: sequence(:subsup_exp)) { Utility.filter_values(subsup_exp) }
 
       rule(diacritics_accents: simple(:accent)) { accent }
       rule(mini_sub_sup: simple(:mini_sub_sup)) { mini_sub_sup }

--- a/spec/plurimath/fixtures/formula_modules/unicode_math_string_values.rb
+++ b/spec/plurimath/fixtures/formula_modules/unicode_math_string_values.rb
@@ -677,4 +677,5 @@ module UnicodeMathStringValues
   EXAMPLE_676 = '∐_(d)▒〖d〗'
   EXAMPLE_677 = '∐_(d d)▒〖d〗'
   EXAMPLE_678 = '∐_(d d)^(d)▒〖d〗'
+  EXAMPLE_679 = '∑_(⥑)^(⥑)▒〖d〗'
 end

--- a/spec/plurimath/fixtures/formula_modules/unicode_math_transform_values.rb
+++ b/spec/plurimath/fixtures/formula_modules/unicode_math_transform_values.rb
@@ -18799,8 +18799,8 @@ module UnicodeMathTransformValues
   EXAMPLE_679 = Plurimath::Math::Formula.new([
     Plurimath::Math::Function::Sum.new(
       Plurimath::Math::Symbols::Leftupdownharpoon.new,
-      Plurimath::Math::Symbols::Symbol.new("d"),
       Plurimath::Math::Symbols::Leftupdownharpoon.new,
+      Plurimath::Math::Symbols::Symbol.new("d"),
     )
   ])
 end

--- a/spec/plurimath/fixtures/formula_modules/unicode_math_transform_values.rb
+++ b/spec/plurimath/fixtures/formula_modules/unicode_math_transform_values.rb
@@ -18796,4 +18796,11 @@ module UnicodeMathTransformValues
       { mask: "13" }
     )
   ])
+  EXAMPLE_679 = Plurimath::Math::Formula.new([
+    Plurimath::Math::Function::Sum.new(
+      Plurimath::Math::Symbols::Leftupdownharpoon.new,
+      Plurimath::Math::Symbols::Symbol.new("d"),
+      Plurimath::Math::Symbols::Leftupdownharpoon.new,
+    )
+  ])
 end

--- a/spec/plurimath/unicode_math/parser_spec.rb
+++ b/spec/plurimath/unicode_math/parser_spec.rb
@@ -28,5 +28,13 @@ RSpec.describe Plurimath::UnicodeMath::Parser do
         expect(formula).to eq(UnicodeMathTransformValues::EXAMPLE_678)
       end
     end
+
+    context "contains n-ary function with compatibility wrapper values #EXAMPLE_679" do
+      let(:string) { '\sum_"P{updownharpoonleftleft}"^"P{updownharpoonleftleft}" d' }
+
+      it "matches formula structure of UnicodeMath" do
+        expect(formula).to eq(UnicodeMathTransformValues::EXAMPLE_679)
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR updates **UnicodeMath** parsing rules to parse wrapper symbol only string and a string containing wrapper symbols in a complex equation.
