### PR TITLE
Commas in matrices conversion of AsciiMath

### DIFF
--- a/lib/plurimath/math/formula.rb
+++ b/lib/plurimath/math/formula.rb
@@ -54,7 +54,9 @@ module Plurimath
 
       def to_asciimath(formatter: nil, unitsml: {}, options: nil)
         options ||= { formatter: formatter, unitsml: unitsml }.compact
-        value.map { |val| val.to_asciimath(options: options) }.join(" ")
+        output = value.map do |val|
+          val.to_asciimath(options: asciimath_table_options(options, val))
+        end.join(" ")
       rescue
         parse_error!(:asciimath)
       end
@@ -582,6 +584,12 @@ module Plurimath
       end
 
       protected
+
+      def asciimath_table_options(options, object)
+        return options unless options.key?(:table) || object.is_a?(Math::Symbols::Comma)
+
+        options.merge(literal_comma: true)
+      end
 
       def update_temp_order(value, order_name)
         return if value.nil? || value.empty?

--- a/lib/plurimath/math/formula.rb
+++ b/lib/plurimath/math/formula.rb
@@ -586,7 +586,7 @@ module Plurimath
       protected
 
       def asciimath_table_options(options, object)
-        return options unless options.key?(:table) || object.is_a?(Math::Symbols::Comma)
+        return options unless options.key?(:table) && object.is_a?(Math::Symbols::Comma)
 
         options.merge(literal_comma: true)
       end

--- a/lib/plurimath/math/function/td.rb
+++ b/lib/plurimath/math/function/td.rb
@@ -15,7 +15,9 @@ module Plurimath
         end
 
         def to_asciimath(options:)
-          parameter_one.map { |val| val&.to_asciimath(options: options) }.join(" ")
+          parameter_one.map do |val|
+            val&.to_asciimath(options: td_asciimath_options(options, val))
+          end.join(" ")
         end
 
         def to_mathml_without_math_tag(intent, options:)
@@ -104,6 +106,19 @@ module Plurimath
           sliced_result = sliced_value.first.last.omml_line_break(sliced_value)
           table = Table.new(sliced_result.map { |res| Tr.new(Array(Td.new(Array(res)))) })
           self.parameter_one = [table]
+        end
+
+        private
+
+        def td_asciimath_options(options, object)
+          case object
+          when ::Plurimath::Math::Symbols::Comma
+            options.merge(literal_comma: true)
+          when ::Plurimath::Math::Formula
+            options.merge(table: true)
+          else
+            options
+          end
         end
       end
     end

--- a/lib/plurimath/math/symbols/comma.rb
+++ b/lib/plurimath/math/symbols/comma.rb
@@ -16,8 +16,8 @@ module Plurimath
           ","
         end
 
-        def to_asciimath(**)
-          ","
+        def to_asciimath(options:)
+          options[:table] ? "\",\"" : ","
         end
 
         def to_unicodemath(**)

--- a/spec/plurimath/math/symbols/comma_spec.rb
+++ b/spec/plurimath/math/symbols/comma_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Plurimath::Math::Symbols::Comma do
 
     context "Matches all conversion for the Symbol Plurimath::Math::Symbols::Comma" do
       it "matches AsciiMath string" do
-        expect(klass.to_asciimath).to eq(",")
+        expect(klass.to_asciimath(options: {})).to eq(",")
       end
 
       it "matches LaTeX string" do


### PR DESCRIPTION
This PR updates the comma handling in **AsciiMath**’s matrix conversion.

closes #376 