### PR TITLE
LaTeX slashed semicolon `\;` support

### DIFF
--- a/lib/plurimath/latex/constants.rb
+++ b/lib/plurimath/latex/constants.rb
@@ -204,24 +204,6 @@ module Plurimath
         "[": "[",
         "]": "]",
       }.freeze
-      SLASHED_SYMBOLS = %w[
-        backslash
-        langle
-        rangle
-        lfloor
-        rfloor
-        lbrace
-        rbrace
-        lbrack
-        rbrack
-        lceil
-        rceil
-        Vert
-        vert
-        |
-        }
-        {
-      ].freeze
 
       class << self
         def symbols_constants

--- a/lib/plurimath/latex/parse.rb
+++ b/lib/plurimath/latex/parse.rb
@@ -86,6 +86,7 @@ module Plurimath
 
       rule(:symbol_class_commands) do
         (str("&#x") >> match["0-9a-fA-F"].repeat >> str(";")).as(:unicode_symbols) |
+          str("\\;").as(:semicolon_space) |
           hash_to_expression(Constants.symbols_constants) |
           under_over |
           environment |

--- a/lib/plurimath/latex/transform.rb
+++ b/lib/plurimath/latex/transform.rb
@@ -25,6 +25,7 @@ module Plurimath
       rule(under_over: simple(:under_over)) { under_over }
       rule(power_base: simple(:power_base)) { power_base }
       rule(table_data: simple(:table_data)) { table_data }
+      rule(semicolon_space: simple(:space)) { Math::Symbols::SemicolonSpace.new }
 
       rule(intermediate_exp: simple(:int_exp)) { int_exp }
 

--- a/lib/plurimath/math/symbols/semicolon_space.rb
+++ b/lib/plurimath/math/symbols/semicolon_space.rb
@@ -1,0 +1,41 @@
+module Plurimath
+  module Math
+    module Symbols
+      class SemicolonSpace < Symbol
+        INPUT = {
+          unicodemath: [["&#x2004;"], parsing_wrapper(["\\;"], lang: :unicode)],
+          asciimath: [[";", "&#x2004;"], parsing_wrapper(["\\;"], lang: :asciimath)],
+          mathml: ["&#x2004;"],
+          latex: [["\\;", "&#x2004;"]],
+          omml: ["&#x2004;"],
+          html: ["&#x2004;"],
+        }.freeze
+
+        # output methods
+        def to_latex(**)
+          "\\;"
+        end
+
+        def to_asciimath(**)
+          parsing_wrapper("\\;", lang: :asciimath)
+        end
+
+        def to_unicodemath(**)
+          Utility.html_entity_to_unicode("&#x2004;")
+        end
+
+        def to_mathml_without_math_tag(_, **)
+          ox_element("mo") << "&#x2004;"
+        end
+
+        def to_omml_without_math_tag(_, **)
+          "&#x2004;"
+        end
+
+        def to_html(**)
+          "&#x2004;"
+        end
+      end
+    end
+  end
+end

--- a/spec/plurimath/latex/parser_spec.rb
+++ b/spec/plurimath/latex/parser_spec.rb
@@ -2027,7 +2027,7 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Symbols::Symbol.new("n"),
             Plurimath::Math::Symbols::Symbol.new("j"),
           ),
-          Plurimath::Math::Symbols::Semicolon.new,
+          Plurimath::Math::Symbols::SemicolonSpace.new,
           Plurimath::Math::Formula.new([
             Plurimath::Math::Function::FontStyle::Normal.new(
               Plurimath::Math::Symbols::Symbol.new("f"),
@@ -2036,7 +2036,7 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Symbols::Symbol.new("o"),
             Plurimath::Math::Symbols::Symbol.new("r"),
           ]),
-          Plurimath::Math::Symbols::Semicolon.new,
+          Plurimath::Math::Symbols::SemicolonSpace.new,
           Plurimath::Math::Symbols::Symbol.new("i"),
           Plurimath::Math::Symbols::Equal.new,
           Plurimath::Math::Number.new("1"),
@@ -2081,7 +2081,7 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Symbols::Symbol.new("n"),
             Plurimath::Math::Symbols::Symbol.new("j"),
           ),
