### PR TITLE
`mgt` and `mlt` support in AsciiMath

### DIFF
--- a/lib/plurimath/math/symbols/gg.rb
+++ b/lib/plurimath/math/symbols/gg.rb
@@ -3,10 +3,10 @@ module Plurimath
     module Symbols
       class Gg < Symbol
         INPUT = {
-          unicodemath: [["gg", "&#x226b;"]],
-          asciimath: [["&#x226b;"], parsing_wrapper(["gg"], lang: :asciimath)],
+          unicodemath: ["gg", "&#x226b;", parsing_wrapper(["mtg"], lang: :unicodemath)],
+          asciimath: ["&#x226b;", "gg", "mtg"],
           mathml: ["&#x226b;"],
-          latex: [["gg", "&#x226b;"]],
+          latex: ["gg", "&#x226b;", parsing_wrapper(["mtg"], lang: :latex)],
           omml: ["&#x226b;"],
           html: ["&#x226b;"],
         }.freeze
@@ -17,7 +17,7 @@ module Plurimath
         end
 
         def to_asciimath(**)
-          parsing_wrapper("gg", lang: :asciimath)
+          "gg"
         end
 
         def to_unicodemath(**)

--- a/lib/plurimath/math/symbols/gg.rb
+++ b/lib/plurimath/math/symbols/gg.rb
@@ -3,10 +3,10 @@ module Plurimath
     module Symbols
       class Gg < Symbol
         INPUT = {
-          unicodemath: ["gg", "&#x226b;", parsing_wrapper(["mtg"], lang: :unicode)],
-          asciimath: ["&#x226b;", "gg", "mtg"],
+          unicodemath: ["gg", "&#x226b;", parsing_wrapper(["mgt"], lang: :unicode)],
+          asciimath: ["&#x226b;", "gg", "mgt"],
           mathml: ["&#x226b;"],
-          latex: ["gg", "&#x226b;", parsing_wrapper(["mtg"], lang: :latex)],
+          latex: ["gg", "&#x226b;", parsing_wrapper(["mgt"], lang: :latex)],
           omml: ["&#x226b;"],
           html: ["&#x226b;"],
         }.freeze

