### PR TITLE
Updated internal use of `element_order` and Mml configuration

### DIFF
--- a/lib/plurimath/math/formula.rb
+++ b/lib/plurimath/math/formula.rb
@@ -308,7 +308,7 @@ module Plurimath
       end
 
       def element_order=(value)
-        @value = validated_order(value)
+        @value = validated_order(value.map(&:name))
       end
 
       # Attributes start

--- a/lib/plurimath/math/formula/mrow.rb
+++ b/lib/plurimath/math/formula/mrow.rb
@@ -18,7 +18,7 @@ module Plurimath
         end
 
         def element_order=(value)
-          @value = validated_order(value, rejectable_array: ["comment"])
+          @value = validated_order(value&.map(&:name), rejectable_array: ["comment"])
         end
 
         def content; end

--- a/lib/plurimath/math/function/fenced.rb
+++ b/lib/plurimath/math/function/fenced.rb
@@ -186,7 +186,7 @@ module Plurimath
         end
 
         def element_order=(value)
-          @parameter_two = validated_order(value)
+          @parameter_two = validated_order(value&.map(&:name))
         end
 
         def mi_value=(value)

--- a/lib/plurimath/math/function/none.rb
+++ b/lib/plurimath/math/function/none.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 require_relative "unary_function"
+require_relative "../../mathml/utility"
 
 module Plurimath
   module Math
     module Function
       class None < UnaryFunction
+        include Mathml::Utility
+
         def to_asciimath(**); end
 
         def to_latex(**); end

--- a/lib/plurimath/math/function/underset.rb
+++ b/lib/plurimath/math/function/underset.rb
@@ -27,7 +27,7 @@ module Plurimath
 
         def element_order=(value)
           @temp_mathml_order = validated_order(
-            value,
+            value&.map(&:name),
             rejectable_array: ["comment"]
           )
         end

--- a/lib/plurimath/math/symbols/symbol.rb
+++ b/lib/plurimath/math/symbols/symbol.rb
@@ -41,7 +41,7 @@ module Plurimath
         end
 
         def value=(value)
-          @value = value.is_a?(Array) ? value.join : value.to_s
+          @value = value.is_a?(Array) ? value.join : value&.to_s
         end
 
         def to_mathml_without_math_tag(intent, **)

--- a/lib/plurimath/mathml/parser.rb
+++ b/lib/plurimath/mathml/parser.rb
@@ -1,67 +1,67 @@
 # frozen_string_literal: true
 
 require_relative "constants"
+require "mml"
 
 module Plurimath
   class Mathml
     class Parser
+      CONFIGURATION = {
+        Mml::MathWithNilNamespace => Plurimath::Math::Formula,
+        Mml::MathWithNamespace => Plurimath::Math::Formula,
+        Mml::Mmultiscripts => Plurimath::Math::Function::Multiscript,
+        Mml::Mlabeledtr => Plurimath::Math::Function::Mlabeledtr,
+        Mml::Munderover => Plurimath::Math::Function::Underover,
+        Mml::Semantics => Plurimath::Math::Function::Semantics,
+        Mml::Mscarries => Plurimath::Math::Function::Scarries,
+        Mml::Mfraction => Plurimath::Math::Function::Frac,
+        Mml::Menclose => Plurimath::Math::Function::Menclose,
+        Mml::Mlongdiv => Plurimath::Math::Function::Longdiv,
+        Mml::Mphantom => Plurimath::Math::Function::Phantom,
+        Mml::Msubsup => Plurimath::Math::Function::PowerBase,
+        Mml::Msgroup => Plurimath::Math::Function::Msgroup,
+        Mml::Mpadded => Plurimath::Math::Function::Mpadded,
+        Mml::Mfenced => Plurimath::Math::Function::Fenced,
+        Mml::Mstack => Plurimath::Math::Function::Stackrel,
+        Mml::Munder => Plurimath::Math::Function::Underset,
+        Mml::Msline => Plurimath::Math::Function::Msline,
+        Mml::Merror => Plurimath::Math::Function::Merror,
+        Mml::Mtable => Plurimath::Math::Function::Table,
+        Mml::Mstyle => Plurimath::Math::Formula::Mstyle,
+        Mml::Mglyph => Plurimath::Math::Function::Mglyph,
+        Mml::Mover => Plurimath::Math::Function::Overset,
+        Mml::Msqrt => Plurimath::Math::Function::Sqrt,
+        Mml::Mroot => Plurimath::Math::Function::Root,
+        Mml::Mtext => Plurimath::Math::Function::Text,
+        Mml::Mfrac => Plurimath::Math::Function::Frac,
+        Mml::Msrow => Plurimath::Math::Formula,
+        Mml::Msup => Plurimath::Math::Function::Power,
+        Mml::Msub => Plurimath::Math::Function::Base,
+        Mml::None => Plurimath::Math::Function::None,
+        Mml::Mrow => Plurimath::Math::Formula::Mrow,
+        Mml::Mtd => Plurimath::Math::Function::Td,
+        Mml::Mtr => Plurimath::Math::Function::Tr,
+        Mml::Mi => Plurimath::Math::Symbols::Symbol,
+        Mml::Mo => Plurimath::Math::Symbols::Symbol,
+        Mml::Ms => Plurimath::Math::Function::Ms,
+        Mml::Mn => Plurimath::Math::Number,
+      }
       attr_accessor :text