-          Plurimath::Math::Symbols::Semicolon.new,
+          Plurimath::Math::Symbols::SemicolonSpace.new,
           Plurimath::Math::Formula.new([
             Plurimath::Math::Function::FontStyle::Normal.new(
               Plurimath::Math::Symbols::Symbol.new("f"),
@@ -2090,7 +2090,7 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Symbols::Symbol.new("o"),
             Plurimath::Math::Symbols::Symbol.new("r"),
           ]),
-          Plurimath::Math::Symbols::Semicolon.new,
+          Plurimath::Math::Symbols::SemicolonSpace.new,
           Plurimath::Math::Symbols::Symbol.new("i"),
           Plurimath::Math::Symbols::Equal.new,
           Plurimath::Math::Number.new("1"),
@@ -2309,7 +2309,7 @@ RSpec.describe Plurimath::Latex::Parser do
               Plurimath::Math::Symbols::Symbol.new("l"),
             ]),
           ),
-          Plurimath::Math::Symbols::Semicolon.new,
+          Plurimath::Math::Symbols::SemicolonSpace.new,
           Plurimath::Math::Formula.new([
             Plurimath::Math::Function::FontStyle::Normal.new(
               Plurimath::Math::Symbols::Symbol.new("f"),
@@ -2318,13 +2318,13 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Symbols::Symbol.new("o"),
             Plurimath::Math::Symbols::Symbol.new("r"),
           ]),
-          Plurimath::Math::Symbols::Semicolon.new,
+          Plurimath::Math::Symbols::SemicolonSpace.new,
           Plurimath::Math::Symbols::Symbol.new("i"),
           Plurimath::Math::Symbols::Equal.new,
           Plurimath::Math::Number.new("1"),
           Plurimath::Math::Symbols::Comma.new,
           Plurimath::Math::Number.new("2"),
-          Plurimath::Math::Symbols::Semicolon.new,
+          Plurimath::Math::Symbols::SemicolonSpace.new,
           Plurimath::Math::Formula.new([
             Plurimath::Math::Function::FontStyle::Normal.new(
               Plurimath::Math::Symbols::Symbol.new("a"),
@@ -2333,7 +2333,7 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Symbols::Symbol.new("n"),
             Plurimath::Math::Symbols::Symbol.new("d"),
           ]),
-          Plurimath::Math::Symbols::Semicolon.new,
+          Plurimath::Math::Symbols::SemicolonSpace.new,
           Plurimath::Math::Symbols::Symbol.new("j"),
           Plurimath::Math::Symbols::Equal.new,
           Plurimath::Math::Number.new("1"),
@@ -2791,7 +2791,7 @@ RSpec.describe Plurimath::Latex::Parser do
             ],
             Plurimath::Math::Symbols::Paren::Rround.new,
           ),
-          Plurimath::Math::Symbols::Semicolon.new,
+          Plurimath::Math::Symbols::SemicolonSpace.new,
           Plurimath::Math::Formula.new([
             Plurimath::Math::Function::FontStyle::Normal.new(
               Plurimath::Math::Symbols::Symbol.new("f"),
@@ -2800,13 +2800,13 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Symbols::Symbol.new("o"),
             Plurimath::Math::Symbols::Symbol.new("r")
           ]),
-          Plurimath::Math::Symbols::Semicolon.new,
+          Plurimath::Math::Symbols::SemicolonSpace.new,
           Plurimath::Math::Symbols::Symbol.new("i"),
           Plurimath::Math::Symbols::Equal.new,
           Plurimath::Math::Number.new("1"),
           Plurimath::Math::Symbols::Comma.new,
           Plurimath::Math::Number.new("3"),
-          Plurimath::Math::Symbols::Semicolon.new,
+          Plurimath::Math::Symbols::SemicolonSpace.new,
           Plurimath::Math::Formula.new([
             Plurimath::Math::Function::FontStyle::Normal.new(
               Plurimath::Math::Symbols::Symbol.new("a"),
@@ -2815,7 +2815,7 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Symbols::Symbol.new("n"),
             Plurimath::Math::Symbols::Symbol.new("d")
           ]),
-          Plurimath::Math::Symbols::Semicolon.new,
+          Plurimath::Math::Symbols::SemicolonSpace.new,
           Plurimath::Math::Symbols::Symbol.new("j"),
           Plurimath::Math::Symbols::Equal.new,
           Plurimath::Math::Number.new("1"),
@@ -4926,7 +4926,7 @@ RSpec.describe Plurimath::Latex::Parser do
             ],
             Plurimath::Math::Symbols::Paren::Rround.new,
           ),
