### PR TITLE
Performance optimizations

### DIFF
--- a/lib/plurimath/asciimath/parse.rb
+++ b/lib/plurimath/asciimath/parse.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "parslet"
+require_relative "parslet_extensions"
+
 module Plurimath
   class Asciimath
     class Parse < Parslet::Parser

--- a/lib/plurimath/asciimath/parslet_extensions.rb
+++ b/lib/plurimath/asciimath/parslet_extensions.rb
@@ -5,6 +5,10 @@ module Parslet
     def lookahead?(pattern)
       @str.match?(pattern)
     end
+
+    def charpos
+      @string[0, @bytepos].length
+    end
   end
 end
 

--- a/lib/plurimath/asciimath/parslet_extensions.rb
+++ b/lib/plurimath/asciimath/parslet_extensions.rb
@@ -5,10 +5,6 @@ module Parslet
     def lookahead?(pattern)
       @str.match?(pattern)
     end
-
-    def charpos
-      @string[0, @bytepos].length
-    end
   end
 end
 

--- a/lib/plurimath/asciimath/parslet_extensions.rb
+++ b/lib/plurimath/asciimath/parslet_extensions.rb
@@ -53,6 +53,7 @@ class Parslet::Atoms::Alternative < Parslet::Atoms::Base
   end
 
   def try(source, context, consume_all)
+    # TODO: this optimization should be disabled if the order of @alternatives matters
     if apply_group_optimization
       @alternatives_by_char.each_key do |ch|
         char_alternatives = @alternatives_by_char[ch]

--- a/lib/plurimath/asciimath/parslet_extensions.rb
+++ b/lib/plurimath/asciimath/parslet_extensions.rb
@@ -103,7 +103,7 @@ class Parslet::Atoms::Sequence < Parslet::Atoms::Base
   end
 
   def first_char
-    return parslets[0].first_char
+    parslets[0].first_char
   end
 
   def try(source, context, consume_all)
@@ -188,8 +188,13 @@ end
 
 class Parslet::Atoms::Entity < Parslet::Atoms::Base
   def lookahead?(source)
-    @parslet.lookahead?(source) if @parslet
+    return @parslet.lookahead?(source) if @parslet
     true
+  end
+
+  def first_char
+    return @parslet.first_char if @parslet
+    ""
   end
 end
 

