### PR TITLE
LutaML-Model version `0.7.1` compatibility

### DIFF
--- a/.github/workflows/dependent-repos.json
+++ b/.github/workflows/dependent-repos.json
@@ -1,0 +1,5 @@
+{
+  "repo": [
+    "unitsml/unitsml-ruby"
+  ]
+}

--- a/.github/workflows/dependent-tests.yml
+++ b/.github/workflows/dependent-tests.yml
@@ -1,0 +1,16 @@
+name: dependent-gems-test
+
+on:
+  push:
+    branches: [ main ]
+    tags: [ v* ]
+  pull_request:
+  workflow_dispatch:
+  repository_dispatch:
+    types: [ release-passed ]
+
+jobs:
+  rake:
+    uses: metanorma/ci/.github/workflows/dependent-rake.yml@main
+    with:
+      command: bundle exec rspec

--- a/lib/plurimath/math/core.rb
+++ b/lib/plurimath/math/core.rb
@@ -344,6 +344,7 @@ module Plurimath
           :@temp_mathml_order,
           :@using_default,
           :@displaystyle,
+          :@__encoding,
           :@__ordered,
           :@unitsml,
           :@__mixed,

--- a/lib/plurimath/math/formula.rb
+++ b/lib/plurimath/math/formula.rb
@@ -415,7 +415,7 @@ module Plurimath
       end
 
       def mstyle_value=(value)
-        return if value.empty?
+        return if value.nil? || value.empty?
 
         update(
           filter_values(

--- a/lib/plurimath/math/function/fenced.rb
+++ b/lib/plurimath/math/function/fenced.rb
@@ -238,7 +238,7 @@ module Plurimath
         end
 
         def mstyle_value=(value)
-          return if value.empty?
+          return if value.nil? || value.empty?
 
           update(
             replace_order_with_value(

--- a/lib/plurimath/math/function/ms.rb
+++ b/lib/plurimath/math/function/ms.rb
@@ -36,8 +36,11 @@ module Plurimath
         end
 
         def value=(content)
-          internal_content = updated_temp_mathml_values.flatten.map(&:to_ms_value)
-          @parameter_one = [internal_content, content.is_a?(String) ? content : content].flatten.compact.join(" ")
+          temp_content = updated_temp_mathml_values.flatten.map(&:to_ms_value)
+          @parameter_one = [
+            temp_content,
+            content&.empty? ? nil : content,
+          ].flatten.compact.join(" ")
         end
 
         def mi_value=(value)


### PR DESCRIPTION
This PR updates the **MathML** parsing methods and fixes failing specs.

related to => **metanorma/iso-10303#459**