-          Plurimath::Math::Symbols::Semicolon.new,
+          Plurimath::Math::Symbols::SemicolonSpace.new,
           Plurimath::Math::Formula.new([
             Plurimath::Math::Function::FontStyle::Normal.new(
               Plurimath::Math::Symbols::Symbol.new("f"),
@@ -4935,7 +4935,7 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Symbols::Symbol.new("o"),
             Plurimath::Math::Symbols::Symbol.new("r")
           ]),
-          Plurimath::Math::Symbols::Semicolon.new,
+          Plurimath::Math::Symbols::SemicolonSpace.new,
           Plurimath::Math::Symbols::Symbol.new("i"),
           Plurimath::Math::Symbols::Equal.new,
           Plurimath::Math::Number.new("1"),
@@ -5365,7 +5365,7 @@ RSpec.describe Plurimath::Latex::Parser do
               Plurimath::Math::Symbols::Symbol.new("l"),
             ])
           ),
-          Plurimath::Math::Symbols::Semicolon.new,
+          Plurimath::Math::Symbols::SemicolonSpace.new,
           Plurimath::Math::Formula.new([
             Plurimath::Math::Function::FontStyle::Normal.new(
               Plurimath::Math::Symbols::Symbol.new("f"),
@@ -5374,13 +5374,13 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Symbols::Symbol.new("o"),
             Plurimath::Math::Symbols::Symbol.new("r"),
           ]),
-          Plurimath::Math::Symbols::Semicolon.new,
+          Plurimath::Math::Symbols::SemicolonSpace.new,
           Plurimath::Math::Symbols::Symbol.new("i"),
           Plurimath::Math::Symbols::Equal.new,
           Plurimath::Math::Number.new("1"),
           Plurimath::Math::Symbols::Comma.new,
           Plurimath::Math::Number.new("3"),
-          Plurimath::Math::Symbols::Semicolon.new,
+          Plurimath::Math::Symbols::SemicolonSpace.new,
           Plurimath::Math::Formula.new([
             Plurimath::Math::Function::FontStyle::Normal.new(
               Plurimath::Math::Symbols::Symbol.new("a"),
@@ -5389,7 +5389,7 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Symbols::Symbol.new("n"),
             Plurimath::Math::Symbols::Symbol.new("d"),
           ]),
-          Plurimath::Math::Symbols::Semicolon.new,
+          Plurimath::Math::Symbols::SemicolonSpace.new,
           Plurimath::Math::Symbols::Symbol.new("j"),
           Plurimath::Math::Symbols::Equal.new,
           Plurimath::Math::Number.new("1"),
@@ -5449,7 +5449,7 @@ RSpec.describe Plurimath::Latex::Parser do
               Plurimath::Math::Symbols::Symbol.new("l"),
             ])
           ),
