### PR TITLE
Fix significant digit formatting for base conversion

### DIFF
--- a/lib/plurimath/formatter/numeric_formatter.rb
+++ b/lib/plurimath/formatter/numeric_formatter.rb
@@ -127,6 +127,8 @@ module Plurimath
       # When precision is omitted, infer the target-base fractional digits
       # needed to satisfy :significant. Cap the count to the source significant
       # digits so base conversion does not invent precision for values like 0.1.
+      # Add one extra digit when the source has more significant digits so
+      # Significant can still perform the final rounding pass.
       def significant_base_precision(num, format)
         base = format[:base] || Formatter::NumberFormatter::DEFAULT_BASE
         return unless target_base?(base)
@@ -134,19 +136,17 @@ module Plurimath
         significant = format[:significant].to_i
         return if significant.zero?
 
-        decimal_precision = source_fractional_digits(num)
-        return 0 if decimal_precision.zero?
+        return 0 unless source_fractional?(num)
 
-        effective_significant = [
-          significant,
-          source_significant_digits(num),
-        ].min
+        source_significant = source_significant_digits(num)
+        effective_significant = [significant, source_significant].min
         target_precision = [
           effective_significant - target_base_integer_length(num, base),
           0,
         ].max
 
-        [decimal_precision, target_precision].max
+        target_precision += 1 if source_significant > effective_significant
+        target_precision
       end
 
       def target_base?(base)
@@ -154,11 +154,11 @@ module Plurimath
           base != Formatter::NumberFormatter::DEFAULT_BASE
       end
 
-      def source_fractional_digits(num)
+      def source_fractional?(num)
         mantissa, exponent = num.to_s.downcase.split("e", 2)
         fraction_length = mantissa.split(".", 2)[1].to_s.length
 
-        [fraction_length - exponent.to_i, 0].max
+        fraction_length > exponent.to_i
       end
 
       def source_significant_digits(num)

--- a/lib/plurimath/formatter/numeric_formatter.rb
+++ b/lib/plurimath/formatter/numeric_formatter.rb
@@ -106,18 +106,68 @@ module Plurimath
         @e = format[:e]&.to_sym || :e
         @times = format[:times]&.to_sym || "\u{d7}"
         @notation = format[:notation]&.to_sym || nil
-        @precision = update_precision(string, precision)
+        @precision = update_precision(string, precision, format)
         @exponent_sign = format[:exponent_sign]&.to_sym || nil
       end
 
-      def update_precision(num, precision)
+      def update_precision(num, precision, format)
         return precision if precision
+
+        significant_precision = significant_base_precision(num, format)
+        return significant_precision if significant_precision
+
         if SUPPORTED_NOTATIONS.include?(@notation&.to_sym)
           return num.sub(".",
                          "").size - 1
         end
 
         num.include?(".") ? num.sub(/^.*\./, "").size : 0
+      end
+
+      def significant_base_precision(num, format)
+        base = format[:base] || Formatter::NumberFormatter::DEFAULT_BASE
+        return unless target_base?(base)
+
+        significant = format[:significant].to_i
+        return if significant.zero?
+
+        decimal_precision = source_fractional_digits(num)
+        return 0 if decimal_precision.zero?
+
+        effective_significant = [
+          significant,
+          source_significant_digits(num),
+        ].min
+        target_precision = [
+          effective_significant - target_base_integer_length(num, base),
+          0,
+        ].max
+
+        [decimal_precision, target_precision].max
+      end
+
+      def target_base?(base)
+        Formatter::NumberFormatter::DEFAULT_BASE_PREFIXES.key?(base) &&
+          base != Formatter::NumberFormatter::DEFAULT_BASE
+      end
+
+      def source_fractional_digits(num)
+        mantissa, exponent = num.to_s.downcase.split("e", 2)
+        fraction_length = mantissa.split(".", 2)[1].to_s.length
+
+        [fraction_length - exponent.to_i, 0].max
+      end
+
+      def source_significant_digits(num)
+        mantissa = num.to_s.downcase.split("e", 2).first
+        mantissa.sub(/\A[-+]/, "").delete(".").sub(/\A0+/, "").length
+      end
+
+      def target_base_integer_length(num, base)
+        integer = BigDecimal(num).abs.to_i
+        return 0 if integer.zero?
+
+        integer.to_s(base).length
       end
 
       def update_string_index(chars, index)

