### PR TITLE
Updated `mml` configuration and added `display` methods

### DIFF
--- a/lib/plurimath/math/formula.rb
+++ b/lib/plurimath/math/formula.rb
@@ -585,6 +585,16 @@ module Plurimath
         update_temp_order(value, "mglyph")
       end
 
+      def display
+        @display
+      end
+
+      def display=(value)
+        return unless value
+
+        @display = value
+      end
+
       protected
 
       def update_temp_order(value, order_name)

--- a/lib/plurimath/math/formula.rb
+++ b/lib/plurimath/math/formula.rb
@@ -7,7 +7,7 @@ module Plurimath
     class Formula < Core
       include Mathml::Utility
 
-      attr_accessor :value, :left_right_wrapper, :displaystyle, :input_string, :unitsml, :unitsml_xml
+      attr_accessor :value, :left_right_wrapper, :displaystyle, :input_string, :unitsml, :unitsml_xml, :display
 
       MATH_ZONE_TYPES = %i[
         omml
@@ -583,16 +583,6 @@ module Plurimath
 
       def mglyph_value=(value)
         update_temp_order(value, "mglyph")
-      end
-
-      def display
-        @display
-      end
-
-      def display=(value)
-        return unless value
-
-        @display = value
       end
 
       protected

--- a/lib/plurimath/mathml/parser.rb
+++ b/lib/plurimath/mathml/parser.rb
@@ -1,6 +1,46 @@
 # frozen_string_literal: true
 
 require_relative "constants"
+::Mml::Configuration.config = {
+  mmultiscripts: Plurimath::Math::Function::Multiscript,
+  mlabeledtr: Plurimath::Math::Function::Mlabeledtr,
+  munderover: Plurimath::Math::Function::Underover,
+  semantics: Plurimath::Math::Function::Semantics,
+  mscarries: Plurimath::Math::Function::Scarries,
+  mfraction: Plurimath::Math::Function::Frac,
+  menclose: Plurimath::Math::Function::Menclose,
+  mlongdiv: Plurimath::Math::Function::Longdiv,
+  mphantom: Plurimath::Math::Function::Phantom,
+  msubsup: Plurimath::Math::Function::PowerBase,
+  msgroup: Plurimath::Math::Function::Msgroup,
+  mpadded: Plurimath::Math::Function::Mpadded,
+  mfenced: Plurimath::Math::Function::Fenced,
+  mstack: Plurimath::Math::Function::Stackrel,
+  munder: Plurimath::Math::Function::Underset,
+  msline: Plurimath::Math::Function::Msline,
+  merror: Plurimath::Math::Function::Merror,
+  mtable: Plurimath::Math::Function::Table,
+  mstyle: Plurimath::Math::Formula::Mstyle,
+  mglyph: Plurimath::Math::Function::Mglyph,
+  mover: Plurimath::Math::Function::Overset,
+  msqrt: Plurimath::Math::Function::Sqrt,
+  mroot: Plurimath::Math::Function::Root,
+  mtext: Plurimath::Math::Function::Text,
+  mfrac: Plurimath::Math::Function::Frac,
+  msrow: Plurimath::Math::Formula,
+  msup: Plurimath::Math::Function::Power,
+  msub: Plurimath::Math::Function::Base,
+  none: Plurimath::Math::Function::None,
+  mrow: Plurimath::Math::Formula::Mrow,
+  math: Plurimath::Math::Formula,
+  mtd: Plurimath::Math::Function::Td,
+  mtr: Plurimath::Math::Function::Tr,
+  mi: Plurimath::Math::Symbols::Symbol,
+  mo: Plurimath::Math::Symbols::Symbol,
+  ms: Plurimath::Math::Function::Ms,
+  mn: Plurimath::Math::Number,
+}
+require "mml"
 
 module Plurimath
   class Mathml
@@ -8,58 +48,12 @@ module Plurimath
       attr_accessor :text
 
       def initialize(text)
-        mml_config
         @text = text
       end
 
       def parse
         namespace_exist = text.split(">").first.include?(" xmlns=")
         ::Mml.parse(text, namespace_exist: namespace_exist)
-      end
-
-      private
-
-      def mml_config
-        ::Mml::Configuration.config = {
-          mmultiscripts: Plurimath::Math::Function::Multiscript,
-          mlabeledtr: Plurimath::Math::Function::Mlabeledtr,
-          munderover: Plurimath::Math::Function::Underover,
-          semantics: Plurimath::Math::Function::Semantics,
-          mscarries: Plurimath::Math::Function::Scarries,
-          mfraction: Plurimath::Math::Function::Frac,
-          menclose: Plurimath::Math::Function::Menclose,
-          mlongdiv: Plurimath::Math::Function::Longdiv,
-          mphantom: Plurimath::Math::Function::Phantom,
-          msubsup: Plurimath::Math::Function::PowerBase,
-          msgroup: Plurimath::Math::Function::Msgroup,
-          mpadded: Plurimath::Math::Function::Mpadded,
-          mfenced: Plurimath::Math::Function::Fenced,
-          mstack: Plurimath::Math::Function::Stackrel,
-          munder: Plurimath::Math::Function::Underset,
-          msline: Plurimath::Math::Function::Msline,
-          merror: Plurimath::Math::Function::Merror,
-          mtable: Plurimath::Math::Function::Table,
-          mstyle: Plurimath::Math::Formula::Mstyle,
-          mglyph: Plurimath::Math::Function::Mglyph,
-          mover: Plurimath::Math::Function::Overset,
-          msqrt: Plurimath::Math::Function::Sqrt,
-          mroot: Plurimath::Math::Function::Root,
-          mtext: Plurimath::Math::Function::Text,
-          mfrac: Plurimath::Math::Function::Frac,
-          msrow: Plurimath::Math::Formula,
-          msup: Plurimath::Math::Function::Power,
-          msub: Plurimath::Math::Function::Base,
-          none: Plurimath::Math::Function::None,
-          mrow: Plurimath::Math::Formula::Mrow,
-          math: Plurimath::Math::Formula,
-          mtd: Plurimath::Math::Function::Td,
-          mtr: Plurimath::Math::Function::Tr,
-          mi: Plurimath::Math::Symbols::Symbol,
-          mo: Plurimath::Math::Symbols::Symbol,
-          ms: Plurimath::Math::Function::Ms,
-          mn: Plurimath::Math::Number,
-        }
-        require "mml" unless ::Mml.respond_to?(:config)
       end
     end
   end


### PR DESCRIPTION
This PR moves the `Mml` configuration from the method to the file's top level.
Add the `display` attribute's methods (added in `mml`) in `formula.rb`.

related => plurimath/mml#4