### PR TITLE
feat: contextual number formatting with formula access 

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1135,7 +1135,9 @@ method using a `formatter` option, which serializes the formula into an math
 representation language.
 
 The formatter should be an instance of `Plurimath::NumberFormatter` or a custom
-formatter derived from `Plurimath::Formatter::Standard`.
+formatter derived from `Plurimath::Formatter::Standard`. Custom formatters can
+define a `format(formula, number)` method to make context-aware formatting
+decisions based on the surrounding formula (see <<Contextual number formatting>>).
 
 The quick example below demonstrates how to format a number in a formula.
 
@@ -1343,6 +1345,60 @@ end
 > formula.to_asciimath(formatter: formatter)
 # => 'sum_(i = 1)^(10,00;00.1) i^(2,12,12,21;34.34)'
 ----
+====
+
+
+==== Contextual number formatting
+
+In some cases, certain numbers within a formula should be formatted differently
+depending on their context. For example, a year like "2024" should not have digit
+grouping applied, while other numbers in the same formula should.
+
+The `format` method on the formatter receives both the root
+`Plurimath::Math::Formula` tree and the current `Plurimath::Math::Number` node
+being processed, allowing context-aware formatting decisions.
+
+.Signature of the `format` method
+[source,ruby]
+----
+def format(formula, number)
+  # formula: the root Plurimath::Math::Formula containing the full equation
+  # number:  the Plurimath::Math::Number node currently being formatted
+  # returns: a formatted string
+end
+----
+
+Formatters that do not define `format` will fall back to `localized_number`, so
+existing formatters continue to work without changes.
+
+To implement contextual formatting, define a `format` method in a custom
+formatter subclass.
+
+.Creating a year-aware formatter that skips digit grouping for year-like numbers
+[example]
+====
+[source,ruby]
+----
+class YearFormatter < Plurimath::Formatter::Standard
+  def format(formula, number) <1>
+    int_value = Integer(number.value, exception: false)
+    if int_value && int_value > 1800 && int_value < 2200 <2>
+      number.value.to_s
+    else
+      localized_number(number.value.to_s) <3>
+    end
+  end
+end
+
+formatter = YearFormatter.new
+formula = Plurimath::Math.parse("2024 + 1000000", :asciimath)
+formula.to_latex(formatter: formatter)
+# => "2024 + 1,000,000" <4>
+----
+<1> Define `format` to receive the formula tree and number node.
+<2> Detect year-like numbers and return them unformatted.
+<3> Call `localized_number` to apply locale-based formatting for other numbers.
+<4> "2024" is left as-is, while "1000000" is formatted with digit grouping.
 ====
 
 

--- a/lib/plurimath/math/formula.rb
+++ b/lib/plurimath/math/formula.rb
@@ -54,6 +54,7 @@ module Plurimath
 
       def to_asciimath(formatter: nil, unitsml: {}, options: nil)
         options ||= { formatter: formatter, unitsml: unitsml }.compact
+        options[:formula] ||= self
         output = value.map do |val|
           val.to_asciimath(options: asciimath_table_options(options, val))
         end.join(" ")
@@ -74,6 +75,7 @@ module Plurimath
           unitsml: unitsml,
           unary_function_spacing: unary_function_spacing
         }.compact
