### PR TITLE
empty `mo` tag to OMML conversion

### DIFF
--- a/lib/plurimath/math/symbols/symbol.rb
+++ b/lib/plurimath/math/symbols/symbol.rb
@@ -108,7 +108,10 @@ module Plurimath
         end
 
         def t_tag(options:)
-          Utility.ox_element("t", namespace: "m") << (value || to_omml_without_math_tag(nil, options: options))
+          output = value || to_omml_without_math_tag(nil, options: options)
+          return t_element unless output
+
+          t_element << output
         end
 
         def separate_table
@@ -157,6 +160,10 @@ module Plurimath
         end
 
         private
+
+        def t_element
+          Utility.ox_element("t", namespace: "m")
+        end
 
         def explicit_checks(unicode)
           return true if [unicode, value].any? { |v| ["∣", "|"].include?(v) }

--- a/spec/plurimath/mathml_spec.rb
+++ b/spec/plurimath/mathml_spec.rb
@@ -3421,34 +3421,70 @@ RSpec.describe Plurimath::Mathml do
         omml = <<~OMML
           <m:oMathPara xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:mo="http://schemas.microsoft.com/office/mac/office/2008/main" xmlns:mv="urn:schemas-microsoft-com:mac:vml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w10="urn:schemas-microsoft-com:office:word" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml" xmlns:wne="http://schemas.microsoft.com/office/word/2006/wordml" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns:wp14="http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing" xmlns:wpc="http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas" xmlns:wpg="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup" xmlns:wpi="http://schemas.microsoft.com/office/word/2010/wordprocessingInk" xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape">
             <m:oMath>
-              <m:nary>
-                <m:naryPr>
-                  <m:chr m:val="∭"/>
-                  <m:limLoc m:val="undOvr"/>
-                  <m:supHide m:val="1"/>
+              <m:sSub>
+                <m:sSubPr>
                   <m:ctrlPr>
                     <w:rPr>
                       <w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/>
                       <w:i/>
                     </w:rPr>
                   </m:ctrlPr>
-                </m:naryPr>
-                <m:sub>
-                  <m:r>
-                    <m:t>F</m:t>
-                  </m:r>
-                </m:sub>
-                <m:sup>
-                  <m:r>
-                    <m:t>&#8203;</m:t>
-                  </m:r>
-                </m:sup>
+                </m:sSubPr>
                 <m:e>
                   <m:r>
-                    <m:t>C</m:t>
+                    <m:t>y</m:t>
                   </m:r>
                 </m:e>
-              </m:nary>
+                <m:sub>
+                  <m:r>
+                    <m:t>k</m:t>
+                  </m:r>
+                </m:sub>
+              </m:sSub>
+              <m:r>
+                <m:t>=</m:t>
+              </m:r>
+              <m:d>
+                <m:dPr>
+                  <m:begChr m:val="("/>
+                  <m:sepChr m:val=""/>
+                  <m:endChr m:val=")"/>
+                </m:dPr>
+                <m:e>
+                  <m:sSub>
+                    <m:sSubPr>
+                      <m:ctrlPr>
+                        <w:rPr>
+                          <w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/>
+                          <w:i/>
+                        </w:rPr>
+                      </m:ctrlPr>
+                    </m:sSubPr>
+                    <m:e>
+                      <m:r>
+                        <m:t>x</m:t>
+                      </m:r>
+                    </m:e>
+                    <m:sub>
+                      <m:r>
+                        <m:t>k</m:t>
+                      </m:r>
+                    </m:sub>
+                  </m:sSub>
+                  <m:r>
+                    <m:t>&#xb1;</m:t>
+                  </m:r>
+                  <m:r>
+                    <m:t>h</m:t>
+                  </m:r>
+                </m:e>
+              </m:d>
+              <m:r>
+                <m:t/>
+              </m:r>
+              <m:r>
+                <m:t>m</m:t>
+              </m:r>
             </m:oMath>
           </m:oMathPara>
         OMML

--- a/spec/plurimath/mathml_spec.rb
+++ b/spec/plurimath/mathml_spec.rb
@@ -3385,6 +3385,76 @@ RSpec.describe Plurimath::Mathml do
         expect(formula).to eq(omml)
       end
     end
+
+    context "contains empty mo example from plurimath/plurimath#318 Mathml" do
+      let(:string)  do
+        <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <mstyle displaystyle="true">
+              <msub>
+                <mi>y</mi>
+                <mi>k</mi>
+              </msub>
+              <mrow>
+                <mo>=</mo>
+              </mrow>
+              <mrow>
+                <mo>(</mo>
+                <msub>
+                  <mi>x</mi>
+                  <mi>k</mi>
+                </msub>
+                <mrow>
+                  <mo>&#xB1;</mo>
+                </mrow>
+                <mi>h</mi>
+                <mo>)</mo>
+              </mrow>
+              <mo/>
+              <mi>m</mi>
+            </mstyle>
+          </math>
+        MATHML
+      end
+
+      it 'compares OMML string' do
+        omml = <<~OMML
+          <m:oMathPara xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:mo="http://schemas.microsoft.com/office/mac/office/2008/main" xmlns:mv="urn:schemas-microsoft-com:mac:vml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w10="urn:schemas-microsoft-com:office:word" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml" xmlns:wne="http://schemas.microsoft.com/office/word/2006/wordml" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns:wp14="http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing" xmlns:wpc="http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas" xmlns:wpg="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup" xmlns:wpi="http://schemas.microsoft.com/office/word/2010/wordprocessingInk" xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape">
+            <m:oMath>
+              <m:nary>
+                <m:naryPr>
+                  <m:chr m:val="∭"/>
+                  <m:limLoc m:val="undOvr"/>
+                  <m:supHide m:val="1"/>
+                  <m:ctrlPr>
+                    <w:rPr>
+                      <w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/>
+                      <w:i/>
+                    </w:rPr>
+                  </m:ctrlPr>
+                </m:naryPr>
+                <m:sub>
+                  <m:r>
+                    <m:t>F</m:t>
+                  </m:r>
+                </m:sub>
+                <m:sup>
+                  <m:r>
+                    <m:t>&#8203;</m:t>
+                  </m:r>
+                </m:sup>
+                <m:e>
+                  <m:r>
+                    <m:t>C</m:t>
+                  </m:r>
+                </m:e>
+              </m:nary>
+            </m:oMath>
+          </m:oMathPara>
+        OMML
+        expect(formula).to eq(omml)
+      end
+    end
   end
 
   describe ".to_html" do


### PR DESCRIPTION
This PR fixes the empty `mo` tag to **OMML** conversion.

close #318 