### PR TITLE
Temporarily set cache default to true to isolate timing regression

### DIFF
--- a/lib/plurimath/math.rb
+++ b/lib/plurimath/math.rb
@@ -40,7 +40,7 @@ module Plurimath
 
     FORMULA_CACHE = Hash.new { |h, k| h[k] = {} }
 
-    def parse(text, type, cache: false)
+    def parse(text, type, cache: true)
       raise InvalidTypeError.new unless valid_type?(type)
 
       if cache && FORMULA_CACHE[type].key?(text)

--- a/spec/plurimath/math_spec.rb
+++ b/spec/plurimath/math_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Plurimath::Math do
     let(:input) { "x + y" }
     let(:type) { :asciimath }
 
-    context "contains cache option set to false (default)" do
+    context "contains cache option set to true (default)" do
       it "returns independent formula objects for same input" do
         f1 = Plurimath::Math.parse(input, type)
         f2 = Plurimath::Math.parse(input, type)
@@ -67,38 +67,38 @@ RSpec.describe Plurimath::Math do
         expect(f1).to eq(f2)
       end
 
-      it "does not populate the formula cache" do
-        Plurimath::Math.parse(input, type)
-        expect(Plurimath::Math::FORMULA_CACHE[type]).to be_empty
-      end
-    end
-
-    context "contains cache option set to true" do
-      it "returns independent formula objects for same input" do
-        f1 = Plurimath::Math.parse(input, type, cache: true)
-        f2 = Plurimath::Math.parse(input, type, cache: true)
-        expect(f1).not_to equal(f2)
-        expect(f1).to eq(f2)
-      end
-
       it "populates the formula cache" do
-        Plurimath::Math.parse(input, type, cache: true)
+        Plurimath::Math.parse(input, type)
         expect(Plurimath::Math::FORMULA_CACHE[type]).not_to be_empty
       end
 
       it "protects cache from mutation by first caller" do
-        f1 = Plurimath::Math.parse("a^2", :latex, cache: true)
+        f1 = Plurimath::Math.parse("a^2", :latex)
         f1.value.clear
-        f2 = Plurimath::Math.parse("a^2", :latex, cache: true)
+        f2 = Plurimath::Math.parse("a^2", :latex)
         expect(f2.value).not_to be_empty
       end
 
       it "protects cache from mutation by cache-hit caller" do
-        Plurimath::Math.parse("a^2", :latex, cache: true)
-        f2 = Plurimath::Math.parse("a^2", :latex, cache: true)
+        Plurimath::Math.parse("a^2", :latex)
+        f2 = Plurimath::Math.parse("a^2", :latex)
         f2.value.clear
-        f3 = Plurimath::Math.parse("a^2", :latex, cache: true)
+        f3 = Plurimath::Math.parse("a^2", :latex)
         expect(f3.value).not_to be_empty
+      end
+    end
+
+    context "contains cache option set to false" do
+      it "returns independent formula objects for same input" do
+        f1 = Plurimath::Math.parse(input, type, cache: false)
+        f2 = Plurimath::Math.parse(input, type, cache: false)
+        expect(f1).not_to equal(f2)
+        expect(f1).to eq(f2)
+      end
+
+      it "does not populate the formula cache" do
+        Plurimath::Math.parse(input, type, cache: false)
+        expect(Plurimath::Math::FORMULA_CACHE[type]).to be_empty
       end
     end
   end
@@ -107,7 +107,7 @@ RSpec.describe Plurimath::Math do
     before { Plurimath::Math::FORMULA_CACHE.clear }
 
     it "empties the formula cache" do
-      Plurimath::Math.parse("x + y", :asciimath, cache: true)
+      Plurimath::Math.parse("x + y", :asciimath)
       expect(Plurimath::Math::FORMULA_CACHE).not_to be_empty
 
       Plurimath::Math.clear_cache!
@@ -115,9 +115,9 @@ RSpec.describe Plurimath::Math do
     end
 
     it "forces re-parsing after cache is cleared" do
-      f1 = Plurimath::Math.parse("a^2", :latex, cache: true)
+      f1 = Plurimath::Math.parse("a^2", :latex)
       Plurimath::Math.clear_cache!
-      f2 = Plurimath::Math.parse("a^2", :latex, cache: true)
+      f2 = Plurimath::Math.parse("a^2", :latex)
       expect(f1).not_to equal(f2)
       expect(f1).to eq(f2)
     end


### PR DESCRIPTION
Temporarily sets the cache default to true to confirm that the `cache: false` default introduced during review is the source of the 3-5 minute per-job CI regression. This change will be reverted once timing is verified — the final PR will ship with `cache: false` as the default.