+        options[:formula] ||= self
         return line_breaked_mathml(display_style, intent, options: options) if split_on_linebreak
 
         math_attrs = {
@@ -119,6 +121,7 @@ module Plurimath
 
       def to_latex(formatter: nil, unitsml: {}, options: nil)
         options ||= { formatter: formatter, unitsml: unitsml }.compact
+        options[:formula] ||= self
         value.map { |val| val.to_latex(options: options) }.join(" ")
       rescue
         parse_error!(:latex)
@@ -126,6 +129,7 @@ module Plurimath
 
       def to_html(formatter: nil, unitsml: {}, options: nil)
         options ||= { formatter: formatter, unitsml: unitsml }.compact
+        options[:formula] ||= self
         value&.map { |val| val.to_html(options: options) }&.join(" ")
       rescue
         parse_error!(:html)
@@ -134,6 +138,7 @@ module Plurimath
       def to_omml(display_style: displaystyle, split_on_linebreak: false, formatter: nil, unitsml: {})
         objects = split_on_linebreak ? new_line_support : [self]
         options = { formatter: formatter, unitsml: unitsml }.compact
+        options[:formula] ||= self
         para_element = Utility.ox_element("oMathPara", attributes: OMML_NAMESPACES, namespace: "m")
         objects.each.with_index(1) do |object, index|
           para_element << Utility.update_nodes(
@@ -159,6 +164,7 @@ module Plurimath
 
       def to_unicodemath(formatter: nil, unitsml: {}, options: nil)
         options ||= { formatter: formatter, unitsml: unitsml }.compact
+        options[:formula] ||= self
         Utility.html_entity_to_unicode(unicodemath_value(options: options)).gsub(/\s\/\s/, "/")
       rescue
         parse_error!(:unicodemath)
@@ -170,6 +176,7 @@ module Plurimath
           unitsml: unitsml,
           unary_function_spacing: unary_function_spacing
         }
+        options[:formula] ||= self
         return type_error!(type) unless MATH_ZONE_TYPES.include?(type.downcase.to_sym)
 
         math_zone = case type

--- a/lib/plurimath/math/formula.rb
+++ b/lib/plurimath/math/formula.rb
@@ -55,6 +55,7 @@ module Plurimath
 
       def to_asciimath(formatter: nil, unitsml: {}, options: nil)
         options ||= { formatter: formatter, unitsml: unitsml }.compact
+        options[:formula] ||= self
         wrap_render_error(:asciimath) do
           value.map do |val|
             val.to_asciimath(options: asciimath_table_options(options, val))
@@ -75,6 +76,7 @@ module Plurimath
           unitsml: unitsml,
           unary_function_spacing: unary_function_spacing
         }.compact
+        options[:formula] ||= self
         return line_breaked_mathml(display_style, intent, options: options) if split_on_linebreak
 
         wrap_render_error(:mathml) do
@@ -120,6 +122,7 @@ module Plurimath
 
       def to_latex(formatter: nil, unitsml: {}, options: nil)
         options ||= { formatter: formatter, unitsml: unitsml }.compact
+        options[:formula] ||= self
         wrap_render_error(:latex) do
           value.map { |val| val.to_latex(options: options) }.join(" ")
         end
@@ -127,6 +130,7 @@ module Plurimath
 
       def to_html(formatter: nil, unitsml: {}, options: nil)
         options ||= { formatter: formatter, unitsml: unitsml }.compact
+        options[:formula] ||= self
         wrap_render_error(:html) do
           value&.map { |val| val.to_html(options: options) }&.join(" ")
         end
@@ -136,6 +140,7 @@ module Plurimath
         wrap_render_error(:omml) do
           objects = split_on_linebreak ? new_line_support : [self]
           options = { formatter: formatter, unitsml: unitsml }.compact
+          options[:formula] ||= self
           para_element = Utility.ox_element("oMathPara", attributes: OMML_NAMESPACES, namespace: "m")
           objects.each.with_index(1) do |object, index|
             para_element << Utility.update_nodes(
@@ -160,6 +165,7 @@ module Plurimath
 
       def to_unicodemath(formatter: nil, unitsml: {}, options: nil)
         options ||= { formatter: formatter, unitsml: unitsml }.compact
+        options[:formula] ||= self
         wrap_render_error(:unicodemath) do
           Utility.html_entity_to_unicode(unicodemath_value(options: options)).gsub(/\s\/\s/, "/")
         end
@@ -171,6 +177,7 @@ module Plurimath
           unitsml: unitsml,
           unary_function_spacing: unary_function_spacing
         }
+        options[:formula] ||= self
         return type_error!(type) unless MATH_ZONE_TYPES.include?(type.downcase.to_sym)
 
         math_zone = case type

--- a/lib/plurimath/math/function/text.rb
+++ b/lib/plurimath/math/function/text.rb
@@ -97,7 +97,7 @@ module Plurimath
           text = text.join if text.is_a?(Array)
           entities = HTMLEntities.new
           symbols  = Mathml::Constants::UNICODE_SYMBOLS.transform_keys(&:to_s)
