### PR TITLE
Update: Significant digits

### DIFF
--- a/lib/plurimath/formatter/numbers/significant.rb
+++ b/lib/plurimath/formatter/numbers/significant.rb
@@ -33,9 +33,9 @@ module Plurimath
           frac_part = false
           new_chars = []
           sig_count = significant
-          chars.each.with_index do |char, ind|
-            frac_part = frac_part || char == decimal
-            sig_num = sig_num || char.match?(/[1-9]/)
+          chars.each_with_index do |char, ind|
+            frac_part ||= char == decimal
+            sig_num ||= char.match?(/[1-9]/)
             break if sig_count.zero?
 
             new_chars << char
@@ -47,7 +47,6 @@ module Plurimath
 
           if sig_count > 0
             new_chars << decimal unless frac_part
-            new_chars << ("0" * sig_count)
           else
             remain_chars = count_chars(chars, frac_part) - significant
             if remain_chars > 0
@@ -66,7 +65,7 @@ module Plurimath
 
           frac_part = false if chars[arr_len] == decimal
           prev_ten  = false
-          array.reverse!.each.with_index do |char, ind|
+          array.reverse!.each_with_index do |char, ind|
             if char == decimal
               array[ind] = ""
               frac_part  = false

--- a/spec/plurimath/number_formatter_spec.rb
+++ b/spec/plurimath/number_formatter_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe Plurimath::NumberFormatter do
         output_string = formatter.localized_number(number, format: { digit_count: 6, notation: :scientific, group_digits: 3 })
         expect(output_string).to eql("1,00000 × 10^-3")
         output_string = formatter.localized_number(number, format: { significant: 3, group_digits: 3 })
-        expect(output_string).to eql("0,00100")
+        expect(output_string).to eql("0,001")
         output_string = formatter.localized_number(number, format: { significant: 3, notation: :e, group_digits: 3 })
         expect(output_string).to eql("1,00e-3")
         output_string = formatter.localized_number(number, format: { significant: 3, notation: :scientific, group_digits: 3 })


### PR DESCRIPTION
This PR updates the behaviour of `significant` options passed inside `format` hash for number formatting.

#### Previous behaviour:
```ruby
> Plurimath::NumberFormatter.new(:en).localized_number("0.0082", format: { significant: 4 })
=> "0.008200" # adding significant zeros to meet the significant number passed.
```
#### New behaviour:
```ruby
> Plurimath::NumberFormatter.new(:en).localized_number("0.0082", format: { significant: 4 })
=> "0.0082" # If the value of the `significant` option exceeds the given number, then truncate the number; otherwise, do nothing.
```

closes #363 