--- a/lib/plurimath/asciimath/parslet_extensions.rb
+++ b/lib/plurimath/asciimath/parslet_extensions.rb
@@ -1,0 +1,151 @@
+require "parslet"
+
+module Parslet
+  class Source
+    def lookahead?(pattern)
+      @str.match?(pattern)
+    end
+  end
+end
+
+class Parslet::Atoms::Base
+  def lookahead?(source)
+    # Assume lookup is successful by default
+    # Override in child classes by need
+    true
+  end
+end
+
+class Parslet::Atoms::Alternative < Parslet::Atoms::Base
+  def lookahead?(source)
+    # We need to stop the recursive lookahead at some point, otherwise it might go too deep
+    true
+  end
+
+  def try(source, context, consume_all)
+    alternatives.map { |a|
+      # Instead of entering the more expensive apply() method,
+      # we attempt to look ahead and continue to the next alternative if there's no match
+      # The `Constants.precompile_constants` alternative has over 3k options
+      next unless a.lookahead?(source)
+
+      success, _ = result = a.apply(source, context, consume_all)
+      return result if success
+    }
+
+    # If we reach this point, all alternatives have failed.
+    context.err(self, source, error_msg)
+  end
+
+  precedence ALTERNATE
+  def to_s_inner(prec)
+    # Don't dump all the alternatives, it takes too much time
+    limit = 5
+    items = alternatives.first(limit)
+                        .map { |a| "#{a.class}[#{a.to_s(prec).gsub("\n", " ")}]" }
+                        .join(' / ')
+
+    if alternatives.size > limit
+      items += " and (#{alternatives.size - limit}) more"
+    end
+
+    items
+  end
+end
+
+class Parslet::Atoms::Sequence < Parslet::Atoms::Base
+  def lookahead?(source)
+    parslets[0].lookahead?(source)
+  end
+
+  def try(source, context, consume_all)
+    # Lazy init array
+    result = nil
+
+    parslets.each_with_index do |p, idx|
+      unless p.lookahead?(source)
+        return context.err(self, source, error_msgs[:failed])
+      end
+
+      child_consume_all = consume_all && (idx == parslets.size-1)
+      success, value = p.apply(source, context, child_consume_all)
+
+      unless success
+        return context.err(self, source, error_msgs[:failed])
+      end
+
+      if result.nil?
+        result = Array.new(parslets.size + 1)
+        result[0] = :sequence
+      end
+      result[idx+1] = value
+    end
+
+    succ(result)
+  end
+end
+
+class Parslet::Atoms::Str < Parslet::Atoms::Base
+  def lookahead?(source)
+    source.lookahead?(@pat)
+  end
+end
+
+class Parslet::Atoms::Named < Parslet::Atoms::Base
+  def lookahead?(source)
+    @parslet.lookahead?(source)
+  end
+end
+
+class Parslet::Atoms::Lookahead < Parslet::Atoms::Base
+  def lookahead?(source)
+    return @bound_parslet.lookahead?(source) if @positive
+    # negative case covered below
+    true
+  end
+
+  def try(source, context, consume_all)
+    rewind_pos  = source.bytepos
+    error_pos   = source.pos
+
+    # Exit early for non-match
+    if not positive and not bound_parslet.lookahead?(source)
+      return succ(nil)
+    end
+
+    success, _ = bound_parslet.apply(source, context, consume_all)
+
+    if positive
+      return succ(nil) if success
+      return context.err_at(self, source, error_msgs[:positive], error_pos)
+    else
+      return succ(nil) unless success
+      return context.err_at(self, source, error_msgs[:negative], error_pos)
+    end
+
+    # This is probably the only parslet that rewinds its input in #try.
+    # Lookaheads NEVER consume their input, even on success, that's why.
+  ensure
+    source.bytepos = rewind_pos
+  end
+end
+
+class Parslet::Atoms::Entity < Parslet::Atoms::Base
+  def lookahead?(source)
+    @parslet.lookahead?(source) if @parslet
+    true
+  end
+end
+
+class Parslet::Atoms::Re < Parslet::Atoms::Base
+  def lookahead?(source)
+    source.lookahead?(@re)
+  end
+end
+
+class Parslet::Atoms::Repetition < Parslet::Atoms::Base
+  def lookahead?(source)
+    return true if @min == 0
+    @parslet.lookahead?(source)
+  end
+end

--- a/lib/plurimath/asciimath/parslet_extensions.rb
+++ b/lib/plurimath/asciimath/parslet_extensions.rb
@@ -119,6 +119,12 @@ class Parslet::Atoms::Sequence < Parslet::Atoms::Base
     @is_combined
   end
 
+  def error_msgs
+    @error_msgs ||= {
+      failed: "Failed to match sequence (<omited for performance reasons>)"
+    }
+  end
+
   def lookahead?(source)
     return source.lookahead?(@combined_re) if is_combined_re
     parslets[0].lookahead?(source)

--- a/lib/plurimath/math.rb
+++ b/lib/plurimath/math.rb
@@ -40,14 +40,19 @@ module Plurimath
       asciimath: Asciimath,
     }.freeze
 
+    # TODO: make optional/weak
+    FORMULA_CACHE = Hash.new { |h, k| h[k] = {} }
+
     def parse(text, type)
       type_error! unless valid_type?(type)
+
+      return FORMULA_CACHE[type][text] if FORMULA_CACHE[type].key?(text)
 
       begin
         klass = klass_from_type(type)
         formula = klass.new(text).to_formula
         formula.input_string = text
-        formula
+        FORMULA_CACHE[type][text] = formula
       rescue => ee
         parse_error!(text, type.to_sym)
       end


### PR DESCRIPTION
- mn-samples-jcgm contains a lot of formula repetitions. It makes sense to memoize those. I've added a trivial implementation

-  Parslet does a lot of backtracking and we can't fundamentally change that. There's a term containing over 3000 alternatives (hash_to_expression(Constants.precompile_constants) and this seems to be the biggest single performance bottleneck. To deal with it, I've implemented a lookahead optimization which costs less than entering the actual backtracking https://github.com/plurimath/plurimath/blob/1474143d3cb06f1744b7d79a61de1d346157f937/lib/plurimath/asciimath/parse.rb#L81

- If a backtracking step errors, a huge error message is being generated. I've truncated it https://github.com/kschiess/parslet/blob/f61daf0ef11a7b6ff795043ec8f64a6803e5162b/lib/parslet/atoms/alternative.rb#L49