### PR TITLE
`thickmathspace` before every `unitsml`

### DIFF
--- a/spec/plurimath/asciimath_spec.rb
+++ b/spec/plurimath/asciimath_spec.rb
@@ -3948,6 +3948,7 @@ RSpec.describe Plurimath::Asciimath do
                 <mtext>X</mtext>
                 <mo>)</mo>
               </mrow>
+              <mo rspace="thickmathspace">&#x2062;</mo>
               <mrow>
                 <mstyle mathvariant="normal">
                   <mi>g</mi>
@@ -5467,7 +5468,7 @@ RSpec.describe Plurimath::Asciimath do
               </mrow>
               <mo>+</mo>
               <mn>1</mn>
-              <mo>&#x2062;</mo>
+              <mo rspace="thickmathspace">&#x2062;</mo>
               <mrow>
                 <mstyle mathvariant="normal">
                   <mo>&#x2032;</mo>
@@ -5524,6 +5525,7 @@ RSpec.describe Plurimath::Asciimath do
                 </mstyle>
               </mrow>
               <mo>&#x22c5;</mo>
+              <mo rspace="thickmathspace">&#x2062;</mo>
               <mrow>
                 <mstyle mathvariant="normal">
                   <mi>m</mi>
@@ -5608,10 +5610,12 @@ RSpec.describe Plurimath::Asciimath do
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
             <mstyle displaystyle="true">
+              <mo rspace="thickmathspace">&#x2062;</mo>
               <mrow>
                 <mi>u</mi>
               </mrow>
               <mo>+</mo>
+              <mo rspace="thickmathspace">&#x2062;</mo>
               <mrow>
                 <mstyle mathvariant="normal">
                   <mi>&#xb5;m</mi>
@@ -5661,7 +5665,7 @@ RSpec.describe Plurimath::Asciimath do
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
             <mstyle displaystyle="true">
               <mn>1</mn>
-              <mo>&#x2062;</mo>
+              <mo rspace="thickmathspace">&#x2062;</mo>
               <mrow>
                 <mstyle mathvariant="normal">
                   <mi>&#xb0;</mi>

--- a/spec/plurimath/math/formula/unitsml_spec.rb
+++ b/spec/plurimath/math/formula/unitsml_spec.rb
@@ -125,8 +125,8 @@ RSpec.describe Plurimath::Math::Formula do
                     <ElectricCurrent symbol="I" powerNumerator="4"/>
                   </Dimension>
                 </mrow>
-                <mo rspace="thickmathspace">&#x2062;</mo>
                 <mn>9</mn>
+                <mo rspace="thickmathspace">&#x2062;</mo>
                 <mrow xref="U_C2.m">
                   <msup>
                     <mstyle mathvariant="normal">


### PR DESCRIPTION
This PR inserts `thickmathspace` before each unitsml example.

closes #314 