### PR TITLE
Unitsml semantics in MathML output

### DIFF
--- a/lib/plurimath/unitsml.rb
+++ b/lib/plurimath/unitsml.rb
@@ -11,9 +11,11 @@ module Plurimath
     end
 
     def to_formula
-      formula = ::Unitsml.parse(text).to_plurimath
+      unitsml = ::Unitsml.parse(text)
+      formula = unitsml.to_plurimath
       formula.unitsml = true
       formula.input_string = text
+      formula.unitsml_xml = unitsml.to_xml
       formula
     end
 

--- a/spec/plurimath/math/formula/unitsml_spec.rb
+++ b/spec/plurimath/math/formula/unitsml_spec.rb
@@ -1,0 +1,107 @@
+require 'spec_helper'
+
+RSpec.describe Plurimath::Math::Formula do
+  describe ".to_mathml(unitsml_xml: true)" do
+    let(:mathml) { described_class.new(exp).to_mathml(unitsml_xml: unitsml_xml) }
+
+    context "contains mathml with unitsml semantics" do
+      let(:unitsml_xml) { true }
+      let(:exp) do
+        Plurimath::Math::Formula.new([
+          Plurimath::Math::Number.new("9"),
+          Plurimath::Unitsml.new("C^3*A").to_formula,
+        ])
+      end
+
+      it 'matches instance of Unitsml and input text' do
+        expected_value = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mrow>
+                <mn>9</mn>
+                <mo rspace="thickmathspace">&#x2062;</mo>
+                <mrow xref="U_C3.A">
+                  <msup>
+                    <mstyle mathvariant="normal">
+                      <mi>C</mi>
+                    </mstyle>
+                    <mn>3</mn>
+                  </msup>
+                  <mo>&#x22c5;</mo>
+                  <mstyle mathvariant="normal">
+                    <mi>A</mi>
+                  </mstyle>
+                  <Unit xmlns="https://schema.unitsml.org/unitsml/1.0" id="U_C3.A" dimensionURL="#D_M3I4">
+                    <UnitSystem name="SI" type="SI_derived" lang="en-US"/>
+                    <UnitName lang="en">C^3*A</UnitName>
+                    <UnitSymbol type="HTML">C
+                      <sup>3</sup>⋅A</UnitSymbol>
+                    <UnitSymbol type="MathMl">
+                      <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+                        <msup>
+                          <mrow>
+                            <mi mathvariant="normal">C</mi>
+                          </mrow>
+                          <mrow>
+                            <mn>3</mn>
+                          </mrow>
+                        </msup>
+                        <mo>⋅</mo>
+                        <mi mathvariant="normal">A</mi>
+                      </math>
+                    </UnitSymbol>
+                    <RootUnits>
+                      <EnumeratedRootUnit unit="coulomb" powerNumerator="3"/>
+                      <EnumeratedRootUnit unit="ampere"/>
+                    </RootUnits>
+                  </Unit>
+                  <Dimension xmlns="https://schema.unitsml.org/unitsml/1.0" id="D_M3I4">
+                    <Mass symbol="M" powerNumerator="3"/>
+                    <ElectricCurrent symbol="I" powerNumerator="4"/>
+                  </Dimension>
+                </mrow>
+              </mrow>
+            </mstyle>
+          </math>
+        MATHML
+        expect(mathml).to eql(expected_value)
+      end
+    end
+
+    context "contains mathml without unitsml semantics" do
+      let(:exp) do
+        Plurimath::Math::Formula.new([
+          Plurimath::Math::Number.new("9"),
+          Plurimath::Unitsml.new("C^3*A").to_formula,
+        ])
+      end
+      let(:unitsml_xml) { false }
+
+      it 'matches instance of Unitsml and input text' do
+        expected_value = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mrow>
+                <mn>9</mn>
+                <mo rspace="thickmathspace">&#x2062;</mo>
+                <mrow>
+                  <msup>
+                    <mstyle mathvariant="normal">
+                      <mi>C</mi>
+                    </mstyle>
+                    <mn>3</mn>
+                  </msup>
+                  <mo>&#x22c5;</mo>
+                  <mstyle mathvariant="normal">
+                    <mi>A</mi>
+                  </mstyle>
+                </mrow>
+              </mrow>
+            </mstyle>
+          </math>
+        MATHML
+        expect(mathml).to eql(expected_value)
+      end
+    end
+  end
+end

--- a/spec/plurimath/math/formula/unitsml_spec.rb
+++ b/spec/plurimath/math/formula/unitsml_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Plurimath::Math::Formula do
-  describe ".to_mathml(unitsml_xml: true)" do
+  describe ".to_mathml(unitsml_xml: boolean)" do
     let(:mathml) { described_class.new(exp).to_mathml(unitsml_xml: unitsml_xml) }
 
     context "contains mathml with unitsml semantics" do
@@ -67,15 +67,123 @@ RSpec.describe Plurimath::Math::Formula do
         expect(mathml).to eql(expected_value)
       end
     end
