### PR TITLE
Updated `unary_function_spacing` argument default value to true

### DIFF
--- a/lib/plurimath/math/formula.rb
+++ b/lib/plurimath/math/formula.rb
@@ -82,7 +82,12 @@ module Plurimath
 
       def line_breaked_mathml(display_style, intent, options:)
         new_line_support.map do |formula|
-          formula.to_mathml(display_style: display_style, intent: intent, formatter: options[:formatter])
+          formula.to_mathml(
+            display_style: display_style,
+            intent: intent,
+            formatter: options[:formatter],
+            unary_function_spacing: options[:unary_function_spacing],
+          )
         end.join
       end
 
@@ -171,8 +176,12 @@ module Plurimath
         parse_error!(:unicodemath)
       end
 
-      def to_display(type = nil, formatter: nil, unitsml: {})
-        options = { formatter: formatter, unitsml: unitsml }
+      def to_display(type = nil, formatter: nil, unitsml: {}, unary_function_spacing: true)
+        options = {
+          formatter: formatter,
+          unitsml: unitsml,
+          unary_function_spacing: unary_function_spacing
+        }
         return type_error!(type) unless MATH_ZONE_TYPES.include?(type.downcase.to_sym)
 
         math_zone = case type
@@ -181,7 +190,7 @@ module Plurimath
                     when :latex
                       "  |_ \"#{to_latex(options: options)}\"\n#{to_latex_math_zone("     ", options: options).join}"
                     when :mathml
-                      mathml = to_mathml(formatter: formatter).gsub(/\n\s*/, "")
+                      mathml = to_mathml(formatter: formatter, unary_function_spacing: options[:unary_function_spacing]).gsub(/\n\s*/, "")
                       math_display = to_mathml_math_zone("     ", options: options).join
                       "  |_ \"#{mathml}\"\n#{math_display}"
                     when :omml

--- a/lib/plurimath/math/formula.rb
+++ b/lib/plurimath/math/formula.rb
@@ -9,20 +9,29 @@ module Plurimath
 
       attr_accessor :value, :left_right_wrapper, :displaystyle, :input_string, :display
 
-      MATH_ZONE_TYPES = %i[
-        omml
-        latex
-        mathml
-        asciimath
-        unicodemath
-      ].freeze
       POWER_BASE_CLASSES = %w[powerbase power base].freeze