--- a/lib/plurimath/math/symbols/gg.rb
+++ b/lib/plurimath/math/symbols/gg.rb
@@ -3,7 +3,7 @@ module Plurimath
     module Symbols
       class Gg < Symbol
         INPUT = {
-          unicodemath: ["gg", "&#x226b;", parsing_wrapper(["mtg"], lang: :unicodemath)],
+          unicodemath: ["gg", "&#x226b;", parsing_wrapper(["mtg"], lang: :unicode)],
           asciimath: ["&#x226b;", "gg", "mtg"],
           mathml: ["&#x226b;"],
           latex: ["gg", "&#x226b;", parsing_wrapper(["mtg"], lang: :latex)],

--- a/lib/plurimath/math/symbols/ll.rb
+++ b/lib/plurimath/math/symbols/ll.rb
@@ -3,10 +3,10 @@ module Plurimath
     module Symbols
       class Ll < Symbol
         INPUT = {
-          unicodemath: [["ll", "&#x226a;"]],
-          asciimath: [["&#x226a;"], parsing_wrapper(["ll"], lang: :asciimath)],
+          unicodemath: ["ll", "&#x226a;", parsing_wrapper(["mlt"], lang: :unicodemath)],
+          asciimath: ["&#x226a;", "ll", "mlt"],
           mathml: ["&#x226a;"],
-          latex: [["ll", "&#x226a;"]],
+          latex: ["ll", "&#x226a;", parsing_wrapper(["mlt"], lang: :latex)],
           omml: ["&#x226a;"],
           html: ["&#x226a;"],
         }.freeze
@@ -17,7 +17,7 @@ module Plurimath
         end
 
         def to_asciimath(**)
-          parsing_wrapper("ll", lang: :asciimath)
+          "ll"
         end
 
         def to_unicodemath(**)

--- a/lib/plurimath/math/symbols/ll.rb
+++ b/lib/plurimath/math/symbols/ll.rb
@@ -3,7 +3,7 @@ module Plurimath
     module Symbols
       class Ll < Symbol
         INPUT = {
-          unicodemath: ["ll", "&#x226a;", parsing_wrapper(["mlt"], lang: :unicodemath)],
+          unicodemath: ["ll", "&#x226a;", parsing_wrapper(["mlt"], lang: :unicode)],
           asciimath: ["&#x226a;", "ll", "mlt"],
           mathml: ["&#x226a;"],
           latex: ["ll", "&#x226a;", parsing_wrapper(["mlt"], lang: :latex)],

--- a/spec/plurimath/asciimath/asciidoctor_examples_spec.rb
+++ b/spec/plurimath/asciimath/asciidoctor_examples_spec.rb
@@ -1559,11 +1559,9 @@ RSpec.describe Plurimath::Asciimath::Parser do
         expected_value = Plurimath::Math::Formula.new([
           Plurimath::Math::Symbols::Sptilde.new,
           Plurimath::Math::Symbols::Symbol.new("a"),
-          Plurimath::Math::Symbols::Symbol.new("m"),
-          Plurimath::Math::Symbols::Less.new,
+          Plurimath::Math::Symbols::Ll.new,
           Plurimath::Math::Symbols::Symbol.new("b"),
-          Plurimath::Math::Symbols::Symbol.new("m"),
-          Plurimath::Math::Symbols::Greater.new,
+          Plurimath::Math::Symbols::Gg.new,
           Plurimath::Math::Symbols::Minus.new,
           Plurimath::Math::Symbols::Plus.new,
           Plurimath::Math::Symbols::Symbol.new("c")

--- a/spec/plurimath/asciimath_spec.rb
+++ b/spec/plurimath/asciimath_spec.rb
@@ -6435,7 +6435,7 @@ RSpec.describe Plurimath::Asciimath do
     end
 
     context "contains much less and greater than request example from plrimath/issue#308 example #121" do
-      let(:string) { 'll or mlt & gg or mtg' }
+      let(:string) { 'll or mlt & gg or mgt' }
 
       it 'matches LaTeX, AsciiMath, and MathML' do
         latex = "\\ll o r \\ll \\& \\gg o r \\gg"

--- a/spec/plurimath/asciimath_spec.rb
+++ b/spec/plurimath/asciimath_spec.rb
@@ -6433,6 +6433,33 @@ RSpec.describe Plurimath::Asciimath do
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
+
+    context "contains much less and greater than request example from plrimath/issue#308 example #121" do
+      let(:string) { 'll or mlt & gg or mtg' }
+
+      it 'matches LaTeX, AsciiMath, and MathML' do
+        latex = "\\ll o r \\ll \\& \\gg o r \\gg"
+        asciimath = "ll o r ll & gg o r gg"
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mi>&#x226a;</mi>
+              <mi>o</mi>
+              <mi>r</mi>
+              <mi>&#x226a;</mi>
+              <mo>&</mo>
+              <mi>&#x226b;</mi>
+              <mi>o</mi>
+              <mi>r</mi>
+              <mi>&#x226b;</mi>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
+      end
+    end
   end
 
   describe ".to_omml" do

--- a/spec/plurimath/math/symbols/gg_spec.rb
+++ b/spec/plurimath/math/symbols/gg_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Plurimath::Math::Symbols::Gg do
 
     context "Matches all conversion for the Symbol Plurimath::Math::Symbols::Gg" do
       it "matches AsciiMath string" do
-        expect(klass.to_asciimath).to eq("\"P{gg}\"")
+        expect(klass.to_asciimath).to eq("gg")
       end
 
       it "matches LaTeX string" do

--- a/spec/plurimath/math/symbols/ll_spec.rb
+++ b/spec/plurimath/math/symbols/ll_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Plurimath::Math::Symbols::Ll do
 
     context "Matches all conversion for the Symbol Plurimath::Math::Symbols::Ll" do
       it "matches AsciiMath string" do
-        expect(klass.to_asciimath).to eq("\"P{ll}\"")
+        expect(klass.to_asciimath).to eq("ll")
       end
 
       it "matches LaTeX string" do


### PR DESCRIPTION
This PR supports the **much greater than** and **much less than** signs **AsciiMath** parsing and conversion.

closes #308 