### PR TITLE
Fix: release workflow permissions for trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ on:
 
 jobs:
   release:
+    permissions:
+      contents: write
+      id-token: write
     uses: metanorma/ci/.github/workflows/rubygems-release.yml@main
     with:
       next_version: ${{ github.event.inputs.next_version }}


### PR DESCRIPTION
This PR adds `id-token: write` and `contents: write` permissions to the release job, required by the reusable `metanorma/ci` `rubygems-release` workflow.