-          Plurimath::Math::Symbols::Semicolon.new,
+          Plurimath::Math::Symbols::SemicolonSpace.new,
           Plurimath::Math::Formula.new([
             Plurimath::Math::Function::FontStyle::Normal.new(
               Plurimath::Math::Symbols::Symbol.new("f"),
@@ -5458,13 +5458,13 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Symbols::Symbol.new("o"),
             Plurimath::Math::Symbols::Symbol.new("r"),
           ]),
-          Plurimath::Math::Symbols::Semicolon.new,
+          Plurimath::Math::Symbols::SemicolonSpace.new,
           Plurimath::Math::Symbols::Symbol.new("i"),
           Plurimath::Math::Symbols::Equal.new,
           Plurimath::Math::Number.new("1"),
           Plurimath::Math::Symbols::Comma.new,
           Plurimath::Math::Number.new("2"),
-          Plurimath::Math::Symbols::Semicolon.new,
+          Plurimath::Math::Symbols::SemicolonSpace.new,
           Plurimath::Math::Formula.new([
             Plurimath::Math::Function::FontStyle::Normal.new(
               Plurimath::Math::Symbols::Symbol.new("a"),
@@ -5473,7 +5473,7 @@ RSpec.describe Plurimath::Latex::Parser do
             Plurimath::Math::Symbols::Symbol.new("n"),
             Plurimath::Math::Symbols::Symbol.new("d"),
           ]),
-          Plurimath::Math::Symbols::Semicolon.new,
+          Plurimath::Math::Symbols::SemicolonSpace.new,
           Plurimath::Math::Symbols::Symbol.new("j"),
           Plurimath::Math::Symbols::Equal.new,
           Plurimath::Math::Number.new("1"),
@@ -8337,7 +8337,7 @@ RSpec.describe Plurimath::Latex::Parser do
           Plurimath::Math::Symbols::Mathcolon.new,
           Plurimath::Math::Symbols::Symbol.new("d"),
           Plurimath::Math::Symbols::Symbol.new("s"),
-          Plurimath::Math::Symbols::Semicolon.new,
+          Plurimath::Math::Symbols::SemicolonSpace.new,
           Plurimath::Math::Function::FontStyle::Bold.new(
             Plurimath::Math::Symbols::Symbol.new("u"),
             "bf"
@@ -8453,7 +8453,7 @@ RSpec.describe Plurimath::Latex::Parser do
           Plurimath::Math::Symbols::Mathcolon.new,
           Plurimath::Math::Symbols::Symbol.new("d"),
           Plurimath::Math::Symbols::Symbol.new("s"),
-          Plurimath::Math::Symbols::Semicolon.new,
+          Plurimath::Math::Symbols::SemicolonSpace.new,
           Plurimath::Math::Function::FontStyle::Bold.new(
             Plurimath::Math::Symbols::Symbol.new("u"),
             "bf"

--- a/spec/plurimath/latex_spec.rb
+++ b/spec/plurimath/latex_spec.rb
@@ -2223,7 +2223,7 @@ RSpec.describe Plurimath::Latex do
               <mo>&#x3a;</mo>
               <mi>d</mi>
               <mi>s</mi>
-              <mo>&#x3b;</mo>
+              <mo>&#x2004;</mo>
               <mstyle mathvariant="bold">
                 <mi>u</mi>
               </mstyle>
@@ -2233,7 +2233,7 @@ RSpec.describe Plurimath::Latex do
         latex = <<~LATEX
           V = \\frac{1}{2} : \\mathbf{u}^{t} :
             \\int_{\\text{surface}} : \\int_{t h i c k n e s s} : B^{t} : D : B : d t : d s
-            ; \\mathbf{u}
+            \\; \\mathbf{u}
         LATEX
         expect(formula.to_latex.gsub(/\s+/, "")).to eql(latex.gsub(/\s+/, ""))
         expect(formula.to_mathml(unary_function_spacing: false)).to be_equivalent_to(mathml)

--- a/spec/plurimath/math/symbols/semicolon_space_spec.rb
+++ b/spec/plurimath/math/symbols/semicolon_space_spec.rb
@@ -1,0 +1,42 @@
+require "spec_helper"
+
+RSpec.describe Plurimath::Math::Symbols::SemicolonSpace do
+
+  describe ".initialize" do
+    it 'returns instance of Symbol SemicolonSpace' do
+      klass = described_class.new
+      expect(klass).to be_a(Plurimath::Math::Symbols::SemicolonSpace)
+    end
+  end
+
+  describe "All language conversion specs" do
+    subject(:klass) { described_class.new }
+
+    context "Matches all conversion for the Symbol Plurimath::Math::Symbols::SemicolonSpace" do
+      it "matches AsciiMath string" do
+        expect(klass.to_asciimath).to eq("\"P{\\;}\"")
+      end
+
+      it "matches LaTeX string" do
+        expect(klass.to_latex).to eq("\\;")
+      end
+
+      it "matches UnicodeMath string" do
+        expect(klass.to_unicodemath).to eq(" ")
+      end
+
+      it "matches OMML string" do
+        expect(klass.to_omml_without_math_tag(true)).to eq("&#x2004;")
+      end
+
+      it "matches MathML string" do
+        string = dump_ox_nodes(klass.to_mathml_without_math_tag(false)).strip
+        expect(string).to eq("<mo>&#x2004;</mo>")
+      end
+
+      it "matches HTML string" do
+        expect(klass.to_html).to eq("&#x2004;")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR updates support of `\;` slashed semicolon conversion.

Additionally, removed unused constant.

originally posted => https://github.com/plurimath/plurimath/issues/376#:~:text=However%2C%20three%2Dper%2Dem%20space%20%5C%3B%20in%20LaTeX%20is%20changed%20into%20semicolon%20in%20AsciiMath...%20Is%20it%20possible%20to%20change%20it%20into