-      DERIVATIVE_CONSTS = [
-        "&#x1d451;",
-        "&#x2145;",
-        "&#x2146;",
-        "d",
-      ].freeze
+      DERIVATIVE_CONSTS  = ["&#x1d451;", "&#x2145;", "&#x2146;", "d"].freeze
+      MATH_ZONE_TYPES    = %i[omml latex mathml asciimath unicodemath].freeze
+      OMML_NAMESPACES    = {
+        "xmlns:m": "http://schemas.openxmlformats.org/officeDocument/2006/math",
+        "xmlns:mc": "http://schemas.openxmlformats.org/markup-compatibility/2006",
+        "xmlns:mo": "http://schemas.microsoft.com/office/mac/office/2008/main",
+        "xmlns:mv": "urn:schemas-microsoft-com:mac:vml",
+        "xmlns:o": "urn:schemas-microsoft-com:office:office",
+        "xmlns:r": "http://schemas.openxmlformats.org/officeDocument/2006/relationships",
+        "xmlns:v": "urn:schemas-microsoft-com:vml",
+        "xmlns:w": "http://schemas.openxmlformats.org/wordprocessingml/2006/main",
+        "xmlns:w10": "urn:schemas-microsoft-com:office:word",
+        "xmlns:w14": "http://schemas.microsoft.com/office/word/2010/wordml",
+        "xmlns:w15": "http://schemas.microsoft.com/office/word/2012/wordml",
+        "xmlns:wne": "http://schemas.microsoft.com/office/word/2006/wordml",
+        "xmlns:wp": "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing",
+        "xmlns:wp14": "http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing",
+        "xmlns:wpc": "http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas",
+        "xmlns:wpg": "http://schemas.microsoft.com/office/word/2010/wordprocessingGroup",
+        "xmlns:wpi": "http://schemas.microsoft.com/office/word/2010/wordprocessingInk",
+        "xmlns:wps": "http://schemas.microsoft.com/office/word/2010/wordprocessingShape",
+      }.freeze
 
       def initialize(
         value = [],
@@ -56,7 +65,7 @@ module Plurimath
         unitsml: {},
         split_on_linebreak: false,
         display_style: displaystyle,
-        unary_function_spacing: false
+        unary_function_spacing: true
       )
         options = {
           formatter: formatter,
@@ -120,33 +129,10 @@ module Plurimath
         parse_error!(:html)
       end
 
-      def omml_attrs
-        {
-          "xmlns:m": "http://schemas.openxmlformats.org/officeDocument/2006/math",
-          "xmlns:mc": "http://schemas.openxmlformats.org/markup-compatibility/2006",
-          "xmlns:mo": "http://schemas.microsoft.com/office/mac/office/2008/main",
-          "xmlns:mv": "urn:schemas-microsoft-com:mac:vml",
-          "xmlns:o": "urn:schemas-microsoft-com:office:office",
-          "xmlns:r": "http://schemas.openxmlformats.org/officeDocument/2006/relationships",
-          "xmlns:v": "urn:schemas-microsoft-com:vml",
-          "xmlns:w": "http://schemas.openxmlformats.org/wordprocessingml/2006/main",
-          "xmlns:w10": "urn:schemas-microsoft-com:office:word",
-          "xmlns:w14": "http://schemas.microsoft.com/office/word/2010/wordml",
-          "xmlns:w15": "http://schemas.microsoft.com/office/word/2012/wordml",
-          "xmlns:wne": "http://schemas.microsoft.com/office/word/2006/wordml",
-          "xmlns:wp": "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing",
-          "xmlns:wp14": "http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing",
-          "xmlns:wpc": "http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas",
-          "xmlns:wpg": "http://schemas.microsoft.com/office/word/2010/wordprocessingGroup",
-          "xmlns:wpi": "http://schemas.microsoft.com/office/word/2010/wordprocessingInk",
-          "xmlns:wps": "http://schemas.microsoft.com/office/word/2010/wordprocessingShape",
-        }
-      end
-
       def to_omml(display_style: displaystyle, split_on_linebreak: false, formatter: nil, unitsml: {})
         objects = split_on_linebreak ? new_line_support : [self]
         options = { formatter: formatter, unitsml: unitsml }.compact
-        para_element = Utility.ox_element("oMathPara", attributes: omml_attrs, namespace: "m")
+        para_element = Utility.ox_element("oMathPara", attributes: OMML_NAMESPACES, namespace: "m")
         objects.each.with_index(1) do |object, index|
           para_element << Utility.update_nodes(
             Utility.ox_element("oMath", namespace: "m"),

--- a/spec/plurimath/asciimath_spec.rb
+++ b/spec/plurimath/asciimath_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eq(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eq(asciimath)
       end
     end
@@ -96,7 +96,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eq(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eq(asciimath)
       end
     end
@@ -134,7 +134,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -164,7 +164,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -193,7 +193,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -228,7 +228,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -261,7 +261,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -291,7 +291,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -322,7 +322,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -344,7 +344,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -366,7 +366,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -388,7 +388,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -442,7 +442,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -467,7 +467,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -495,7 +495,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -517,7 +517,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -550,7 +550,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -607,7 +607,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -647,7 +647,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -673,7 +673,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -699,7 +699,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -754,7 +754,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -792,7 +792,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -856,7 +856,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -899,7 +899,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -950,7 +950,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -1005,7 +1005,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -1048,7 +1048,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -1088,7 +1088,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -1122,7 +1122,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -1168,7 +1168,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -1223,7 +1223,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -1301,7 +1301,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -1325,7 +1325,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -1361,7 +1361,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -1380,7 +1380,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -1414,7 +1414,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -1488,7 +1488,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -1518,7 +1518,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -1540,7 +1540,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -1572,7 +1572,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -1606,7 +1606,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -1639,7 +1639,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -1685,7 +1685,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -1731,7 +1731,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -1782,7 +1782,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -1840,7 +1840,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -2026,7 +2026,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -2180,7 +2180,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -2243,7 +2243,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -2565,7 +2565,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -2678,7 +2678,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -2778,7 +2778,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -2815,7 +2815,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -3094,7 +3094,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -3239,7 +3239,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -3317,7 +3317,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -3382,7 +3382,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -3425,7 +3425,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -3489,7 +3489,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -3614,7 +3614,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -3675,7 +3675,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -3709,7 +3709,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -3761,7 +3761,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -3791,7 +3791,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -3824,7 +3824,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -3857,7 +3857,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -3890,7 +3890,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -3971,7 +3971,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -4005,7 +4005,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -4026,7 +4026,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -4049,7 +4049,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -4072,7 +4072,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -4094,7 +4094,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -4124,7 +4124,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -4156,7 +4156,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -4182,7 +4182,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -4204,7 +4204,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -4223,7 +4223,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -4242,7 +4242,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -4266,7 +4266,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -4289,7 +4289,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -4313,7 +4313,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -4337,7 +4337,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -4373,7 +4373,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -4395,7 +4395,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -4548,7 +4548,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -4636,7 +4636,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -4707,7 +4707,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -4777,7 +4777,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -4894,7 +4894,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -4939,7 +4939,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -4983,7 +4983,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -5009,7 +5009,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -5082,7 +5082,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -5169,7 +5169,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -5218,7 +5218,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -5249,7 +5249,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -5274,7 +5274,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -5294,7 +5294,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -5351,7 +5351,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -5388,7 +5388,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -5423,7 +5423,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -5448,7 +5448,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -5506,7 +5506,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -5538,7 +5538,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -5566,7 +5566,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -5599,7 +5599,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -5628,7 +5628,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -5653,7 +5653,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -5678,7 +5678,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -5749,7 +5749,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -5805,7 +5805,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -5931,7 +5931,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -6065,7 +6065,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -6165,7 +6165,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -6240,7 +6240,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -6283,7 +6283,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -6304,7 +6304,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -6325,7 +6325,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -6367,7 +6367,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -6413,7 +6413,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -6436,7 +6436,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -6463,7 +6463,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -6608,7 +6608,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -6748,7 +6748,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -6927,7 +6927,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -6970,7 +6970,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -7013,7 +7013,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -7057,7 +7057,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -7102,7 +7102,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -7148,7 +7148,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -7193,7 +7193,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -7238,7 +7238,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -7282,7 +7282,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -7326,7 +7326,7 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end
@@ -7352,7 +7352,8 @@ RSpec.describe Plurimath::Asciimath do
           </math>
         MATHML
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml(unary_function_spacing: true)).to be_equivalent_to(mathml)
+        # testing MathML conversion's behaviour to add `unary_function_spacing: true` by default
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eql(asciimath)
       end
     end

--- a/spec/plurimath/latex_spec.rb
+++ b/spec/plurimath/latex_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "\\cos{45}"
         expect(formula.to_latex).to be_equivalent_to(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -164,7 +164,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "{1 \\over 2}"
         expect(formula.to_latex).to be_equivalent_to(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -195,7 +195,7 @@ RSpec.describe Plurimath::Latex do
           </math>
         MATHML
         latex = "L{' \\over {1 \\over 2}}"
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -213,7 +213,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "\\left \\{ \\right ."
         expect(formula.to_latex).to be_equivalent_to(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -247,7 +247,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "\\begin{matrix}a & b \\\\ c & d\\end{matrix}"
         expect(formula.to_latex).to be_equivalent_to(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -327,7 +327,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "\\left \\{ \\begin{array}{l|c}3 x - 5 y + 4 z = 0 & d \\\\ x - y + 8 z = 0 & e \\\\ 2 x - 6 y + z = 0 & c\\end{array} \\right \\}"
         expect(formula.to_latex).to be_equivalent_to(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -361,7 +361,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "\\begin{matrix*}[r]a & b \\\\ c & d\\end{matrix*}"
         expect(formula.to_latex).to be_equivalent_to(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -395,7 +395,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "\\begin{matrix*}[r]a & b \\\\ c & d\\end{matrix*}"
         expect(formula.to_latex).to be_equivalent_to(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -432,7 +432,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "\\begin{matrix}- a & b \\\\ c & d\\end{matrix}"
         expect(formula.to_latex).to be_equivalent_to(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -455,7 +455,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "\\begin{matrix}-\\end{matrix}"
         expect(formula.to_latex).to be_equivalent_to(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -501,7 +501,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "\\begin{matrix}a_{1} & b_{2} \\\\ c_{3} & d_{4}\\end{matrix}"
         expect(formula.to_latex).to be_equivalent_to(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -535,7 +535,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "\\begin{array}{cc}1 & 2 \\\\ 3 & 4\\end{array}"
         expect(formula.to_latex).to be_equivalent_to(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -685,7 +685,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "\\begin{bmatrix}a_{1 , 1} & a_{1 , 2} & \\cdots & a_{1 , n} \\\\ a_{2 , 1} & a_{2 , 2} & \\cdots & a_{2 , n} \\\\ \\vdots & \\vdots & \\ddots & \\vdots \\\\ a_{m , 1} & a_{m , 2} & \\cdots & a_{m , n}\\end{bmatrix}"
         expect(formula.to_latex).to be_equivalent_to(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -715,7 +715,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "\\sqrt{( - 25 )^{2}} = \\pm 25"
         expect(formula.to_latex).to be_equivalent_to(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -747,7 +747,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "\\left ( - x^{3} + 5 \\right )^{5}"
         expect(formula.to_latex).to be_equivalent_to(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -798,7 +798,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "\\begin{array}{rcl}A B C & = & a \\\\ A & = & a b c\\end{array}"
         expect(formula.to_latex).to be_equivalent_to(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -848,7 +848,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "\\begin{array}{c|r}1 & 2 \\\\ 3 & 4 \\\\ \\hline 5 & 6\\end{array}"
         expect(formula.to_latex).to be_equivalent_to(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -898,7 +898,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "\\begin{array}{cr}1 & 2 \\\\ \\hline 3 & 4 \\\\ \\hline 5 & 6\\end{array}"
         expect(formula.to_latex).to be_equivalent_to(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -921,7 +921,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "\\mathrm{. . .}"
         expect(formula.to_latex).to be_equivalent_to(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -969,7 +969,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "\\frac{x + 4}{x + \\frac{123 \\left ( \\sqrt{x} + 5 \\right )}{x + 4} - 8}"
         expect(formula.to_latex).to be_equivalent_to(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -999,7 +999,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "\\sqrt{\\sqrt{\\left ( x^{3} \\right ) + v}}"
         expect(formula.to_latex).to be_equivalent_to(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -1019,7 +1019,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "\\left ( x \\right ) 5"
         expect(formula.to_latex).to be_equivalent_to(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -1041,7 +1041,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "\\sqrt[3]{}"
         expect(formula.to_latex).to be_equivalent_to(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -1060,7 +1060,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "1_{}"
         expect(formula.to_latex).to be_equivalent_to(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -1081,7 +1081,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "\\begin{array}.\\end{array}"
         expect(formula.to_latex).to be_equivalent_to(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -1102,7 +1102,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "\\begin{array}.\\end{array}"
         expect(formula.to_latex).to be_equivalent_to(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -1189,7 +1189,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "\\left [ \\begin{matrix}1 & 0 & 0 & 0 \\\\ 0 & 1 & 0 & 0 \\\\ 0 & 0 & 1 & 0 \\\\ 0 & 0 & 0 & 1\\end{matrix} \\right ]"
         expect(formula.to_latex).to be_equivalent_to(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -1284,7 +1284,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "x^{x^{x^{x}}} \\left ( x^{x^{x}} \\left ( x^{x} \\left ( \\log \\left ( x \\right ) + 1 \\right ) \\log \\left ( x \\right ) + \\frac{x^{x}}{x} \\right ) \\log \\left ( x \\right ) + \\frac{x^{x^{x}}}{x} \\right )"
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -1305,7 +1305,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "\\log_{2} x"
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -1325,7 +1325,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "\\sqrt[]{3}"
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -1354,7 +1354,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "\\frac{3}{\\frac{1}{2} x^{2}}"
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -1397,7 +1397,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "\\frac{3}{\\frac{1}{2} x^{2} - \\frac{3 \\sqrt[]{3}}{2} x + 3}"
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -1415,7 +1415,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "^ 3"
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -1446,7 +1446,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "\\lim_{x \\to + \\infty} f ( x )"
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -1476,7 +1476,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "\\inf_{x > s} f ( x )"
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -1510,7 +1510,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "\\sup{}_{x \\in \\mathbb{R}} f ( x )"
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -1546,7 +1546,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "\\max{}_{x \\in \\[ a , b \\]} f ( x )"
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -1582,7 +1582,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "\\min{}_{x \\in \\[ \\alpha , \\beta \\]} f ( x )"
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -1603,7 +1603,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "\\int\\limits_{0}^{\\pi}"
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -1640,7 +1640,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "\\sum_{\\substack{1 \\le i \\le n \\\\ i \\ne j}}"
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -1662,7 +1662,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "\\mathrm{A A}"
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -1694,7 +1694,7 @@ RSpec.describe Plurimath::Latex do
         MATHML
         latex = "( 1 + ( x - y )^{2} )"
         expect(formula.to_latex).to eql(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -1944,7 +1944,7 @@ RSpec.describe Plurimath::Latex do
           \\end{array}
         LATEX
         expect(formula.to_latex.gsub(/\s+/, "")).to eql(latex.gsub(/\s+/, ""))
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -2152,7 +2152,7 @@ RSpec.describe Plurimath::Latex do
           \\end{split}
         LATEX
         expect(formula.to_latex.gsub(/\s+/, "")).to eql(latex.gsub(/\s+/, ""))
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -2236,7 +2236,7 @@ RSpec.describe Plurimath::Latex do
             ; \\mathbf{u}
         LATEX
         expect(formula.to_latex.gsub(/\s+/, "")).to eql(latex.gsub(/\s+/, ""))
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -2336,7 +2336,7 @@ RSpec.describe Plurimath::Latex do
           \\[out_{k} = \\frac{1}{s}\\left(k == 0 ? 1 : \\sqrt{2}\\right)\\sum_{n = 0}^{s - 1}in_{n} \\cdot \\cos{\\left( \\frac{\\pi k}{s}\\left( n + \\frac{1}{2} \\right) \\right)}\\]
         LATEX
         expect(formula.to_latex.gsub(/\s+/, "")).to eql(latex.gsub(/\s+/, ""))
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -2435,7 +2435,7 @@ RSpec.describe Plurimath::Latex do
           \\[out_{k} = \\frac{1}{s}(k == 0 ? 1 : \\sqrt{2})\\sum_{n = 0}^{s - 1}in_{n} \\cdot \\cos{( \\frac{\\pi k}{s}( n + \\frac{1}{2} ) )}\\]
         LATEX
         expect(formula.to_latex.gsub(/\s+/, "")).to eql(latex.gsub(/\s+/, ""))
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -2462,7 +2462,7 @@ RSpec.describe Plurimath::Latex do
           \\sin{}_{d}^{e}
         LATEX
         expect(formula.to_latex.gsub(/\s+/, "")).to eql(latex.gsub(/\s+/, ""))
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -2488,7 +2488,7 @@ RSpec.describe Plurimath::Latex do
           \\sin{}^{e}
         LATEX
         expect(formula.to_latex.gsub(/\s+/, "")).to eql(latex.gsub(/\s+/, ""))
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -2520,7 +2520,7 @@ RSpec.describe Plurimath::Latex do
           \\left . s i n_{e} \\right .
         LATEX
         expect(formula.to_latex.gsub(/\s+/, "")).to eql(latex.gsub(/\s+/, ""))
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -2545,7 +2545,7 @@ RSpec.describe Plurimath::Latex do
           \\left . e \\right .
         LATEX
         expect(formula.to_latex.gsub(/\s+/, "")).to eql(latex.gsub(/\s+/, ""))
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -2569,7 +2569,7 @@ RSpec.describe Plurimath::Latex do
         asciimath = ' "symmentic"'
         expect(formula.to_asciimath).to eql(asciimath)
         expect(formula.to_latex.gsub(/\s+/, "")).to eql(latex.gsub(/\s+/, ""))
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -2602,7 +2602,7 @@ RSpec.describe Plurimath::Latex do
         asciimath = "inf_(oint_(lgsigma))^(200)"
         expect(formula.to_asciimath).to eql(asciimath)
         expect(formula.to_latex.gsub(/\s+/, "")).to eql(latex.gsub(/\s+/, ""))
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -2637,7 +2637,7 @@ RSpec.describe Plurimath::Latex do
         asciimath = "a (\"&#x200c;\"^(28) \"Si\")^(3)"
         expect(formula.to_asciimath).to eql(asciimath)
         expect(formula.to_latex.gsub(/\s+/, "")).to eql(latex.gsub(/\s+/, ""))
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -2671,7 +2671,7 @@ RSpec.describe Plurimath::Latex do
         asciimath = "ii(M) (\"\"^(12) \"C\")"
         expect(formula.to_asciimath).to eql(asciimath)
         expect(formula.to_latex.gsub(/\s+/, "")).to eql(latex.gsub(/\s+/, ""))
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -2722,7 +2722,7 @@ RSpec.describe Plurimath::Latex do
         asciimath = "\"\"_(d) \"d\"_(d) mathfrak(d)_(d)^(w) 100_(d)^(w) \"\" \"SO\"_(4)^(2 -)"
         expect(formula.to_asciimath).to eql(asciimath)
         expect(formula.to_latex.gsub(/\s+/, "")).to eql(latex.gsub(/\s+/, ""))
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -2744,7 +2744,7 @@ RSpec.describe Plurimath::Latex do
             </mstyle>
           </math>
         MATHML
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
 
@@ -2800,7 +2800,7 @@ RSpec.describe Plurimath::Latex do
             </mstyle>
           </math>
         MATHML
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
       end
     end
   end

--- a/spec/plurimath/math/formula/intent_encoding_spec.rb
+++ b/spec/plurimath/math/formula/intent_encoding_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe Plurimath::Math::Formula do
     end
   end
 
-  describe ".to_mathml(intent: true)" do
-    subject(:formula) { Plurimath::Math.parse(string, lang).to_mathml(intent: true) }
+  describe ".to_mathml(intent: true, unary_function_spacing: false)" do
+    subject(:formula) { Plurimath::Math.parse(string, lang).to_mathml(intent: true, unary_function_spacing: false) }
 
     context "contains prod AsciiMath string" do
       let(:lang) { :asciimath }

--- a/spec/plurimath/math/formula/mathml_spec.rb
+++ b/spec/plurimath/math/formula/mathml_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe Plurimath::Math::Formula do
   describe ".to_mathml" do
-    subject(:formula) { exp.to_mathml(display_style: display_style) }
+    subject(:formula) { exp.to_mathml(display_style: display_style, unary_function_spacing: false) }
     let(:display_style) { true }
 
     context "contains mathml string of sin formula" do

--- a/spec/plurimath/math/formula_spec.rb
+++ b/spec/plurimath/math/formula_spec.rb
@@ -959,7 +959,7 @@ RSpec.describe Plurimath::Math::Formula do
   end
 
   describe ".to_mathml" do
-    subject(:formula) { described_class.new(exp).to_mathml }
+    subject(:formula) { described_class.new(exp).to_mathml(unary_function_spacing: false) }
 
     context "contains left right with table string" do
       let(:exp) do

--- a/spec/plurimath/math_zone_spec.rb
+++ b/spec/plurimath/math_zone_spec.rb
@@ -291,7 +291,7 @@ RSpec.describe Plurimath::Math do
   end
 
   describe ".to_display(:mathml)" do
-    subject(:formula) { Plurimath::Math.parse(exp, :mathml).to_display(:mathml) }
+    subject(:formula) { Plurimath::Math.parse(exp, :mathml).to_display(:mathml, unary_function_spacing: false) }
 
     context "MathML Math zone representation of sin and simple equation #1" do
       let(:exp) do
@@ -1921,7 +1921,7 @@ RSpec.describe Plurimath::Math do
         ASCIIMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
       end
     end
@@ -1964,7 +1964,7 @@ RSpec.describe Plurimath::Math do
         ASCIIMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
       end
     end
@@ -2119,7 +2119,7 @@ RSpec.describe Plurimath::Math do
         ASCIIMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
       end
     end
@@ -2162,7 +2162,7 @@ RSpec.describe Plurimath::Math do
         ASCIIMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
       end
     end
@@ -2237,7 +2237,7 @@ RSpec.describe Plurimath::Math do
         ASCIIMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
       end
     end
@@ -2292,7 +2292,7 @@ RSpec.describe Plurimath::Math do
         ASCIIMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
       end
     end
@@ -2363,7 +2363,7 @@ RSpec.describe Plurimath::Math do
         ASCIIMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
       end
     end
@@ -2434,7 +2434,7 @@ RSpec.describe Plurimath::Math do
         ASCIIMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
       end
     end
@@ -2473,7 +2473,7 @@ RSpec.describe Plurimath::Math do
         ASCIIMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
       end
     end
@@ -2512,7 +2512,7 @@ RSpec.describe Plurimath::Math do
         ASCIIMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
       end
     end
@@ -2550,7 +2550,7 @@ RSpec.describe Plurimath::Math do
         ASCIIMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
       end
     end
@@ -2637,7 +2637,7 @@ RSpec.describe Plurimath::Math do
         ASCIIMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
       end
     end
@@ -2736,7 +2736,7 @@ RSpec.describe Plurimath::Math do
         ASCIIMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
       end
     end
@@ -2795,7 +2795,7 @@ RSpec.describe Plurimath::Math do
         ASCIIMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
       end
     end
@@ -2838,7 +2838,7 @@ RSpec.describe Plurimath::Math do
         ASCIIMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
       end
     end
@@ -2993,7 +2993,7 @@ RSpec.describe Plurimath::Math do
         ASCIIMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
       end
     end
@@ -3032,7 +3032,7 @@ RSpec.describe Plurimath::Math do
         ASCIIMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
       end
     end
@@ -3099,7 +3099,7 @@ RSpec.describe Plurimath::Math do
         ASCIIMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
       end
     end
@@ -3150,7 +3150,7 @@ RSpec.describe Plurimath::Math do
         ASCIIMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
       end
     end
@@ -3213,7 +3213,7 @@ RSpec.describe Plurimath::Math do
         ASCIIMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
       end
     end
@@ -3292,7 +3292,7 @@ RSpec.describe Plurimath::Math do
         ASCIIMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
       end
     end
@@ -3331,7 +3331,7 @@ RSpec.describe Plurimath::Math do
         ASCIIMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
       end
     end
@@ -3370,7 +3370,7 @@ RSpec.describe Plurimath::Math do
         ASCIIMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
       end
     end
@@ -3408,7 +3408,7 @@ RSpec.describe Plurimath::Math do
         ASCIIMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
       end
     end
@@ -3507,7 +3507,7 @@ RSpec.describe Plurimath::Math do
         ASCIIMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
       end
     end
@@ -3584,7 +3584,7 @@ RSpec.describe Plurimath::Math do
         ASCIIMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
       end
     end
@@ -3645,7 +3645,7 @@ RSpec.describe Plurimath::Math do
         ASCIIMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
       end
     end
@@ -3858,7 +3858,7 @@ RSpec.describe Plurimath::Math do
         ASCIIMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
       end
     end
@@ -3916,7 +3916,7 @@ RSpec.describe Plurimath::Math do
         ASCIIMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
       end
     end
@@ -4018,7 +4018,7 @@ RSpec.describe Plurimath::Math do
         ASCIIMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
       end
     end
@@ -4092,7 +4092,7 @@ RSpec.describe Plurimath::Math do
         ASCIIMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
       end
     end
@@ -4194,7 +4194,7 @@ RSpec.describe Plurimath::Math do
         ASCIIMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
       end
     end
@@ -4294,7 +4294,7 @@ RSpec.describe Plurimath::Math do
         ASCIIMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
       end
     end
@@ -4344,7 +4344,7 @@ RSpec.describe Plurimath::Math do
         ASCIIMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
       end
     end
@@ -4394,7 +4394,7 @@ RSpec.describe Plurimath::Math do
         ASCIIMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
       end
     end
@@ -4442,7 +4442,7 @@ RSpec.describe Plurimath::Math do
         ASCIIMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
       end
     end
@@ -4537,7 +4537,7 @@ RSpec.describe Plurimath::Math do
         ASCIIMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
       end
     end
@@ -4607,7 +4607,7 @@ RSpec.describe Plurimath::Math do
         UNICODEMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
         expect(formula.to_display(:unicodemath)).to eql(unicodemath)
       end
@@ -4659,7 +4659,7 @@ RSpec.describe Plurimath::Math do
         UNICODEMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
         expect(formula.to_display(:unicodemath)).to eql(unicodemath)
       end
@@ -4831,7 +4831,7 @@ RSpec.describe Plurimath::Math do
         UNICODEMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
         expect(formula.to_display(:unicodemath)).to eql(unicodemath)
       end
@@ -4883,7 +4883,7 @@ RSpec.describe Plurimath::Math do
         UNICODEMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
         expect(formula.to_display(:unicodemath)).to eql(unicodemath)
       end
@@ -4975,7 +4975,7 @@ RSpec.describe Plurimath::Math do
         UNICODEMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
         expect(formula.to_display(:unicodemath)).to eql(unicodemath)
       end
@@ -5037,7 +5037,7 @@ RSpec.describe Plurimath::Math do
         UNICODEMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
         expect(formula.to_display(:unicodemath)).to eql(unicodemath)
       end
@@ -5119,7 +5119,7 @@ RSpec.describe Plurimath::Math do
         UNICODEMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
         expect(formula.to_display(:unicodemath)).to eql(unicodemath)
       end
@@ -5206,7 +5206,7 @@ RSpec.describe Plurimath::Math do
         UNICODEMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
         expect(formula.to_display(:unicodemath)).to eql(unicodemath)
       end
@@ -5253,7 +5253,7 @@ RSpec.describe Plurimath::Math do
         UNICODEMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
       end
     end
@@ -5299,7 +5299,7 @@ RSpec.describe Plurimath::Math do
         UNICODEMATH
         expect(formula.to_display(:omml)).to eql(omml)
         expect(formula.to_display(:latex)).to eql(latex)
-        expect(formula.to_display(:mathml)).to eql(mathml)
+        expect(formula.to_display(:mathml, unary_function_spacing: false)).to eql(mathml)
         expect(formula.to_display(:asciimath)).to eql(asciimath)
       end
     end

--- a/spec/plurimath/mathml/line_breaks_spec.rb
+++ b/spec/plurimath/mathml/line_breaks_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 require "plurimath/fixtures/formula_modules/line_break_values.rb"
 
 RSpec.describe Plurimath::Mathml::Parser do
-  subject(:mathml) { expected_value.to_mathml(split_on_linebreak: true) }
+  subject(:mathml) { expected_value.to_mathml(split_on_linebreak: true, unary_function_spacing: false) }
   subject(:file) { File.read(file_name) }
 
   context "contains #line-break-001.mathml" do

--- a/spec/plurimath/mathml_spec.rb
+++ b/spec/plurimath/mathml_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe Plurimath::Mathml do
         latex = "h a n n i n g ( k ) = 0 . 5 \\cdot [ 1 - \\cos{(} 2 \\pi \\cdot \\frac{k + 1}{n + 1} ) ] \\text{} ( 0 \\le k \\le n - 1 )"
         asciimath = 'h a n n i n g ( k ) = 0 . 5 * [ 1 - cos( 2 pi * frac(k + 1)(n + 1) ) ] "" ( 0 le k le n - 1 )'
         expect(formula.to_latex).to eq(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eq(asciimath)
       end
     end
@@ -254,7 +254,7 @@ RSpec.describe Plurimath::Mathml do
         latex = "\\int_{t_{2}}^{t_{1}} f ( t ) \\\\ d t"
         asciimath = "int_(t_(2))^(t_(1)) f ( t ) \\\n d t"
         expect(formula.to_latex).to eq(latex)
-        expect(formula.to_mathml(split_on_linebreak: true)).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(split_on_linebreak: true, unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eq(asciimath)
       end
     end
@@ -299,7 +299,7 @@ RSpec.describe Plurimath::Mathml do
         latex = " x  \\phantom{+} \\phantom{ y } +  z "
         asciimath = ' x  \  \ \ \  +  z '
         expect(formula.to_latex).to eq(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eq(asciimath)
       end
     end
@@ -338,7 +338,7 @@ RSpec.describe Plurimath::Mathml do
         latex = "a_{b}^{c}"
         asciimath = 'a_(b)^(c)'
         expect(formula.to_latex).to eq(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eq(asciimath)
       end
     end
@@ -379,7 +379,7 @@ RSpec.describe Plurimath::Mathml do
         latex = "100_{\\alpha}^{\\beta}"
         asciimath = '100_(alpha)^(beta)'
         expect(formula.to_latex).to eq(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eq(asciimath)
       end
     end
@@ -1167,7 +1167,7 @@ RSpec.describe Plurimath::Mathml do
         latex = "\\text{Convert} ( x , y , z , p_{a} , p_{o} , R , S , T ) = R_{z} ( \\alpha ) R_{y} ( \\beta ) R_{x} ( \\gamma ) S ( x - a_{x} , y - a_{y} , z - a_{z} ) + p_{o} + T =\\\\  \\left [\\begin{matrix}\\cos{\\text{P[funcapply]}} \\alpha \\cos{\\beta} & \\cos{\\text{P[funcapply]}} \\alpha \\sin{\\text{P[funcapply]}} \\beta \\sin{\\text{P[funcapply]}} \\gamma - \\sin{\\text{P[funcapply]}} \\alpha \\cos{\\gamma} & \\cos{\\text{P[funcapply]}} \\alpha \\sin{\\text{P[funcapply]}} \\beta \\cos{\\text{P[funcapply]}} \\gamma + \\sin{\\text{P[funcapply]}} \\alpha \\sin{\\text{P[funcapply]}} \\gamma \\\\ \\sin{\\text{P[funcapply]}} \\alpha \\cos{\\text{P[funcapply]}} \\beta & \\sin{\\text{P[funcapply]}} \\alpha \\sin{\\text{P[funcapply]}} \\beta \\sin{\\text{P[funcapply]}} \\gamma + \\cos{\\text{P[funcapply]}} \\alpha \\cos{\\text{P[funcapply]}} \\gamma & \\sin{\\text{P[funcapply]}} \\alpha \\sin{\\text{P[funcapply]}} \\beta \\cos{\\text{P[funcapply]}} \\gamma - \\cos{\\text{P[funcapply]}} \\alpha \\sin{\\text{P[funcapply]}} \\gamma \\\\ - \\sin{\\text{P[funcapply]}} \\beta & \\text{“cos ⁡”} \\beta \\sin{\\text{P[funcapply]}} \\gamma & \\cos{\\text{P[funcapply]}} \\beta \\cos{\\text{P[funcapply]}} \\gamma\\end{matrix}\\right ] \\left [\\begin{matrix}s_{x} \\ast ( x - a_{x} ) \\\\ s_{y} \\ast ( y - a_{y} ) \\\\ s_{z} \\ast ( z - a_{z} )\\end{matrix}\\right ] + \\left [\\begin{matrix}x_{0} + t_{x} \\\\ y_{0} + t_{y} \\\\ z_{0} + t_{z}\\end{matrix}\\right ] \\sqrt{d}"
         asciimath = "\"Convert\" (x , y , z , p_(a) , p_(o) , R , S , T) = R_(z) (alpha) R_(y) (beta) R_(x) (gamma) S (x - a_(x) , y - a_(y) , z - a_(z)) + p_(o) + T =\\\n  [[cos\"P{funcapply}\" alpha cosbeta, cos\"P{funcapply}\" alpha sin\"P{funcapply}\" beta sin\"P{funcapply}\" gamma - sin\"P{funcapply}\" alpha cosgamma, cos\"P{funcapply}\" alpha sin\"P{funcapply}\" beta cos\"P{funcapply}\" gamma + sin\"P{funcapply}\" alpha sin\"P{funcapply}\" gamma], [sin\"P{funcapply}\" alpha cos\"P{funcapply}\" beta, sin\"P{funcapply}\" alpha sin\"P{funcapply}\" beta sin\"P{funcapply}\" gamma + cos\"P{funcapply}\" alpha cos\"P{funcapply}\" gamma, sin\"P{funcapply}\" alpha sin\"P{funcapply}\" beta cos\"P{funcapply}\" gamma - cos\"P{funcapply}\" alpha sin\"P{funcapply}\" gamma], [- sin\"P{funcapply}\" beta, \"“cos ⁡”\" beta sin\"P{funcapply}\" gamma, cos\"P{funcapply}\" beta cos\"P{funcapply}\" gamma]] [[s_(x) ast (x - a_(x))], [s_(y) ast (y - a_(y))], [s_(z) ast (z - a_(z))]] + [[x_(0) + t_(x)], [y_(0) + t_(y)], [z_(0) + t_(z)]] sqrt(d)"
         expect(formula.to_latex).to eq(latex)
-        expect(formula.to_mathml(split_on_linebreak: true)).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(split_on_linebreak: true, unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eq(asciimath)
       end
     end
@@ -1216,7 +1216,7 @@ RSpec.describe Plurimath::Mathml do
         latex = "12  i "
         asciimath = "12i "
         expect(formula.to_latex).to eq(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eq(asciimath)
       end
     end
@@ -1247,7 +1247,7 @@ RSpec.describe Plurimath::Mathml do
         latex = "Alternate Text Alternate Text 1 Alternate Text 2"
         asciimath = "Alternate Text Alternate Text 1 Alternate Text 2"
         expect(formula.to_latex).to eq(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eq(asciimath)
       end
     end
@@ -1285,7 +1285,7 @@ RSpec.describe Plurimath::Mathml do
         latex = "F F"
         asciimath = "F F"
         expect(formula.to_latex).to eq(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eq(asciimath)
       end
     end
@@ -1342,7 +1342,7 @@ RSpec.describe Plurimath::Mathml do
         latex = "{}_{}^{}\\sum_{F}^{A} {}_{4}^{E}\\sum_{F}^{B}"
         asciimath = "\\ _()^()sum_(F)^(A) \\ _(4)^(E)sum_(F)^(B)"
         expect(formula.to_latex).to eq(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eq(asciimath)
       end
     end
@@ -1381,7 +1381,7 @@ RSpec.describe Plurimath::Mathml do
         latex = "\\oint_{F}^{A} C"
         asciimath = "oint_(F)^(A) C"
         expect(formula.to_latex).to eq(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eq(asciimath)
       end
     end
@@ -1416,7 +1416,7 @@ RSpec.describe Plurimath::Mathml do
         latex = "\\oint_{F} C"
         asciimath = "oint_(F) C"
         expect(formula.to_latex).to eq(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eq(asciimath)
       end
     end
@@ -1469,7 +1469,7 @@ RSpec.describe Plurimath::Mathml do
         latex = "\\left .\\begin{matrix}{a}\\cup F \\\\ \\cup E\\end{matrix}\\right ."
         asciimath = "[[uu F], [uu E]]"
         expect(formula.to_latex).to eq(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eq(asciimath)
       end
     end
@@ -1600,7 +1600,7 @@ RSpec.describe Plurimath::Mathml do
         latex = 's_{\text{p}}^{2} = \frac{\sum_{i = 1}^{\mathit{N}} \mathit{\nu}_{i} s_{i}^{2}}{\sum_{i = 1}^{\mathit{N}} \mathit{\nu}_{i}}'
         asciimath = 's_("p")^(2) = frac(sum_(i = 1)^(ii(N)) ii(nu)_(i) s_(i)^(2))(sum_(i = 1)^(ii(N)) ii(nu)_(i))'
         expect(formula.to_latex).to eq(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eq(asciimath)
       end
     end
@@ -1825,7 +1825,7 @@ RSpec.describe Plurimath::Mathml do
         latex = '\underline{\mathit{B}} = \left [\begin{matrix}1 &  &  &  &  \\\\ 1 & 1 &  &  &  \\\\ 1 & 2 & 1 &  &  \\\\ {\color{"red"} 1} & {\color{"red"} 3} & {\color{"red"} 3} & {\color{"red"} 1} &  \\\\ 1 & 4 & 6 & 4 & 1 \\\\  &  & \ldots &  & \end{matrix}\right ]'
         asciimath = 'underline(ii(B)) = [[1, , , , ], [1, 1, , , ], [1, 2, 1, , ], [color("red")(1), color("red")(3), color("red")(3), color("red")(1), ], [1, 4, 6, 4, 1], [, , ..., , ]]'
         expect(formula.to_latex).to eq(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eq(asciimath)
       end
     end
@@ -1884,7 +1884,7 @@ RSpec.describe Plurimath::Mathml do
         latex = "y_{k} = ( x_{k} \\pm h )  m"
         asciimath = "y_(k) = (x_(k) pm h)  m"
         expect(formula.to_latex).to eq(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eq(asciimath)
       end
     end
@@ -2005,7 +2005,7 @@ RSpec.describe Plurimath::Mathml do
         latex = '\int_{o}^{1} B_{4} ( \mathit{\rho} ) \text{d} \mathit{\rho} = [ \frac{1}{24} \mathit{\rho}^{4} ]_{0}^{1} = \frac{1}{24} \approx 0.0417'
         asciimath = 'int_(o)^(1) B_(4) (ii(rho)) "d" ii(rho) = [frac(1)(24) ii(rho)^(4)]_(0)^(1) = frac(1)(24) approx 0.0417'
         expect(formula.to_latex).to eq(latex)
-        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)
         expect(formula.to_asciimath).to eq(asciimath)
       end
     end


### PR DESCRIPTION
This PR updates the default value of `unary_function_spacing` from `false` to `true`.
Additionally, some syntax-related changes.

related to #362 