### PR TITLE
Added `type_error` method in Formula

### DIFF
--- a/lib/plurimath/math/formula.rb
+++ b/lib/plurimath/math/formula.rb
@@ -172,7 +172,7 @@ module Plurimath
 
       def to_display(type = nil, formatter: nil)
         options = { formatter: formatter }
-        return type_error! unless MATH_ZONE_TYPES.include?(type.downcase.to_sym)
+        return type_error!(type) unless MATH_ZONE_TYPES.include?(type.downcase.to_sym)
 
         math_zone = case type
                     when :asciimath
@@ -997,9 +997,9 @@ module Plurimath
       end
       # Dd derivative nodes end
 
-      def type_error!
+      def type_error!(type)
         raise Math::InvalidTypeError.new(
-          "`type` must be one of: `#{MATH_ZONE_TYPES.join('`, `')}`",
+          "Invalid type provided: #{type}. Must be one of #{MATH_ZONE_TYPES.join(', ')}.",
         )
       end
     end

--- a/lib/plurimath/math/formula.rb
+++ b/lib/plurimath/math/formula.rb
@@ -996,6 +996,12 @@ module Plurimath
         encode(str)
       end
       # Dd derivative nodes end
+
+      def type_error!
+        raise Math::InvalidTypeError.new(
+          "`type` must be one of: `#{MATH_ZONE_TYPES.join('`, `')}`",
+        )
+      end
     end
   end
 end

--- a/spec/plurimath/math/formula_spec.rb
+++ b/spec/plurimath/math/formula_spec.rb
@@ -23,6 +23,19 @@ RSpec.describe Plurimath::Math::Formula do
     end
   end
 
+  describe ".type_error!" do
+    subject(:formula) { Plurimath::Math.parse(string, :asciimath) }
+
+    context "raises invalid type error when to_display is called with unsupported type plurimath#310" do
+      let(:string) { "theta" }
+
+      it "raises an error" do
+        expect { formula.to_display(:formula) }.to raise_error(Plurimath::Math::InvalidTypeError)
+      end
+    end
+  end
+
+
   describe ".==" do
     subject(:formula) { described_class.new(exp) }
 


### PR DESCRIPTION
This PR updates the error message for the un-supported `to_display` type.

closes #310 