--- a/lib/plurimath/formatter/numeric_formatter.rb
+++ b/lib/plurimath/formatter/numeric_formatter.rb
@@ -124,6 +124,9 @@ module Plurimath
         num.include?(".") ? num.sub(/^.*\./, "").size : 0
       end
 
+      # When precision is omitted, infer the target-base fractional digits
+      # needed to satisfy :significant. Cap the count to the source significant
+      # digits so base conversion does not invent precision for values like 0.1.
       def significant_base_precision(num, format)
         base = format[:base] || Formatter::NumberFormatter::DEFAULT_BASE
         return unless target_base?(base)

--- a/spec/plurimath/number_formatter_spec.rb
+++ b/spec/plurimath/number_formatter_spec.rb
@@ -1319,6 +1319,62 @@ RSpec.describe Plurimath::NumberFormatter do
         end
       end
 
+      context "base conversion with significant digits and inferred precision" do
+        it "pads finite converted fractions to the requested significant count" do
+          format = base_format_defaults.merge(
+            base: 16,
+            significant: 5,
+            group_digits: 10,
+            decimal: "."
+          )
+
+          output_string = formatter.localized_number("123.25", format: format)
+          expect(output_string).to eql("0x7b.400")
+        end
+
+        it "does not use E-notation suffix characters as fractional precision" do
+          format = base_format_defaults.merge(
+            base: 16,
+            significant: 5,
+            group_digits: 10,
+            decimal: "."
+          )
+
+          output_string = formatter.localized_number("0.123e3", format: format)
+          expect(output_string).to eql("0x7b")
+        end
+
+        it "keeps the issue 417 reproducer and explicit precision workaround" do
+          format = base_format_defaults.merge(
+            base: 16,
+            significant: 5,
+            group_digits: 10,
+            decimal: "."
+          )
+
+          expect(formatter.localized_number("0.12325e3", format: format)).to eql("0x7b.400")
+          expect(
+            formatter.localized_number(
+              "0.12325e3",
+              precision: 3,
+              format: format
+            )
+          ).to eql("0x7b.400")
+        end
+
+        it "does not expand repeating conversions beyond source significant digits" do
+          format = base_format_defaults.merge(
+            base: 16,
+            significant: 5,
+            group_digits: 10,
+            decimal: "."
+          )
+
+          output_string = formatter.localized_number("0.1", format: format)
+          expect(output_string).to eql("0x0.1")
+        end
+      end
+
       context "base conversion with notation :basic" do
         it "applies base conversion when notation is explicitly :basic" do
           output_string = formatter.localized_number("255",

--- a/spec/plurimath/number_formatter_spec.rb
+++ b/spec/plurimath/number_formatter_spec.rb
@@ -1373,6 +1373,30 @@ RSpec.describe Plurimath::NumberFormatter do
           output_string = formatter.localized_number("0.1", format: format)
           expect(output_string).to eql("0x0.1")
         end
+
+        it "bounds inferred precision for negative scientific exponents" do
+          format = base_format_defaults.merge(
+            base: 16,
+            significant: 1,
+            group_digits: 10,
+            decimal: "."
+          )
+
+          output_string = formatter.localized_number("1e-1000", format: format)
+          expect(output_string).to eql("0x0.0")
+        end
+
+        it "rounds up when source has more significant digits than requested" do
+          format = base_format_defaults.merge(
+            base: 16,
+            significant: 3,
+            group_digits: 10,
+            decimal: "."
+          )
+
+          output_string = formatter.localized_number("1.999", format: format)
+          expect(output_string).to eql("0x2")
+        end
       end
 
       context "base conversion with notation :basic" do


### PR DESCRIPTION
This PR fixes number formatting when converting values to another base with significant digits enabled. It preserves the expected trailing zeros for fractional values and adds regression specs for the reported issue.

closes #417 