### PR TITLE
Handle `nil` number formatter in Opal

### DIFF
--- a/lib/plurimath/math/number.rb
+++ b/lib/plurimath/math/number.rb
@@ -94,6 +94,8 @@ module Plurimath
 
       def format_value_with_options(options)
         formatter = options[:formatter]
+        return value unless formatter
+
         if formatter.respond_to?(:format)
           formatter.format(options[:formula], self)
         elsif formatter.respond_to?(:localized_number)

--- a/spec/plurimath/math/number_spec.rb
+++ b/spec/plurimath/math/number_spec.rb
@@ -29,6 +29,23 @@ RSpec.describe Plurimath::Math::Number do
     end
   end
 
+  describe "nil formatter handling" do
+    subject(:number) { described_class.new("42") }
+    let(:nil_options) { { formatter: nil } }
+
+    it "returns value from to_latex" do
+      expect(number.to_latex(options: nil_options)).to eq("42")
+    end
+
+    it "returns value from to_html" do
+      expect(number.to_html(options: nil_options)).to eq("42")
+    end
+
+    it "returns value from to_unicodemath" do
+      expect(number.to_unicodemath(options: nil_options)).to eq("42")
+    end
+  end
+
   describe ".==" do
     subject(:number) { described_class.new(value) }
 

--- a/spec/plurimath/math/number_spec.rb
+++ b/spec/plurimath/math/number_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe Plurimath::Math::Number do
       it "returns string" do
         expect(number.to_asciimath(options: {})).to eq(value)
       end
+
+      it "returns string when formatter is nil" do
+        expect(number.to_asciimath(options: { formatter: nil })).to eq(value)
+      end
     end
   end
 


### PR DESCRIPTION
Handles `nil` number formatters explicitly before checking formatter capabilities.

In Opal, nil can report support for `Kernel#format` differently than MRI, which causes number formatting to dispatch into `Kernel#format` and fail in generated JavaScript bundles. This keeps the MRI behavior intact while avoiding the Opal runtime failure.