+    context "contains mathml with unitsml semantics" do
+      let(:unitsml_xml) { true }
+      let(:exp) do
+        Plurimath::Math::Formula.new([
+          Plurimath::Math::Number.new("9"),
+          Plurimath::Unitsml.new("C^3*A").to_formula,
+          Plurimath::Math::Number.new("9"),
+          Plurimath::Unitsml.new("C^2*m").to_formula,
+        ])
+      end
+
+      it 'matches instance of Unitsml and input text' do
+        expected_value = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mrow>
+                <mn>9</mn>
+                <mo rspace="thickmathspace">&#x2062;</mo>
+                <mrow xref="U_C3.A">
+                  <msup>
+                    <mstyle mathvariant="normal">
+                      <mi>C</mi>
+                    </mstyle>
+                    <mn>3</mn>
+                  </msup>
+                  <mo>&#x22c5;</mo>
+                  <mstyle mathvariant="normal">
+                    <mi>A</mi>
+                  </mstyle>
+                  <Unit xmlns="https://schema.unitsml.org/unitsml/1.0" id="U_C3.A" dimensionURL="#D_M3I4">
+                    <UnitSystem name="SI" type="SI_derived" lang="en-US"/>
+                    <UnitName lang="en">C^3*A</UnitName>
+                    <UnitSymbol type="HTML">C
+                      <sup>3</sup>⋅A</UnitSymbol>
+                    <UnitSymbol type="MathMl">
+                      <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+                        <msup>
+                          <mrow>
+                            <mi mathvariant="normal">C</mi>
+                          </mrow>
+                          <mrow>
+                            <mn>3</mn>
+                          </mrow>
+                        </msup>
+                        <mo>⋅</mo>
+                        <mi mathvariant="normal">A</mi>
+                      </math>
+                    </UnitSymbol>
+                    <RootUnits>
+                      <EnumeratedRootUnit unit="coulomb" powerNumerator="3"/>
+                      <EnumeratedRootUnit unit="ampere"/>
+                    </RootUnits>
+                  </Unit>
+                  <Dimension xmlns="https://schema.unitsml.org/unitsml/1.0" id="D_M3I4">
+                    <Mass symbol="M" powerNumerator="3"/>
+                    <ElectricCurrent symbol="I" powerNumerator="4"/>
+                  </Dimension>
+                </mrow>
+                <mo rspace="thickmathspace">&#x2062;</mo>
+                <mn>9</mn>
+                <mrow xref="U_C2.m">
+                  <msup>
+                    <mstyle mathvariant="normal">
+                      <mi>C</mi>
+                    </mstyle>
+                    <mn>2</mn>
+                  </msup>
+                  <mo>&#x22c5;</mo>
+                  <mstyle mathvariant="normal">
+                    <mi>m</mi>
+                  </mstyle>
+                  <Unit xmlns="https://schema.unitsml.org/unitsml/1.0" id="U_C2.m" dimensionURL="#D_LM2I2">
+                    <UnitSystem name="SI" type="SI_derived" lang="en-US"/>
+                    <UnitName lang="en">C^2*m</UnitName>
+                    <UnitSymbol type="HTML">C
+                      <sup>2</sup>⋅m</UnitSymbol>
+                    <UnitSymbol type="MathMl">
+                      <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+                        <msup>
+                          <mrow>
+                            <mi mathvariant="normal">C</mi>
+                          </mrow>
+                          <mrow>
+                            <mn>2</mn>
+                          </mrow>
+                        </msup>
+                        <mo>⋅</mo>
+                        <mi mathvariant="normal">m</mi>
+                      </math>
+                    </UnitSymbol>
+                    <RootUnits>
+                      <EnumeratedRootUnit unit="coulomb" powerNumerator="2"/>
+                      <EnumeratedRootUnit unit="meter"/>
+                    </RootUnits>
+                  </Unit>
+                  <Dimension xmlns="https://schema.unitsml.org/unitsml/1.0" id="D_LM2I2">
+                    <Length symbol="L" powerNumerator="1"/>
+                    <Mass symbol="M" powerNumerator="2"/>
+                    <ElectricCurrent symbol="I" powerNumerator="2"/>
+                  </Dimension>
+                </mrow>
+              </mrow>
+            </mstyle>
+          </math>
+        MATHML
+        expect(mathml).to eql(expected_value)
+      end
+    end
 
     context "contains mathml without unitsml semantics" do
+      let(:unitsml_xml) { false }
       let(:exp) do
         Plurimath::Math::Formula.new([
           Plurimath::Math::Number.new("9"),
           Plurimath::Unitsml.new("C^3*A").to_formula,
         ])
       end
-      let(:unitsml_xml) { false }
 
       it 'matches instance of Unitsml and input text' do
         expected_value = <<~MATHML


### PR DESCRIPTION
This PR introduces a new boolean argument called `unitsml_xml` in the `to_mathml` method for **MathML** conversion. This argument provides optional support for **UnitsML** in the **MathML** conversion.

closes #297 