-          text     = entities.encode(text, :hexadecimal)
+          text     = entities.encode(entities.decode(text), :hexadecimal)
           symbols.each do |code, string|
             text = text.gsub(code.downcase, "unicode[:#{string}]")
           end

--- a/lib/plurimath/math/number.rb
+++ b/lib/plurimath/math/number.rb
@@ -93,9 +93,13 @@ module Plurimath
 
       def format_value_with_options(options)
         formatter = options[:formatter]
-        return value unless formatter&.respond_to?(:localized_number)
-
-        formatter.format(options[:formula], self)
+        if formatter&.respond_to?(:format)
+          formatter.format(options[:formula], self)
+        elsif formatter&.respond_to?(:localized_number)
+          formatter.localized_number(value.to_s)
+        else
+          value
+        end
       end
     end
   end

--- a/lib/plurimath/math/number.rb
+++ b/lib/plurimath/math/number.rb
@@ -92,9 +92,10 @@ module Plurimath
       end
 
       def format_value_with_options(options)
-        return value unless options[:formatter]&.respond_to?(:localized_number)
+        formatter = options[:formatter]
+        return value unless formatter&.respond_to?(:localized_number)
 
-        options[:formatter].localized_number(value.to_s)
+        formatter.format(options[:formula], self)
       end
     end
   end

--- a/lib/plurimath/math/number.rb
+++ b/lib/plurimath/math/number.rb
@@ -95,9 +95,10 @@ module Plurimath
       end
 
       def format_value_with_options(options)
-        return value unless options[:formatter]&.respond_to?(:localized_number)
+        formatter = options[:formatter]
+        return value unless formatter&.respond_to?(:localized_number)
 
-        options[:formatter].localized_number(value.to_s)
+        formatter.format(options[:formula], self)
       end
     end
   end

--- a/lib/plurimath/math/number.rb
+++ b/lib/plurimath/math/number.rb
@@ -96,9 +96,13 @@ module Plurimath
 
       def format_value_with_options(options)
         formatter = options[:formatter]
-        return value unless formatter&.respond_to?(:localized_number)
-
-        formatter.format(options[:formula], self)
+        if formatter&.respond_to?(:format)
+          formatter.format(options[:formula], self)
+        elsif formatter&.respond_to?(:localized_number)
+          formatter.localized_number(value.to_s)
+        else
+          value
+        end
       end
     end
   end

--- a/lib/plurimath/number_formatter.rb
+++ b/lib/plurimath/number_formatter.rb
@@ -12,6 +12,12 @@ module Plurimath
       @precision = precision
     end
 
