### PR TITLE
Stripping `invisible times` for OMML conversion

### DIFF
--- a/lib/plurimath/math/symbols/symbol.rb
+++ b/lib/plurimath/math/symbols/symbol.rb
@@ -68,6 +68,8 @@ module Plurimath
         end
 
         def to_omml_without_math_tag(_, **)
+          return if value == "&#x2062;"
+
           value
         end
 
@@ -80,6 +82,8 @@ module Plurimath
         end
 
         def insert_t_tag(_, options:)
+          return if value == "&#x2062;"
+
           [(Utility.ox_element("r", namespace: "m") << t_tag(options: options))]
         end
 

--- a/lib/plurimath/math/symbols/symbol.rb
+++ b/lib/plurimath/math/symbols/symbol.rb
@@ -68,6 +68,7 @@ module Plurimath
         end
 
         def to_omml_without_math_tag(_, **)
+          # TODO: remove this condition once to word rendering issue is resolved, plurimath/plurimath/pull/328
           return if value == "&#x2062;"
 
           value
@@ -82,6 +83,7 @@ module Plurimath
         end
 
         def insert_t_tag(_, options:)
+          # TODO: remove this condition once to word rendering issue is resolved, plurimath/plurimath/pull/328
           return if value == "&#x2062;"
 
           [(Utility.ox_element("r", namespace: "m") << t_tag(options: options))]

--- a/spec/plurimath/fixtures/formula_modules/expected_values.rb
+++ b/spec/plurimath/fixtures/formula_modules/expected_values.rb
@@ -2048,6 +2048,23 @@ module ExpectedValues
       )
     ],
   )
+  EX_188 = Plurimath::Math::Formula.new(
+    [
+      Plurimath::Math::Number.new("12"),
+      Plurimath::Math::Symbols::Symbol.new("&#x2062;"),
+      Plurimath::Math::Function::FontStyle::Normal.new(
+        Plurimath::Math::Symbols::Degree.new,
+        "normal"
+      ),
+      Plurimath::Math::Number.new("28"),
+      Plurimath::Math::Symbols::Symbol.new("&#x2062;"),
+      Plurimath::Math::Function::FontStyle::Normal.new(
+        Plurimath::Math::Symbols::Prime.new,
+        "normal"
+      )
+    ]
+  )
+
   EXIssue158 = Plurimath::Math::Formula.new([
     Plurimath::Math::Function::Text.new("U="),
     Plurimath::Math::Function::Table.new(

--- a/spec/plurimath/fixtures/omml/188.omml
+++ b/spec/plurimath/fixtures/omml/188.omml
@@ -1,0 +1,22 @@
+<m:oMathPara xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:mo="http://schemas.microsoft.com/office/mac/office/2008/main" xmlns:mv="urn:schemas-microsoft-com:mac:vml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w10="urn:schemas-microsoft-com:office:word" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml" xmlns:wne="http://schemas.microsoft.com/office/word/2006/wordml" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns:wp14="http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing" xmlns:wpc="http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas" xmlns:wpg="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup" xmlns:wpi="http://schemas.microsoft.com/office/word/2010/wordprocessingInk" xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape">
+  <m:oMath>
+    <m:r>
+      <m:t>12</m:t>
+    </m:r>
+    <m:r>
+      <m:rPr>
+        <m:sty m:val="p"/>
+      </m:rPr>
+      <m:t>&#xb0;</m:t>
+    </m:r>
+    <m:r>
+      <m:t>28</m:t>
+    </m:r>
+    <m:r>
+      <m:rPr>
+        <m:sty m:val="p"/>
+      </m:rPr>
+      <m:t>&#x2032;</m:t>
+    </m:r>
+  </m:oMath>
+</m:oMathPara>

--- a/spec/plurimath/math/formula/omml_spec.rb
+++ b/spec/plurimath/math/formula/omml_spec.rb
@@ -1845,6 +1845,16 @@ RSpec.describe Plurimath::Math::Formula do
       end
     end
 
+    context "contains #188.omml" do
+      let(:file_name) { "spec/plurimath/fixtures/omml/188.omml" }
+      let(:exp) { ExpectedValues::EX_188 }
+
+      it "matches open and close tag" do
+        expected_value = File.read(file_name)
+        expect(formula).to be_equivalent_to(expected_value)
+      end
+    end
+
     context "contains #issue-158.omml" do
       let(:file_name) { "spec/plurimath/fixtures/omml/issue-158.omml" }
       let(:exp) { ExpectedValues::EXIssue158 }


### PR DESCRIPTION
This PR temporarily skips invisible-times: `&#x2062;` conversion to **OMML**.

closes #312 