### PR TITLE
Updated approx symbol's MathML output

### DIFF
--- a/lib/plurimath/math/symbols/approx.rb
+++ b/lib/plurimath/math/symbols/approx.rb
@@ -25,7 +25,7 @@ module Plurimath
         end
 
         def to_mathml_without_math_tag(_, **)
-          ox_element("mi") << "&#x2248;"
+          ox_element("mo") << "&#x2248;"
         end
 
         def to_omml_without_math_tag(_, **)

--- a/spec/plurimath/math/symbols/approx_spec.rb
+++ b/spec/plurimath/math/symbols/approx_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Plurimath::Math::Symbols::Approx do
 
       it "matches MathML string" do
         string = dump_ox_nodes(klass.to_mathml_without_math_tag(false)).strip
-        expect(string).to eq("<mi>&#x2248;</mi>")
+        expect(string).to eq("<mo>&#x2248;</mo>")
       end
 
       it "matches HTML string" do

--- a/spec/plurimath/mathml_spec.rb
+++ b/spec/plurimath/mathml_spec.rb
@@ -1997,7 +1997,7 @@ RSpec.describe Plurimath::Mathml do
                 <mn>1</mn>
                 <mn>24</mn>
               </mfrac>
-              <mi>&#x2248;</mi>
+              <mo>&#x2248;</mo>
               <mn>0.0417</mn>
             </mstyle>
           </math>


### PR DESCRIPTION
This PR updates the approx symbol `&#x2248;` output in **MathML**.

closes #372 