+    # Override in subclasses for contextual number formatting.
+    # Receives the root formula tree and the current number node being formatted.
+    def format(_formula, number)
+      localized_number(number.value.to_s)
+    end
+
     def localized_number(number_string, locale: @locale, precision: @precision, format: {})
       prev_symbols = symbols(locale.to_sym).dup
       Formatter::NumericFormatter.new(

--- a/lib/plurimath/number_formatter.rb
+++ b/lib/plurimath/number_formatter.rb
@@ -13,12 +13,6 @@ module Plurimath
       @precision = precision
     end
 
-    # Override in subclasses for contextual number formatting.
-    # Receives the root formula tree and the current number node being formatted.
-    def format(_formula, number)
-      localized_number(number.value.to_s)
-    end
-
     def localized_number(number_string, locale: @locale, precision: @precision, format: {})
       prev_symbols = symbols(locale.to_sym).dup
       Formatter::NumericFormatter.new(

--- a/lib/plurimath/number_formatter.rb
+++ b/lib/plurimath/number_formatter.rb
@@ -13,6 +13,12 @@ module Plurimath
       @precision = precision
     end
 
+    # Override in subclasses for contextual number formatting.
+    # Receives the root formula tree and the current number node being formatted.
+    def format(_formula, number)
+      localized_number(number.value.to_s)
+    end
+
     def localized_number(number_string, locale: @locale, precision: @precision, format: {})
       prev_symbols = symbols(locale.to_sym).dup
       Formatter::NumericFormatter.new(

--- a/lib/plurimath/number_formatter.rb
+++ b/lib/plurimath/number_formatter.rb
@@ -12,12 +12,6 @@ module Plurimath
       @precision = precision
     end
 
-    # Override in subclasses for contextual number formatting.
-    # Receives the root formula tree and the current number node being formatted.
-    def format(_formula, number)
-      localized_number(number.value.to_s)
-    end
-
     def localized_number(number_string, locale: @locale, precision: @precision, format: {})
       prev_symbols = symbols(locale.to_sym).dup
       Formatter::NumericFormatter.new(

--- a/spec/plurimath/math/formula_spec.rb
+++ b/spec/plurimath/math/formula_spec.rb
@@ -1301,60 +1301,58 @@ RSpec.describe Plurimath::Math::Formula do
         Plurimath::Math::Number.new("1000000"),
       ]
     end
+    let(:formula_obj) { described_class.new(exp) }
 
     describe "formatter receives formula and number node" do
-      it "passes the root formula and number nodes to format" do
-        received_formula = nil
-        received_numbers = []
-        spy = SpyFormatter.new(
+      let(:received_formula) { [] }
+      let(:received_numbers) { [] }
+      let(:spy) do
+        SpyFormatter.new(
           on_format: proc { |formula, number|
-            received_formula = formula
+            received_formula << formula
             received_numbers << number
           }
         )
-        formula_obj = described_class.new(exp)
+      end
+
+      it "passes the root formula and number nodes to format" do
         formula_obj.to_latex(formatter: spy)
 
-        expect(received_formula).to be_a(Plurimath::Math::Formula)
-        expect(received_formula).to eq(formula_obj)
-        expect(received_numbers.length).to eq(2)
-        expect(received_numbers[0]).to be_a(Plurimath::Math::Number)
-        expect(received_numbers[0].value).to eq("2024")
+        expect(received_formula.first).to be_a(Plurimath::Math::Formula)
+        expect(received_formula.first).to eq(formula_obj)
+        expect(received_numbers.first).to be_a(Plurimath::Math::Number)
+        expect(received_numbers.first.value).to eq("2024")
         expect(received_numbers[1].value).to eq("1000000")
       end
 
-      it "passes the formula across all text output formats" do
-        %i[to_latex to_asciimath to_html to_unicodemath].each do |method|
-          received_formula = nil
-          spy = SpyFormatter.new(
-            on_format: proc { |formula, _| received_formula = formula }
-          )
-          formula_obj = described_class.new(exp)
-          formula_obj.send(method, formatter: spy)
+      it "passes the formula via to_latex" do
+        formula_obj.to_latex(formatter: spy)
+        expect(received_formula.first).to eq(formula_obj)
+      end
 
-          expect(received_formula).to eq(formula_obj),
-            "Expected #{method} to pass formula"
-        end
+      it "passes the formula via to_asciimath" do
+        formula_obj.to_asciimath(formatter: spy)
+        expect(received_formula.first).to eq(formula_obj)
+      end
+
+      it "passes the formula via to_html" do
+        formula_obj.to_html(formatter: spy)
+        expect(received_formula.first).to eq(formula_obj)
+      end
+
+      it "passes the formula via to_unicodemath" do
+        formula_obj.to_unicodemath(formatter: spy)
+        expect(received_formula.first).to eq(formula_obj)
       end
 
       it "passes the formula via to_mathml" do
-        received_formula = nil
-        spy = SpyFormatter.new(
-          on_format: proc { |formula, _| received_formula = formula }
-        )
-        formula_obj = described_class.new(exp)
         formula_obj.to_mathml(formatter: spy)
-        expect(received_formula).to eq(formula_obj)
+        expect(received_formula.first).to eq(formula_obj)
       end
 
       it "passes the formula via to_omml" do
-        received_formula = nil
-        spy = SpyFormatter.new(
-          on_format: proc { |formula, _| received_formula = formula }
-        )
-        formula_obj = described_class.new(exp)
         formula_obj.to_omml(formatter: spy)
-        expect(received_formula).to eq(formula_obj)
+        expect(received_formula.first).to eq(formula_obj)
       end
     end
 
@@ -1362,7 +1360,6 @@ RSpec.describe Plurimath::Math::Formula do
       let(:year_formatter) { YearFormatter.new }
 
       it "skips formatting for year-like numbers" do
-        formula_obj = described_class.new(exp)
         result = formula_obj.to_latex(formatter: year_formatter)
         expect(result).to eq("2024 + 1,000,000")
       end
@@ -1390,7 +1387,6 @@ RSpec.describe Plurimath::Math::Formula do
     describe "default formatter backward compatibility" do
       it "formats numbers using localized_number when format is not defined" do
         formatter = Plurimath::Formatter::Standard.new
-        formula_obj = described_class.new(exp)
         result = formula_obj.to_latex(formatter: formatter)
         expect(result).to eq("2,024 + 1,000,000")
       end

--- a/spec/plurimath/math/formula_spec.rb
+++ b/spec/plurimath/math/formula_spec.rb
@@ -1292,6 +1292,110 @@ RSpec.describe Plurimath::Math::Formula do
       end
     end
   end
+
+  context "contextual number formatting (issue #294)" do
+    let(:exp) do
+      [
+        Plurimath::Math::Number.new("2024"),
+        Plurimath::Math::Symbols::Symbol.new("+"),
+        Plurimath::Math::Number.new("1000000"),
+      ]
+    end
+
+    describe "formatter receives formula and number node" do
+      it "passes the root formula and number nodes to format" do
+        received_formula = nil
+        received_numbers = []
+        spy = SpyFormatter.new(
+          on_format: proc { |formula, number|
+            received_formula = formula
+            received_numbers << number
+          }
+        )
+        formula_obj = described_class.new(exp)
+        formula_obj.to_latex(formatter: spy)
+
+        expect(received_formula).to be_a(Plurimath::Math::Formula)
+        expect(received_formula).to eq(formula_obj)
+        expect(received_numbers.length).to eq(2)
+        expect(received_numbers[0]).to be_a(Plurimath::Math::Number)
+        expect(received_numbers[0].value).to eq("2024")
+        expect(received_numbers[1].value).to eq("1000000")
+      end
+
+      it "passes the formula across all text output formats" do
+        %i[to_latex to_asciimath to_html to_unicodemath].each do |method|
+          received_formula = nil
+          spy = SpyFormatter.new(
+            on_format: proc { |formula, _| received_formula = formula }
+          )
+          formula_obj = described_class.new(exp)
+          formula_obj.send(method, formatter: spy)
+
+          expect(received_formula).to eq(formula_obj),
+            "Expected #{method} to pass formula"
+        end
+      end
+
+      it "passes the formula via to_mathml" do
+        received_formula = nil
+        spy = SpyFormatter.new(
+          on_format: proc { |formula, _| received_formula = formula }
+        )
+        formula_obj = described_class.new(exp)
+        formula_obj.to_mathml(formatter: spy)
+        expect(received_formula).to eq(formula_obj)
+      end
+
+      it "passes the formula via to_omml" do
+        received_formula = nil
+        spy = SpyFormatter.new(
+          on_format: proc { |formula, _| received_formula = formula }
+        )
+        formula_obj = described_class.new(exp)
+        formula_obj.to_omml(formatter: spy)
+        expect(received_formula).to eq(formula_obj)
+      end
+    end
+
+    describe "year formatter example from issue #294" do
+      let(:year_formatter) { YearFormatter.new }
+
+      it "skips formatting for year-like numbers" do
+        formula_obj = described_class.new(exp)
+        result = formula_obj.to_latex(formatter: year_formatter)
+        expect(result).to eq("2024 + 1,000,000")
+      end
+
+      it "formats all numbers when none are years" do
+        non_year_exp = [
+          Plurimath::Math::Number.new("50000"),
+          Plurimath::Math::Symbols::Symbol.new("+"),
+          Plurimath::Math::Number.new("1000000"),
+        ]
+        formula_obj = described_class.new(non_year_exp)
+        result = formula_obj.to_latex(formatter: year_formatter)
+        expect(result).to eq("50,000 + 1,000,000")
+      end
+
+      it "handles boundary values correctly" do
+        { "1800" => "1,800", "1801" => "1801", "2199" => "2199", "2200" => "2,200" }.each do |input, expected|
+          formula_obj = described_class.new([Plurimath::Math::Number.new(input)])
+          result = formula_obj.to_latex(formatter: year_formatter)
+          expect(result).to eq(expected), "Expected #{input} -> #{expected}, got #{result}"
+        end
+      end
+    end
+
+    describe "default formatter backward compatibility" do
+      it "formats numbers using the default format method" do
+        formatter = Plurimath::Formatter::Standard.new
+        formula_obj = described_class.new(exp)
+        result = formula_obj.to_latex(formatter: formatter)
+        expect(result).to eq("2,024 + 1,000,000")
+      end
+    end
+  end
 end
 
 class CustomFormatter < Plurimath::Formatter::Standard
@@ -1302,4 +1406,27 @@ class CustomFormatter < Plurimath::Formatter::Standard
     decimal: "^",
     group: ">",
   }.freeze
+end
+
+class YearFormatter < Plurimath::Formatter::Standard
+  def format(formula, number)
+    int_value = Integer(number.value, exception: false)
+    if int_value && int_value > 1800 && int_value < 2200
+      number.value.to_s
+    else
+      super
+    end
+  end
+end
+
+class SpyFormatter < Plurimath::Formatter::Standard
+  def initialize(on_format: nil)
+    super()
+    @on_format = on_format
+  end
+
+  def format(formula, number)
+    @on_format&.call(formula, number)
+    super
+  end
 end

--- a/spec/plurimath/math/formula_spec.rb
+++ b/spec/plurimath/math/formula_spec.rb
@@ -1388,7 +1388,7 @@ RSpec.describe Plurimath::Math::Formula do
     end
 
     describe "default formatter backward compatibility" do
-      it "formats numbers using the default format method" do
+      it "formats numbers using localized_number when format is not defined" do
         formatter = Plurimath::Formatter::Standard.new
         formula_obj = described_class.new(exp)
         result = formula_obj.to_latex(formatter: formatter)
@@ -1414,7 +1414,7 @@ class YearFormatter < Plurimath::Formatter::Standard
     if int_value && int_value > 1800 && int_value < 2200
       number.value.to_s
     else
-      super
+      localized_number(number.value.to_s)
     end
   end
 end
@@ -1427,6 +1427,6 @@ class SpyFormatter < Plurimath::Formatter::Standard
 
   def format(formula, number)
     @on_format&.call(formula, number)
-    super
+    localized_number(number.value.to_s)
   end
 end

--- a/spec/plurimath/omml_spec.rb
+++ b/spec/plurimath/omml_spec.rb
@@ -121,7 +121,6 @@ RSpec.describe Plurimath::Omml do
       end
 
       it 'converts `alpha`, `α` to `&#x3b1;`' do
-        skip "Lutaml::Model::XmlAdapter::Oga doesn't support HTML Entities yet!" if Lutaml::Model::Config.xml_adapter.type == "oga"
         formula = Plurimath::Math.parse(input, :mathml)
         expect(formula.to_omml).to eq(expected_output)
       end
@@ -554,7 +553,6 @@ RSpec.describe Plurimath::Omml do
       end
 
       it 'converts `alpha`, `α` to `&#x3b1;`' do
-        skip "Lutaml::Model::XmlAdapter::Oga doesn't support HTML Entities yet!" if Lutaml::Model::Config.xml_adapter.type == "oga"
         formula = Plurimath::Math.parse(input, :mathml)
         expect(formula.to_omml).to eq(expected_output)
       end


### PR DESCRIPTION
This PR adds a `format(formula, number)` method to `NumberFormatter` that passes both the root Formula tree and the current Number node to the formatter.
This allows custom formatters to inspect the surrounding formula context when deciding how to format a number — for example, skipping digit grouping for year-like values while still formatting other numbers normally.

closes #294 