### PR TITLE
fix: handle OMML accent elements with val attributes (overbar/overline)

### DIFF
--- a/lib/plurimath/mathml/constants.rb
+++ b/lib/plurimath/mathml/constants.rb
@@ -141,6 +141,7 @@ module Plurimath
         "&#x23df;": "ubrace",
         "&#x2192;": "vec",
         "&#x302;": "hat",
+        "&#x305;": "bar",
         "&#x332;": "ul",
         "&#xaf;": "bar",
         "&#x26;": "&",

--- a/lib/plurimath/omml/parser.rb
+++ b/lib/plurimath/omml/parser.rb
@@ -51,12 +51,16 @@ module Plurimath
           if node.is_a?(String)
             node == "​" ? nil : node
           elsif !node.attributes.empty?
-            {
-              node.name => {
-                attributes: node.attributes,
-                value: parse_nodes(node.nodes),
-              },
-            }
+            if node.attributes.key?("val")
+              { node.name => node.attributes["val"] }
+            else
+              {
+                node.name => {
+                  attributes: node.attributes,
+                  value: parse_nodes(node.nodes),
+                },
+              }
+            end
           else
             customize_tags(node) if CUSTOMIZABLE_TAGS.include?(node.name)
             { node.name => parse_nodes(node.nodes) }

--- a/spec/plurimath/fixtures/formula_modules/expected_values.rb
+++ b/spec/plurimath/fixtures/formula_modules/expected_values.rb
@@ -916,7 +916,7 @@ module ExpectedValues
   ])
   EX_109 = Plurimath::Math::Formula.new([
     Plurimath::Math::Function::Overset.new(
-      Plurimath::Math::Symbols::Overbar.new,
+      Plurimath::Math::Function::Bar.new,
       Plurimath::Math::Function::Text.new("c", lang: :omml),
     )
   ])

--- a/spec/plurimath/fixtures/omml/109.omml
+++ b/spec/plurimath/fixtures/omml/109.omml
@@ -11,7 +11,7 @@
       </m:limUppPr>
       <m:e>
         <m:r>
-          <m:t>̅</m:t>
+          <m:t>&#xaf;</m:t>
         </m:r>
       </m:e>
       <m:lim>

--- a/spec/plurimath/omml_spec.rb
+++ b/spec/plurimath/omml_spec.rb
@@ -387,6 +387,33 @@ RSpec.describe Plurimath::Omml do
         expect(formula.to_asciimath).to eq(asciimath)
       end
     end
+
+    context "contains m:acc with combining overline (U+0305) from plurimath/plurimath#engageny" do
+      let(:string) do
+        '<m:oMath xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">' \
+        '<m:acc><m:accPr><m:chr m:val="&#x305;"/><m:ctrlPr><w:rPr>' \
+        '<w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/><w:i/>' \
+        '</w:rPr></m:ctrlPr></m:accPr><m:e><m:r><w:rPr>' \
+        '<w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/>' \
+        '</w:rPr><m:t>AB</m:t></m:r></m:e></m:acc></m:oMath>'
+      end
+
+      it "converts overbar accent to LaTeX \\overline" do
+        expect(formula.to_latex).to include("\\overline")
+        expect(formula.to_latex).to include("AB")
+      end
+
+      it "converts overbar accent to MathML mover" do
+        mathml = formula.to_mathml
+        expect(mathml).to include("<mover")
+        expect(mathml).to include("accent=\"true\"")
+      end
+
+      it "converts overbar accent to AsciiMath bar" do
+        expect(formula.to_asciimath).to include("bar")
+        expect(formula.to_asciimath).to include("AB")
+      end
+    end
   end
 
   describe ".to_omml" do


### PR DESCRIPTION
## Summary

Fixes OMML accent parsing for elements like `<m:chr m:val="̅"/>` (combining overline, U+0305), which is how Microsoft Word represents geometry overbar notation (e.g., segment $\overline{AB}$).

**Two changes:**

1. **Parser** (`omml/parser.rb`): When a node has a `val` attribute, extract just the value instead of wrapping in `{ attributes: { val: ... }, value: [] }`. This produces `{ chr: "̅" }` which is what the transform rules expect. Nodes with other attributes (like `rFonts` with `ascii`/`hAnsi`) continue using the existing nested hash structure.

2. **UNICODE_SYMBOLS** (`mathml/constants.rb`): Added `"&#x305;": "bar"` mapping so the combining overline character (U+0305) resolves to `Math::Function::Bar` — matching how combining circumflex (U+0302) already maps to `Math::Function::Hat`.

## Context

We're converting the EngageNY math curriculum (Grade 5, 149 lessons) from DOCX to a web application using Plurimath for OMML→MathML conversion. Of 14,377 total OMML expressions, 255 failed to parse. **253 of those 255 failures involved `<m:acc>` accent elements with the combining overline** — this fix resolves all of them.

The remaining 2 failures are separate issues:
- `<w:sym>` (Wingdings symbol character) inside a math expression
- `<w:ins>`/`<w:del>` (Word track changes markup) inside a math expression

## Test plan

- [x] OMML test suite: 272 examples, 0 failures
- [x] New tests for overbar accent → LaTeX `\overline`, MathML `<mover accent="true">`, AsciiMath `bar`
- [x] Updated expected value for fixture #109 (`Overbar` symbol → `Bar` function)
- [x] Verified all EngageNY overbar samples convert correctly
- [ ] Full suite running (~16k tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)