### PR TITLE
Whitespaces before Unitsml

### DIFF
--- a/lib/plurimath/math/formula.rb
+++ b/lib/plurimath/math/formula.rb
@@ -83,7 +83,7 @@ module Plurimath
         style = ox_element("mstyle", attributes: style_attrs)
         Utility.update_nodes(style, mathml_content(intent, options: options))
         Utility.update_nodes(math, [style])
-        unitsml_post_processing(math.nodes, math)
+        unitsml_post_processing(math, style)
         dump_nodes(math, indent: 2)
       rescue
         parse_error!(:mathml)
@@ -624,7 +624,21 @@ module Plurimath
         r_tag << ox_element("br")
       end
 
-      def unitsml_post_processing(nodes, prev_node)
+      def unitsml_post_processing(math, style)
+        if all_unitsml_nodes?(style)
+          style.nodes.first.remove_attr("unitsml")
+        else
+          unitsml_processing(math.nodes, math)
+        end
+      end
+
+      def all_unitsml_nodes?(style)
+        return false unless style.nodes.one?
+
+        style.nodes.first.attributes["unitsml"] == "true"
+      end
+
+      def unitsml_processing(nodes, prev_node)
         insert_index = 0
         nodes.each.with_index do |node, index|
           if node[:unitsml]
@@ -632,7 +646,7 @@ module Plurimath
             insert_index += 1
             node.remove_attr("unitsml")
           end
-          unitsml_post_processing(node.nodes, node) if node.nodes.none?(String)
+          unitsml_processing(node.nodes, node) if node.nodes.none?(String)
         end
       end
 

--- a/spec/plurimath/asciimath_spec.rb
+++ b/spec/plurimath/asciimath_spec.rb
@@ -110,7 +110,6 @@ RSpec.describe Plurimath::Asciimath do
         mathml = <<~MATHML
           <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
             <mstyle displaystyle="true">
-              <mo rspace="thickmathspace">&#x2062;</mo>
               <mrow>
                 <mstyle mathvariant="normal">
                   <mi>V</mi>
@@ -7464,6 +7463,54 @@ RSpec.describe Plurimath::Asciimath do
                   </mtr>
                 </mtable>
                 <mo></mo>
+              </mrow>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
+      end
+    end
+
+    context "contains table from plurimath/plurimath#375 example #136" do
+      let(:string) { %("unitsml(mm)") }
+
+      it 'matches LaTeX, AsciiMath, and MathML' do
+        asciimath = 'rm(mm)'
+        latex = '\\mathrm{mm}'
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mrow>
+                <mstyle mathvariant="normal">
+                  <mi>mm</mi>
+                </mstyle>
+              </mrow>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_latex).to eql(latex)
+        expect(formula.to_mathml).to be_equivalent_to(mathml)
+        expect(formula.to_asciimath).to eql(asciimath)
+      end
+    end
+
+    context "contains table from plurimath/plurimath#376 example #137" do
+      let(:string) { %(M "unitsml(mm)") }
+
+      it 'matches LaTeX, AsciiMath, and MathML' do
+        asciimath = 'M rm(mm)'
+        latex = 'M \\mathrm{mm}'
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mi>M</mi>
+              <mo rspace="thickmathspace">&#x2062;</mo>
+              <mrow>
+                <mstyle mathvariant="normal">
+                  <mi>mm</mi>
+                </mstyle>
               </mrow>
             </mstyle>
           </math>

--- a/spec/plurimath/asciimath_spec.rb
+++ b/spec/plurimath/asciimath_spec.rb
@@ -7474,7 +7474,7 @@ RSpec.describe Plurimath::Asciimath do
     end
 
     context "contains table from plurimath/plurimath#375 example #136" do
-      let(:string) { %("unitsml(mm)") }
+      let(:string) { "\"unitsml(mm)\"" }
 
       it 'matches LaTeX, AsciiMath, and MathML' do
         asciimath = 'rm(mm)'
@@ -7497,7 +7497,7 @@ RSpec.describe Plurimath::Asciimath do
     end
 
     context "contains table from plurimath/plurimath#376 example #137" do
-      let(:string) { %(M "unitsml(mm)") }
+      let(:string) { "M \"unitsml(mm)\"" }
 
       it 'matches LaTeX, AsciiMath, and MathML' do
         asciimath = 'M rm(mm)'


### PR DESCRIPTION
This PR updates the whitespacing rule before the units in the formula.

closes #375 