### PR TITLE
Unitsml-Ruby added as dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,5 +11,4 @@ gem 'equivalent-xml'
 gem 'opal-rspec', "~> 1.1.0a"
 gem 'oga'
 gem 'ox'
-gem "unitsml"
 gem "debug"

--- a/plurimath.gemspec
+++ b/plurimath.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'mml'
   spec.add_dependency 'thor'
   spec.add_dependency 'parslet'
+  spec.add_dependency 'unitsml'
   spec.add_dependency 'bigdecimal'
   spec.add_dependency 'lutaml-model'
 end


### PR DESCRIPTION
This PR adds the `Unitsml-Ruby` gem as a `dependency` in the `gemspec` file.

closes #335 