### PR TITLE
fix: handle zero in scientific/engineering notation

### DIFF
--- a/lib/plurimath/formatter/numeric_formatter.rb
+++ b/lib/plurimath/formatter/numeric_formatter.rb
@@ -78,7 +78,10 @@ module Plurimath
       end
 
       def notation_chars(num_str)
-        notation_array = BigDecimal(num_str).to_s("e").split("e")
+        bd = BigDecimal(num_str)
+        return [num_str, 0] if bd.zero?
+
+        notation_array = bd.to_s("e").split("e")
         notation_array[1] = update_exponent_value(notation_array[1])
         number_str = notation_array[0]
         number_str = number_str.gsub(/0\.(\d)/, '\1.')

--- a/spec/plurimath/number_formatter_spec.rb
+++ b/spec/plurimath/number_formatter_spec.rb
@@ -61,6 +61,30 @@ RSpec.describe Plurimath::NumberFormatter do
         output_string = formatter.localized_number(number, locale: locale, precision: 2, format: format)
         expect(output_string).to eql("14,00 x 10^3")
       end
+
+      it "handles zero in scientific notation without crashing" do
+        format = { notation: :scientific }
+        output_string = formatter.localized_number("0", format: format)
+        expect(output_string).to eql("0 × 10^0")
+      end
+
+      it "handles zero in e notation without crashing" do
+        format = { notation: :e }
+        output_string = formatter.localized_number("0", format: format)
+        expect(output_string).to eql("0e0")
+      end
+
+      it "handles zero in engineering notation without crashing" do
+        format = { notation: :engineering }
+        output_string = formatter.localized_number("0", format: format)
+        expect(output_string).to eql("0 × 10^0")
+      end
+
+      it "preserves precision for zero with trailing decimals in scientific notation" do
+        format = { notation: :scientific }
+        output_string = formatter.localized_number("0.00", format: format)
+        expect(output_string).to eql("0.00 × 10^0")
+      end
     end
 
     context "testing digit grouping and decimal symbol" do


### PR DESCRIPTION
## Summary

- `BigDecimal("0").to_s("e")` returns `"0.0"` (no exponent component), causing `notation_chars` to crash with `TypeError: can't convert nil into BigDecimal` when splitting on `"e"`
- Short-circuits for zero values in `notation_chars` to return `[num_str, 0]` directly
- Adds tests for zero in scientific, e, and engineering notation formats, plus precision preservation for `"0.00"`

Fixes #292

## Test plan

- [x] All 43 number formatter tests pass
- [x] `"0"` in scientific notation → `"0 × 10^0"` (consistent with `"5"` → `"5 × 10^0"`)
- [x] `"0"` in e notation → `"0e0"`
- [x] `"0"` in engineering notation → `"0 × 10^0"`
- [x] `"0.00"` preserves trailing precision → `"0.00 × 10^0"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)