### PR TITLE
Added thick math space before standard unary functions

### DIFF
--- a/lib/plurimath/math/formula.rb
+++ b/lib/plurimath/math/formula.rb
@@ -55,9 +55,14 @@ module Plurimath
         formatter: nil,
         unitsml: {},
         split_on_linebreak: false,
-        display_style: displaystyle
+        display_style: displaystyle,
+        unary_function_spacing: false
       )
-        options = { formatter: formatter, unitsml: unitsml }.compact
+        options = {
+          formatter: formatter,
+          unitsml: unitsml,
+          unary_function_spacing: unary_function_spacing
+        }.compact
         return line_breaked_mathml(display_style, intent, options: options) if split_on_linebreak
 
         math_attrs = {

--- a/lib/plurimath/math/formula.rb
+++ b/lib/plurimath/math/formula.rb
@@ -628,7 +628,7 @@ module Plurimath
         insert_index = 0
         nodes.each.with_index do |node, index|
           if node[:unitsml]
-            prev_node.insert_in_nodes(index + insert_index, space_element(node))
+            prev_node.insert_in_nodes(index + insert_index, space_element)
             insert_index += 1
             node.remove_attr("unitsml")
           end
@@ -636,7 +636,7 @@ module Plurimath
         end
       end
 
-      def space_element(node)
+      def space_element
         element = (ox_element("mo") << "&#x2062;")
         element[:rspace] = "thickmathspace"
         element

--- a/lib/plurimath/math/function/unary_function.rb
+++ b/lib/plurimath/math/function/unary_function.rb
@@ -44,11 +44,11 @@ module Plurimath
                           else
                             new_arr.first
                           end
-          if insert_space_tags
+          if insert_space_tags && options[:unary_function_spacing]
             Utility.update_nodes(
               ox_element("mrow"),
               [
-                space_element,
+                ox_element("mo", attributes: { rspace: "thickmathspace" }),
                 unary_element,
               ],
             )
@@ -237,12 +237,6 @@ module Plurimath
           me = Utility.ox_element("e", namespace: "m")
           Utility.update_nodes(me, omml_value(display_style, options: options)) if parameter_one
           [funcpr, fname, me]
-        end
-
-        def space_element
-          element = (ox_element("mo") << "&#x2062;")
-          element[:rspace] = "thickmathspace"
-          element
         end
       end
     end

--- a/lib/plurimath/math/function/unary_function.rb
+++ b/lib/plurimath/math/function/unary_function.rb
@@ -28,16 +28,32 @@ module Plurimath
         end
 
         def to_mathml_without_math_tag(intent, options:)
-          tag_name = Utility::UNARY_CLASSES.include?(class_name) ? "mi" : "mo"
+          tag_name = if Utility::UNARY_CLASSES.include?(class_name)
+                       insert_space_tags = true
+                       "mi"
+                     else
+                       "mo"
+                     end
           new_arr = []
           new_arr << (ox_element(tag_name) << class_name) unless hide_function_name
-          if parameter_one
-            new_arr += mathml_value(intent, options: options)
-            mrow = ox_element("mrow")
-            Utility.update_nodes(mrow, new_arr)
-            intentify(mrow, intent, func_name: :function, intent_name: intent_names[:name])
+          unary_element = if parameter_one
+                            new_arr += mathml_value(intent, options: options)
+                            mrow = ox_element("mrow")
+                            Utility.update_nodes(mrow, new_arr)
+                            intentify(mrow, intent, func_name: :function, intent_name: intent_names[:name])
+                          else
+                            new_arr.first
+                          end
+          if insert_space_tags
+            Utility.update_nodes(
+              ox_element("mrow"),
+              [
+                space_element,
+                unary_element,
+              ],
+            )
           else
-            new_arr.first
+            unary_element
           end
         end
 
@@ -221,6 +237,12 @@ module Plurimath
           me = Utility.ox_element("e", namespace: "m")
           Utility.update_nodes(me, omml_value(display_style, options: options)) if parameter_one
           [funcpr, fname, me]
+        end
+
+        def space_element
+          element = (ox_element("mo") << "&#x2062;")
+          element[:rspace] = "thickmathspace"
+          element
         end
       end
     end

--- a/spec/plurimath/asciimath_spec.rb
+++ b/spec/plurimath/asciimath_spec.rb
@@ -7056,6 +7056,9 @@ RSpec.describe Plurimath::Asciimath do
             </mstyle>
           </math>
         MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
       end
     end
 
@@ -7098,6 +7101,9 @@ RSpec.describe Plurimath::Asciimath do
             </mstyle>
           </math>
         MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
       end
     end
 
@@ -7141,6 +7147,9 @@ RSpec.describe Plurimath::Asciimath do
             </mstyle>
           </math>
         MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
       end
     end
 
@@ -7183,6 +7192,9 @@ RSpec.describe Plurimath::Asciimath do
             </mstyle>
           </math>
         MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
       end
     end
 
@@ -7225,6 +7237,9 @@ RSpec.describe Plurimath::Asciimath do
             </mstyle>
           </math>
         MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
       end
     end
 
@@ -7266,6 +7281,9 @@ RSpec.describe Plurimath::Asciimath do
             </mstyle>
           </math>
         MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
       end
     end
 
@@ -7307,6 +7325,35 @@ RSpec.describe Plurimath::Asciimath do
             </mstyle>
           </math>
         MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
+      end
+    end
+
+    context "contains sin with thickmathspace before it example #134" do
+      let(:string) { "xsiny" }
+
+      it 'matches LaTeX, AsciiMath, and MathML' do
+        asciimath = "x siny"
+        latex = 'x \sin{y}'
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mi>x</mi>
+              <mrow>
+                <mo rspace="thickmathspace"/>
+                <mrow>
+                  <mi>sin</mi>
+                  <mi>y</mi>
+                </mrow>
+              </mrow>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml(unary_function_spacing: true)).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
       end
     end
   end


### PR DESCRIPTION
This PR inserts a space element before standard Unary functions (`sin`, `cos`, `tan`, etc) based on an optional boolean argument `unary_function_spacing`.

Screenshot attachment from PDF presentation.
![Image](https://github.com/user-attachments/assets/46064cfc-5e41-40b8-a922-7ef870b7c61a)

closes #352 