+      @@models_set = false
 
       def initialize(text)
-        mml_config
+        mml_config unless @@models_set
         @text = text
       end
 
       def parse
         namespace_exist = text.split(">").first.include?(" xmlns=")
-        ::Mml.parse(text, namespace_exist: namespace_exist)
+        Mml.parse(text, namespace_exist: namespace_exist)
       end
 
-      private
-
       def mml_config
-        return if ::Mml.respond_to?(:config)
-
-        ::Mml::Configuration.config = {
-          mmultiscripts: Plurimath::Math::Function::Multiscript,
-          mlabeledtr: Plurimath::Math::Function::Mlabeledtr,
-          munderover: Plurimath::Math::Function::Underover,
-          semantics: Plurimath::Math::Function::Semantics,
-          mscarries: Plurimath::Math::Function::Scarries,
-          mfraction: Plurimath::Math::Function::Frac,
-          menclose: Plurimath::Math::Function::Menclose,
-          mlongdiv: Plurimath::Math::Function::Longdiv,
-          mphantom: Plurimath::Math::Function::Phantom,
-          msubsup: Plurimath::Math::Function::PowerBase,
-          msgroup: Plurimath::Math::Function::Msgroup,
-          mpadded: Plurimath::Math::Function::Mpadded,
-          mfenced: Plurimath::Math::Function::Fenced,
-          mstack: Plurimath::Math::Function::Stackrel,
-          munder: Plurimath::Math::Function::Underset,
-          msline: Plurimath::Math::Function::Msline,
-          merror: Plurimath::Math::Function::Merror,
-          mtable: Plurimath::Math::Function::Table,
-          mstyle: Plurimath::Math::Formula::Mstyle,
-          mglyph: Plurimath::Math::Function::Mglyph,
-          mover: Plurimath::Math::Function::Overset,
-          msqrt: Plurimath::Math::Function::Sqrt,
-          mroot: Plurimath::Math::Function::Root,
-          mtext: Plurimath::Math::Function::Text,
-          mfrac: Plurimath::Math::Function::Frac,
-          msrow: Plurimath::Math::Formula,
-          msup: Plurimath::Math::Function::Power,
-          msub: Plurimath::Math::Function::Base,
-          none: Plurimath::Math::Function::None,
-          mrow: Plurimath::Math::Formula::Mrow,
-          math: Plurimath::Math::Formula,
-          mtd: Plurimath::Math::Function::Td,
-          mtr: Plurimath::Math::Function::Tr,
-          mi: Plurimath::Math::Symbols::Symbol,
-          mo: Plurimath::Math::Symbols::Symbol,
-          ms: Plurimath::Math::Function::Ms,
-          mn: Plurimath::Math::Number,
-        }
-        require "mml"
+        Mml::Configuration.set_models(CONFIGURATION)
+        @@models_set = true
       end
     end
   end

