### PR TITLE
OMML `overline` and `comment` parsing error

### DIFF
--- a/lib/plurimath/math/function/bar.rb
+++ b/lib/plurimath/math/function/bar.rb
@@ -93,6 +93,8 @@ module Plurimath
           Utility.update_nodes(barpr, [pos, ctrlp])
         end
       end
+
+      Overline = Bar
     end
   end
 end

--- a/lib/plurimath/mathml/constants.rb
+++ b/lib/plurimath/mathml/constants.rb
@@ -176,6 +176,7 @@ module Plurimath
         mathfrak
         underset
         stackrel
+        overline
         overset
         mathcal
         arccos

--- a/lib/plurimath/omml/parser.rb
+++ b/lib/plurimath/omml/parser.rb
@@ -45,7 +45,7 @@ module Plurimath
       end
 
       def parse_nodes(nodes)
-        nodes.delete_if { |node| node.is_xml_comment? if node.respond_to?(:is_xml_comment?)}
+        nodes.delete_if { |node| node.is_xml_comment? if node.respond_to?(:is_xml_comment?) }
 
         nodes.map do |node|
           if node.is_a?(String)

--- a/lib/plurimath/omml/parser.rb
+++ b/lib/plurimath/omml/parser.rb
@@ -45,6 +45,8 @@ module Plurimath
       end
 
       def parse_nodes(nodes)
+        nodes.delete_if { |node| node.is_xml_comment? if node.respond_to?(:is_xml_comment?)}
+
         nodes.map do |node|
           if node.is_a?(String)
             node == "​" ? nil : node

--- a/spec/plurimath/fixtures/formula_modules/expected_values.rb
+++ b/spec/plurimath/fixtures/formula_modules/expected_values.rb
@@ -1015,7 +1015,7 @@ module ExpectedValues
     Plurimath::Math::Function::Underset.new(
       Plurimath::Math::Function::Text.new("over"),
       Plurimath::Math::Function::FontStyle::Normal.new(
-        Plurimath::Math::Symbols::Overline.new,
+        Plurimath::Math::Function::Bar.new,
         "mathrm",
       ),
     )
@@ -1030,7 +1030,7 @@ module ExpectedValues
     Plurimath::Math::Function::Underset.new(
       Plurimath::Math::Function::Text.new("A"),
       Plurimath::Math::Function::FontStyle::Normal.new(
-        Plurimath::Math::Symbols::Overline.new,
+        Plurimath::Math::Function::Bar.new,
         "mathrm",
       ),
     )
@@ -1039,7 +1039,7 @@ module ExpectedValues
     Plurimath::Math::Function::Underset.new(
       Plurimath::Math::Function::Text.new("ABC"),
       Plurimath::Math::Function::FontStyle::Normal.new(
-        Plurimath::Math::Symbols::Overline.new,
+        Plurimath::Math::Function::Bar.new,
         "mathrm",
       ),
     )
@@ -1048,7 +1048,7 @@ module ExpectedValues
     Plurimath::Math::Function::Underset.new(
       Plurimath::Math::Function::Text.new("x⊕y"),
       Plurimath::Math::Function::FontStyle::Normal.new(
-        Plurimath::Math::Symbols::Overline.new,
+        Plurimath::Math::Function::Bar.new,
         "mathrm",
       ),
     )

--- a/spec/plurimath/fixtures/omml/122.omml
+++ b/spec/plurimath/fixtures/omml/122.omml
@@ -19,7 +19,9 @@
           <m:rPr>
             <m:sty m:val="p"/>
           </m:rPr>
-          <m:t>‾</m:t>
+          <m:r>
+            <m:t>&#xaf;</m:t>
+          </m:r>
         </m:r>
       </m:lim>
     </m:limLow>

--- a/spec/plurimath/fixtures/omml/124.omml
+++ b/spec/plurimath/fixtures/omml/124.omml
@@ -19,7 +19,9 @@
           <m:rPr>
             <m:sty m:val="p"/>
           </m:rPr>
-          <m:t>‾</m:t>
+          <m:r>
+            <m:t>&#xaf;</m:t>
+          </m:r>
         </m:r>
       </m:lim>
     </m:limLow>

--- a/spec/plurimath/fixtures/omml/125.omml
+++ b/spec/plurimath/fixtures/omml/125.omml
@@ -19,7 +19,9 @@
           <m:rPr>
             <m:sty m:val="p"/>
           </m:rPr>
-          <m:t>‾</m:t>
+          <m:r>
+            <m:t>&#xaf;</m:t>
+          </m:r>
         </m:r>
       </m:lim>
     </m:limLow>

--- a/spec/plurimath/fixtures/omml/126.omml
+++ b/spec/plurimath/fixtures/omml/126.omml
@@ -19,7 +19,9 @@
           <m:rPr>
             <m:sty m:val="p"/>
           </m:rPr>
-          <m:t>‾</m:t>
+          <m:r>
+            <m:t>&#xaf;</m:t>
+          </m:r>
         </m:r>
       </m:lim>
     </m:limLow>

--- a/spec/plurimath/mathml/v3/section_3_spec.rb
+++ b/spec/plurimath/mathml/v3/section_3_spec.rb
@@ -487,9 +487,8 @@ RSpec.describe Plurimath::Mathml::Parser do
             Plurimath::Math::Symbols::Symbol.new(" a "),
             Plurimath::Math::Symbols::Symbol.new(" b ")
           ),
-          Plurimath::Math::Function::Overset.new(
-            Plurimath::Math::Symbols::Overline.new,
-            Plurimath::Math::Symbols::Paren::Rround.new
+          Plurimath::Math::Function::Bar.new(
+            Plurimath::Math::Symbols::Paren::Rround.new,
           )
         ])
       ])

--- a/spec/plurimath/omml_spec.rb
+++ b/spec/plurimath/omml_spec.rb
@@ -341,6 +341,43 @@ RSpec.describe Plurimath::Omml do
         expect(formula.to_asciimath).to eq(asciimath)
       end
     end
+
+    context "contains comment and overline example #07 from plurimath/plurimath#324" do
+      let(:string) do
+        <<~OMML
+          <m:oMath xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math">
+            <m:acc>
+              <m:accPr>
+                <m:chr m:val="‾"/> <!-- Overline character -->
+              </m:accPr>
+              <m:e>
+                <m:r>
+                  <m:t>AB</m:t>
+                </m:r>
+              </m:e>
+            </m:acc>
+          </m:oMath>
+        OMML
+      end
+
+      it 'returns parsed Asciimath to Formula' do
+        latex = '\overline{\text{AB}}'
+        asciimath = 'bar("AB")'
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mover accent="true">
+                <mtext>AB</mtext>
+                <mo>&#xaf;</mo>
+              </mover>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eq(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eq(asciimath)
+      end
+    end
   end
 
   describe ".to_omml" do


### PR DESCRIPTION
This PR fixes **OMML** parsing error for `overline` and the `comments`.

closes #324 