### PR TITLE
MathML parsing using Oga

### DIFF
--- a/lib/plurimath/math/function/msgroup.rb
+++ b/lib/plurimath/math/function/msgroup.rb
@@ -97,8 +97,6 @@ module Plurimath
             value.none? { |element| element.match?(/[\S]/) }
           when NilClass
             true
-          else
-            false
           end
         end
       end

--- a/lib/plurimath/math/function/msgroup.rb
+++ b/lib/plurimath/math/function/msgroup.rb
@@ -78,12 +78,27 @@ module Plurimath
         def msgroup_text; end
 
         def msgroup_text=(value)
-          return unless value
+          return if empty_value?(value)
 
-          if value.is_a?(Array) && value.none? { |element| element.match?(/[^\s]/) }
+          if value.is_a?(Array)
             @temp_mathml_order << Text.new(value.pop)
           else
             @temp_mathml_order << Text.new(value)
+          end
+        end
+
+        private
+
+        def empty_value?(value)
+          case value
+          when String
+            value.strip.empty?
+          when Array
+            value.none? { |element| element.match?(/[\S]/) }
+          when NilClass
+            true
+          else
+            false
           end
         end
       end

--- a/spec/plurimath/omml_spec.rb
+++ b/spec/plurimath/omml_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Plurimath::Omml do
       end
 
       it 'converts `alpha`, `α` to `&#x3b1;`' do
-        skip "Lutaml::Model::XmlAdapter::Oga doesn't support HTML Entities yet!" if Lutaml::Model::Config.xml_adapter.type == "oga"
+        skip "Lutaml::Model::XmlAdapter::Oga doesn't support HTML Entities yet!" if Lutaml::Model::Config.xml_adapter == Lutaml::Model::XmlAdapter::OgaAdapter
         formula = Plurimath::Math.parse(input, :mathml)
         expect(formula.to_omml).to eq(expected_output)
       end
@@ -373,7 +373,7 @@ RSpec.describe Plurimath::Omml do
       end
 
       it 'converts `alpha`, `α` to `&#x3b1;`' do
-        skip "Lutaml::Model::XmlAdapter::Oga doesn't support HTML Entities yet!" if Lutaml::Model::Config.xml_adapter.type == "oga"
+        skip "Lutaml::Model::XmlAdapter::Oga doesn't support HTML Entities yet!" if Lutaml::Model::Config.xml_adapter == Lutaml::Model::XmlAdapter::OgaAdapter
         formula = Plurimath::Math.parse(input, :mathml)
         expect(formula.to_omml).to eq(expected_output)
       end

--- a/spec/plurimath/omml_spec.rb
+++ b/spec/plurimath/omml_spec.rb
@@ -112,6 +112,7 @@ RSpec.describe Plurimath::Omml do
       end
 
       it 'converts `alpha`, `α` to `&#x3b1;`' do
+        skip "Lutaml::Model::XmlAdapter::Oga doesn't support HTML Entities yet!" if Lutaml::Model::Config.xml_adapter.type == "oga"
         formula = Plurimath::Math.parse(input, :mathml)
         expect(formula.to_omml).to eq(expected_output)
       end
@@ -372,6 +373,7 @@ RSpec.describe Plurimath::Omml do
       end
 
       it 'converts `alpha`, `α` to `&#x3b1;`' do
+        skip "Lutaml::Model::XmlAdapter::Oga doesn't support HTML Entities yet!" if Lutaml::Model::Config.xml_adapter.type == "oga"
         formula = Plurimath::Math.parse(input, :mathml)
         expect(formula.to_omml).to eq(expected_output)
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,10 +23,12 @@ RSpec.configure do |config|
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
 
-  config.around(:all) do |example|
+  config.around(:each) do |example|
     Plurimath.xml_engine = Plurimath::XmlEngine::Ox
+    Mml::Configuration.adapter = :ox
     example.run
     Plurimath.xml_engine = Plurimath::XmlEngine::Oga
+    Mml::Configuration.adapter = :oga
     example.run
   end
 


### PR DESCRIPTION
This PR updates **MathML** parsing methods and specs for **Oga** adapter support.

related to plurimath/plurimath-js#28