--- a/lib/plurimath/mathml/parser.rb
+++ b/lib/plurimath/mathml/parser.rb
@@ -60,7 +60,7 @@ module Plurimath
       end
 
       def mml_config
-        Mml::Configuration.set_models(CONFIGURATION)
+        Mml::Configuration.custom_models = CONFIGURATION
         @@models_set = true
       end
     end

--- a/lib/plurimath/mathml/utility.rb
+++ b/lib/plurimath/mathml/utility.rb
@@ -12,7 +12,7 @@ module Plurimath
       attr_accessor :temp_mathml_order
 
       def element_order=(value)
-        @temp_mathml_order = Array(validated_order(value))
+        @temp_mathml_order = Array(validated_order(value&.map(&:name)))
       end
 
       def clear_temp_order

--- a/lib/plurimath/mathml/utility/formula_transformation.rb
+++ b/lib/plurimath/mathml/utility/formula_transformation.rb
@@ -104,6 +104,8 @@ module Plurimath
           when Array
             array_validations(value)
           when Math::Symbols::Symbol
+            return value if value.value.nil?
+
             mathml_symbol_to_class(value.value)
           when String
             mathml_symbol_to_class(value)

--- a/spec/plurimath/mathml/parser_spec.rb
+++ b/spec/plurimath/mathml/parser_spec.rb
@@ -1466,7 +1466,7 @@ RSpec.describe Plurimath::Mathml::Parser do
                   [
                     Plurimath::Math::Formula.new([
                       Plurimath::Math::Function::Ln.new(
-                        Plurimath::Math::Symbols::Symbol.new(""),
+                        Plurimath::Math::Symbols::Symbol.new,
                       ),
                       Plurimath::Math::Function::Fenced.new(
                         Plurimath::Math::Symbols::Paren::Lround.new,
@@ -1728,7 +1728,7 @@ RSpec.describe Plurimath::Mathml::Parser do
           ),
           Plurimath::Math::Symbols::Symbol.new("t"),
         ),
-        Plurimath::Math::Symbols::Symbol.new(""),
+        Plurimath::Math::Symbols::Symbol.new,
         Plurimath::Math::Function::Fenced.new(
           Plurimath::Math::Symbols::Paren::Lround.new,
           [

--- a/spec/plurimath/omml_spec.rb
+++ b/spec/plurimath/omml_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Plurimath::Omml do
       end
 
       it 'converts `alpha`, `α` to `&#x3b1;`' do
-        skip "Lutaml::Model::XmlAdapter::Oga doesn't support HTML Entities yet!" if Lutaml::Model::Config.xml_adapter == Lutaml::Model::XmlAdapter::OgaAdapter
+        skip "Lutaml::Model::XmlAdapter::Oga doesn't support HTML Entities yet!" if Lutaml::Model::Config.xml_adapter.type == "oga"
         formula = Plurimath::Math.parse(input, :mathml)
         expect(formula.to_omml).to eq(expected_output)
       end
@@ -410,7 +410,7 @@ RSpec.describe Plurimath::Omml do
       end
 
       it 'converts `alpha`, `α` to `&#x3b1;`' do
-        skip "Lutaml::Model::XmlAdapter::Oga doesn't support HTML Entities yet!" if Lutaml::Model::Config.xml_adapter == Lutaml::Model::XmlAdapter::OgaAdapter
+        skip "Lutaml::Model::XmlAdapter::Oga doesn't support HTML Entities yet!" if Lutaml::Model::Config.xml_adapter.type == "oga"
         formula = Plurimath::Math.parse(input, :mathml)
         expect(formula.to_omml).to eq(expected_output)
       end


### PR DESCRIPTION
This PR implements changes related to the latest version `0.6.0` of the lutaml-model(at the time of implementation).
Also updated the **Mml** configuration syntax for **MathML** parsing.