### PR TITLE
Add configuration and deprecation foundation

### DIFF
--- a/lib/plurimath.rb
+++ b/lib/plurimath.rb
@@ -8,6 +8,11 @@ require "plurimath/xml_engine"
 module Plurimath
   autoload :Asciimath, "plurimath/asciimath"
   autoload :Cli, "plurimath/cli" unless RUBY_ENGINE == "opal"
+  autoload :Configuration, "plurimath/configuration"
+  autoload :Deprecation, "plurimath/deprecation"
+  autoload :Error, "plurimath/errors/error"
+  autoload :ConfigurationError, "plurimath/errors/configuration_error"
+  autoload :DeprecationError, "plurimath/errors/deprecation_error"
   autoload :Formatter, "plurimath/formatter"
   autoload :Html, "plurimath/html"
   autoload :Latex, "plurimath/latex"
@@ -28,7 +33,15 @@ module Plurimath
     Mml::V4::Configuration.adapter = adapter unless Mml::V4::Configuration.adapter
   end
 
-  module_function :mml_adapter
+  def configuration
+    @configuration ||= Configuration.new
+  end
+
+  def configure
+    yield(configuration)
+  end
+
+  module_function :mml_adapter, :configuration, :configure
 end
 
 default_adapter =

--- a/lib/plurimath/configuration.rb
+++ b/lib/plurimath/configuration.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Plurimath
+  class Configuration
+    attr_accessor :number_formatter
+
+    def deprecation
+      Deprecation
+    end
+  end
+end

--- a/lib/plurimath/deprecation.rb
+++ b/lib/plurimath/deprecation.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module Plurimath
+  module Deprecation
+    BEHAVIORS = %i[warn raise silence].freeze
+    DEFAULT_BEHAVIOR = :warn
+
+    class << self
+      def warn(feature:, message: nil, replacement: nil, since: nil, remove_in: nil)
+        feature = validate_feature(feature)
+        return if behavior == :warn && emitted_features[feature]
+
+        emit(
+          feature: feature,
+          message: message,
+          replacement: replacement,
+          since: since,
+          remove_in: remove_in,
+        )
+      end
+
+      def behavior
+        @behavior ||= DEFAULT_BEHAVIOR
+      end
+
+      def behavior=(behavior)
+        @behavior = validate_behavior(behavior)
+      end
+
+      private
+
+      def emit(feature:, message:, replacement:, since:, remove_in:)
+        case behavior
+        when :silence
+          nil
+        when :raise
+          raise DeprecationError.new(
+            feature: feature,
+            message: message,
+            replacement: replacement,
+            since: since,
+            remove_in: remove_in,
+          )
+        when :warn
+          error = DeprecationError.new(
+            feature: feature,
+            message: message,
+            replacement: replacement,
+            since: since,
+            remove_in: remove_in,
+          )
+          Kernel.warn(error.message)
+          emitted_features[feature] = true
+        end
+      end
+
+      def emitted_features
+        @emitted_features ||= {}
+      end
+
+      def validate_behavior(behavior)
+        return behavior if BEHAVIORS.include?(behavior)
+
+        raise ConfigurationError.new(
+          :unsupported_deprecation_behavior,
+          value: behavior,
+          supported: BEHAVIORS,
+        )
+      end
+
+      def validate_feature(feature)
+        feature = feature.to_s
+        return feature unless feature.empty?
+
+        raise ConfigurationError.new(:missing_deprecation_feature)
+      end
+    end
+  end
+end

--- a/lib/plurimath/deprecation.rb
+++ b/lib/plurimath/deprecation.rb
@@ -2,21 +2,30 @@
 
 module Plurimath
   module Deprecation
-    BEHAVIORS = %i[warn raise silence].freeze
-    DEFAULT_BEHAVIOR = :warn
+    BEHAVIORS = %i[collect raise silence].freeze
+    DEFAULT_BEHAVIOR = :collect
 
     class << self
       def warn(feature:, message: nil, replacement: nil, since: nil, remove_in: nil)
         feature = validate_feature(feature)
-        return if behavior == :warn && emitted_features[feature]
+        return if behavior == :collect && emitted_features[feature]
 
-        emit(
+        notice = build_notice(
           feature: feature,
           message: message,
           replacement: replacement,
           since: since,
           remove_in: remove_in,
         )
+
+        case behavior
+        when :silence
+          nil
+        when :raise
+          raise notice
+        when :collect
+          emitted_features[feature] = notice
+        end
       end
 
       def behavior
@@ -27,31 +36,24 @@ module Plurimath
         @behavior = validate_behavior(behavior)
       end
 
+      def notices
+        emitted_features.values
+      end
+
+      def clear!
+        @emitted_features = {}
+      end
+
       private
 
-      def emit(feature:, message:, replacement:, since:, remove_in:)
-        case behavior
-        when :silence
-          nil
-        when :raise
-          raise DeprecationError.new(
-            feature: feature,
-            message: message,
-            replacement: replacement,
-            since: since,
-            remove_in: remove_in,
-          )
-        when :warn
-          error = DeprecationError.new(
-            feature: feature,
-            message: message,
-            replacement: replacement,
-            since: since,
-            remove_in: remove_in,
-          )
-          Kernel.warn(error.message)
-          emitted_features[feature] = true
-        end
+      def build_notice(feature:, message:, replacement:, since:, remove_in:)
+        DeprecationError.new(
+          feature: feature,
+          message: message,
+          replacement: replacement,
+          since: since,
+          remove_in: remove_in,
+        )
       end
 
       def emitted_features

--- a/lib/plurimath/errors/configuration_error.rb
+++ b/lib/plurimath/errors/configuration_error.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Plurimath
+  class ConfigurationError < Error
+    def initialize(type, value: nil, supported: nil)
+      @type = type
+      @value = value
+      @supported = supported
+      super(message)
+    end
+
+    def message
+      case @type
+      when :unsupported_deprecation_behavior
+        "unsupported deprecation behavior: #{@value.inspect}; " \
+        "expected one of #{@supported.inspect}"
+      when :missing_deprecation_feature
+        "deprecation feature must be provided"
+      else
+        "invalid Plurimath configuration"
+      end
+    end
+  end
+end

--- a/lib/plurimath/errors/deprecation_error.rb
+++ b/lib/plurimath/errors/deprecation_error.rb
@@ -2,28 +2,31 @@
 
 module Plurimath
   class DeprecationError < Error
+    SEVERITY = :warning
+
+    attr_reader :feature, :replacement, :since, :remove_in
+
     def initialize(feature:, message: nil, replacement: nil, since: nil, remove_in: nil)
-      super(
-        build_message(
-          feature: feature,
-          message: message,
-          replacement: replacement,
-          since: since,
-          remove_in: remove_in,
-        ),
-      )
+      @feature = feature
+      @replacement = replacement
+      @since = since
+      @remove_in = remove_in
+      @user_message = message
+      super(to_s)
     end
 
-    private
+    def severity
+      SEVERITY
+    end
 
-    def build_message(feature:, message:, replacement:, since:, remove_in:)
+    def to_s
       deprecation = "[plurimath][DEPRECATION] #{feature} is deprecated"
       deprecation = "#{deprecation} since #{since}" if since
       deprecation = "#{deprecation} and will be removed in #{remove_in}" if remove_in
 
       parts = [deprecation]
       parts << "Use #{replacement} instead" if replacement
-      parts << message if message
+      parts << @user_message if @user_message
       "#{parts.join('. ')}."
     end
   end

--- a/lib/plurimath/errors/deprecation_error.rb
+++ b/lib/plurimath/errors/deprecation_error.rb
@@ -3,23 +3,28 @@
 module Plurimath
   class DeprecationError < Error
     def initialize(feature:, message: nil, replacement: nil, since: nil, remove_in: nil)
-      @feature = feature
-      @message = message
-      @replacement = replacement
-      @since = since
-      @remove_in = remove_in
-      super(message)
+      super(
+        build_message(
+          feature: feature,
+          message: message,
+          replacement: replacement,
+          since: since,
+          remove_in: remove_in,
+        ),
+      )
     end
 
-    def message
-      parts = ["[plurimath][DEPRECATION] #{@feature} is deprecated"]
-      parts << "since #{@since}" if @since
-      parts << "and will be removed in #{@remove_in}" if @remove_in
-      parts << "Use #{@replacement} instead" if @replacement
-      parts << @message if @message
-      message = parts.join(". ")
-      message << "."
-      message
+    private
+
+    def build_message(feature:, message:, replacement:, since:, remove_in:)
+      deprecation = "[plurimath][DEPRECATION] #{feature} is deprecated"
+      deprecation = "#{deprecation} since #{since}" if since
+      deprecation = "#{deprecation} and will be removed in #{remove_in}" if remove_in
+
+      parts = [deprecation]
+      parts << "Use #{replacement} instead" if replacement
+      parts << message if message
+      "#{parts.join('. ')}."
     end
   end
 end

--- a/lib/plurimath/errors/deprecation_error.rb
+++ b/lib/plurimath/errors/deprecation_error.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Plurimath
+  class DeprecationError < Error
+    def initialize(feature:, message: nil, replacement: nil, since: nil, remove_in: nil)
+      @feature = feature
+      @message = message
+      @replacement = replacement
+      @since = since
+      @remove_in = remove_in
+      super(message)
+    end
+
+    def message
+      parts = ["[plurimath][DEPRECATION] #{@feature} is deprecated"]
+      parts << "since #{@since}" if @since
+      parts << "and will be removed in #{@remove_in}" if @remove_in
+      parts << "Use #{@replacement} instead" if @replacement
+      parts << @message if @message
+      message = parts.join(". ")
+      message << "."
+      message
+    end
+  end
+end

--- a/lib/plurimath/errors/error.rb
+++ b/lib/plurimath/errors/error.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Plurimath
+  class Error < StandardError
+  end
+end

--- a/lib/plurimath/errors/formatter/unsupported_base.rb
+++ b/lib/plurimath/errors/formatter/unsupported_base.rb
@@ -2,7 +2,7 @@
 
 module Plurimath
   module Formatter
-    class UnsupportedBase < StandardError
+    class UnsupportedBase < Plurimath::Error
       def initialize(base, supported_bases)
         @base = base
         @supported = supported_bases.keys.map do |key|

--- a/lib/plurimath/errors/omml/unsupported_node_error.rb
+++ b/lib/plurimath/errors/omml/unsupported_node_error.rb
@@ -2,7 +2,7 @@
 
 module Plurimath
   class Omml
-    class UnsupportedNodeError < StandardError
+    class UnsupportedNodeError < Plurimath::Error
       def initialize(node)
         @node = node
         super(message)

--- a/lib/plurimath/errors/parse_error.rb
+++ b/lib/plurimath/errors/parse_error.rb
@@ -2,7 +2,7 @@
 
 module Plurimath
   module Math
-    class ParseError < StandardError
+    class ParseError < Plurimath::Error
       def initialize(text, type)
         @text = text
         @type = type.to_sym

--- a/lib/plurimath/math/number.rb
+++ b/lib/plurimath/math/number.rb
@@ -93,7 +93,9 @@ module Plurimath
       end
 
       def format_value_with_options(options)
-        formatter = options[:formatter]
+        formatter = options.fetch(:formatter) do
+          Plurimath.configuration.number_formatter
+        end
         return value unless formatter
 
         if formatter.respond_to?(:format)

--- a/spec/plurimath/configuration_spec.rb
+++ b/spec/plurimath/configuration_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Plurimath::Configuration do
+  around do |example|
+    previous_behavior = Plurimath::Deprecation.behavior
+    previous_number_formatter = Plurimath.configuration.number_formatter
+    example.run
+  ensure
+    Plurimath::Deprecation.behavior = previous_behavior
+    Plurimath.configuration.number_formatter = previous_number_formatter
+  end
+
+  describe ".configuration" do
+    it "returns the shared configuration" do
+      expect(Plurimath.configuration).to be_a(described_class)
+    end
+  end
+
+  describe ".configure" do
+    it "yields the shared configuration" do
+      yielded_config = nil
+
+      result = Plurimath.configure do |config|
+        yielded_config = config
+        :configured
+      end
+
+      expect(yielded_config).to be(Plurimath.configuration)
+      expect(result).to be(:configured)
+    end
+
+    it "allows interacting with deprecation configuration" do
+      Plurimath.configure do |config|
+        config.deprecation.behavior = :raise
+      end
+
+      expect(Plurimath::Deprecation.behavior).to be(:raise)
+    end
+
+    it "allows setting a number formatter" do
+      formatter = Plurimath::Formatter::Standard.new
+
+      Plurimath.configure do |config|
+        config.number_formatter = formatter
+      end
+
+      expect(Plurimath.configuration.number_formatter).to be(formatter)
+    end
+  end
+
+  describe "#deprecation" do
+    it "returns the deprecation module" do
+      expect(Plurimath.configuration.deprecation).to be(Plurimath::Deprecation)
+    end
+  end
+
+  describe "#number_formatter" do
+    it "defaults to nil" do
+      expect(described_class.new.number_formatter).to be_nil
+    end
+  end
+end

--- a/spec/plurimath/deprecation_spec.rb
+++ b/spec/plurimath/deprecation_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Plurimath::Deprecation do
+  before do
+    described_class.behavior = described_class::DEFAULT_BEHAVIOR
+  end
+
+  after do
+    described_class.behavior = described_class::DEFAULT_BEHAVIOR
+  end
+
+  describe ".warn" do
+    it "warns once per feature by default" do
+      allow(Kernel).to receive(:warn)
+      allow(Plurimath::DeprecationError).to receive(:new).and_call_original
+      feature = "number_formatter.old_option.once.#{Plurimath.xml_engine.name}"
+
+      2.times do
+        described_class.warn(
+          feature: feature,
+          since: "0.10",
+          replacement: "number_formatter.new_option",
+          message: "Old option will be removed",
+        )
+      end
+
+      expect(Kernel).to have_received(:warn).once.with(
+        "[plurimath][DEPRECATION] #{feature} is deprecated. " \
+        "since 0.10. Use number_formatter.new_option instead. " \
+        "Old option will be removed.",
+      )
+      expect(Plurimath::DeprecationError).to have_received(:new).once
+    end
+
+    it "raises when configured to raise" do
+      described_class.behavior = :raise
+
+      expect do
+        described_class.warn(feature: "number_formatter.old_option.raise")
+      end.to raise_error(
+        Plurimath::DeprecationError,
+        "[plurimath][DEPRECATION] number_formatter.old_option.raise is deprecated.",
+      )
+    end
+
+    it "does not build or emit warnings when silenced" do
+      described_class.behavior = :silence
+
+      allow(Kernel).to receive(:warn)
+      allow(Plurimath::DeprecationError).to receive(:new)
+
+      described_class.warn(feature: "number_formatter.old_option.silence")
+
+      expect(Kernel).not_to have_received(:warn)
+      expect(Plurimath::DeprecationError).not_to have_received(:new)
+    end
+
+    it "requires a feature identifier" do
+      expect do
+        described_class.warn(feature: nil)
+      end.to raise_error(
+        Plurimath::ConfigurationError,
+        "deprecation feature must be provided",
+      )
+    end
+
+    it "requires a feature identifier when silenced" do
+      described_class.behavior = :silence
+
+      expect do
+        described_class.warn(feature: nil)
+      end.to raise_error(
+        Plurimath::ConfigurationError,
+        "deprecation feature must be provided",
+      )
+    end
+  end
+
+  describe ".behavior" do
+    it "defaults to warning behavior" do
+      expect(described_class.behavior).to be(:warn)
+    end
+  end
+
+  describe ".behavior=" do
+    it "updates deprecation behavior" do
+      described_class.behavior = :raise
+
+      expect(described_class.behavior).to be(:raise)
+    end
+
+    it "rejects unsupported notification behavior" do
+      expect do
+        described_class.behavior = :invalid
+      end.to raise_error(
+        Plurimath::ConfigurationError,
+        /unsupported deprecation behavior/,
+      )
+    end
+  end
+end

--- a/spec/plurimath/deprecation_spec.rb
+++ b/spec/plurimath/deprecation_spec.rb
@@ -3,58 +3,84 @@
 require "spec_helper"
 
 RSpec.describe Plurimath::Deprecation do
-  before do
-    described_class.behavior = described_class::DEFAULT_BEHAVIOR
-  end
-
-  after do
-    described_class.behavior = described_class::DEFAULT_BEHAVIOR
+  around do |example|
+    previous_behavior = described_class.behavior
+    described_class.clear!
+    example.run
+  ensure
+    described_class.behavior = previous_behavior
+    described_class.clear!
   end
 
   describe ".warn" do
-    it "warns once per feature by default" do
-      allow(Kernel).to receive(:warn)
-      allow(Plurimath::DeprecationError).to receive(:new).and_call_original
-      feature = "number_formatter.old_option.once.#{Plurimath.xml_engine.name}"
-
-      2.times do
+    context "with collect behavior (default)" do
+      it "collects deprecation notices" do
+        feature = "test.collect.#{Process.pid}"
         described_class.warn(
           feature: feature,
           since: "0.10",
-          replacement: "number_formatter.new_option",
-          message: "Old option will be removed",
+          replacement: "new_option",
+          message: "Will be removed",
+        )
+
+        expect(described_class.notices.size).to eq(1)
+        notice = described_class.notices.first
+        expect(notice).to be_a(Plurimath::DeprecationError)
+        expect(notice.feature).to eq(feature)
+        expect(notice.to_s).to include("since 0.10")
+        expect(notice.to_s).to include("Use new_option instead")
+      end
+
+      it "deduplicates notices per feature" do
+        feature = "test.dedup.#{Process.pid}"
+        3.times { described_class.warn(feature: feature) }
+
+        expect(described_class.notices.size).to eq(1)
+      end
+
+      it "collects different features separately" do
+        described_class.warn(feature: "test.feature_a")
+        described_class.warn(feature: "test.feature_b")
+
+        expect(described_class.notices.size).to eq(2)
+      end
+    end
+
+    context "with raise behavior" do
+      before { described_class.behavior = :raise }
+
+      it "raises a DeprecationError" do
+        expect do
+          described_class.warn(feature: "test.raise_mode")
+        end.to raise_error(
+          Plurimath::DeprecationError,
+          "[plurimath][DEPRECATION] test.raise_mode is deprecated.",
         )
       end
 
-      expect(Kernel).to have_received(:warn).once.with(
-        "[plurimath][DEPRECATION] #{feature} is deprecated since 0.10. " \
-        "Use number_formatter.new_option instead. " \
-        "Old option will be removed.",
-      )
-      expect(Plurimath::DeprecationError).to have_received(:new).once
+      it "includes replacement and version info in the error" do
+        expect do
+          described_class.warn(
+            feature: "test.raise_details",
+            since: "0.10",
+            remove_in: "1.0",
+            replacement: "new_method",
+          )
+        end.to raise_error(
+          Plurimath::DeprecationError,
+          /since 0\.10.*removed in 1\.0.*Use new_method instead/,
+        )
+      end
     end
 
-    it "raises when configured to raise" do
-      described_class.behavior = :raise
+    context "with silence behavior" do
+      before { described_class.behavior = :silence }
 
-      expect do
-        described_class.warn(feature: "number_formatter.old_option.raise")
-      end.to raise_error(
-        Plurimath::DeprecationError,
-        "[plurimath][DEPRECATION] number_formatter.old_option.raise is deprecated.",
-      )
-    end
+      it "does not collect notices" do
+        described_class.warn(feature: "test.silence_mode")
 
-    it "does not build or emit warnings when silenced" do
-      described_class.behavior = :silence
-
-      allow(Kernel).to receive(:warn)
-      allow(Plurimath::DeprecationError).to receive(:new)
-
-      described_class.warn(feature: "number_formatter.old_option.silence")
-
-      expect(Kernel).not_to have_received(:warn)
-      expect(Plurimath::DeprecationError).not_to have_received(:new)
+        expect(described_class.notices).to be_empty
+      end
     end
 
     it "requires a feature identifier" do
@@ -79,8 +105,8 @@ RSpec.describe Plurimath::Deprecation do
   end
 
   describe ".behavior" do
-    it "defaults to warning behavior" do
-      expect(described_class.behavior).to be(:warn)
+    it "defaults to collect behavior" do
+      expect(described_class.behavior).to be(:collect)
     end
   end
 
@@ -98,6 +124,83 @@ RSpec.describe Plurimath::Deprecation do
         Plurimath::ConfigurationError,
         /unsupported deprecation behavior/,
       )
+    end
+  end
+
+  describe ".notices" do
+    it "returns collected DeprecationError objects" do
+      described_class.warn(feature: "test.notices_a")
+      described_class.warn(feature: "test.notices_b")
+
+      expect(described_class.notices).to all(be_a(Plurimath::DeprecationError))
+      expect(described_class.notices.map(&:feature)).to contain_exactly("test.notices_a", "test.notices_b")
+    end
+  end
+
+  describe ".clear!" do
+    it "removes all collected notices" do
+      described_class.warn(feature: "test.clear")
+      expect(described_class.notices).not_to be_empty
+
+      described_class.clear!
+
+      expect(described_class.notices).to be_empty
+    end
+  end
+end
+
+RSpec.describe Plurimath::DeprecationError do
+  subject(:error) do
+    described_class.new(
+      feature: "old_api",
+      since: "0.10",
+      remove_in: "1.0",
+      replacement: "new_api",
+      message: "Please migrate",
+    )
+  end
+
+  describe "#severity" do
+    it "returns :warning" do
+      expect(error.severity).to be(:warning)
+    end
+  end
+
+  describe "#feature" do
+    it "returns the feature name" do
+      expect(error.feature).to eq("old_api")
+    end
+  end
+
+  describe "#replacement" do
+    it "returns the replacement" do
+      expect(error.replacement).to eq("new_api")
+    end
+  end
+
+  describe "#since" do
+    it "returns the since version" do
+      expect(error.since).to eq("0.10")
+    end
+  end
+
+  describe "#remove_in" do
+    it "returns the remove_in version" do
+      expect(error.remove_in).to eq("1.0")
+    end
+  end
+
+  describe "#to_s" do
+    it "includes all deprecation information" do
+      expect(error.to_s).to eq(
+        "[plurimath][DEPRECATION] old_api is deprecated since 0.10 " \
+        "and will be removed in 1.0. Use new_api instead. Please migrate.",
+      )
+    end
+
+    it "handles minimal information" do
+      minimal = described_class.new(feature: "simple")
+      expect(minimal.to_s).to eq("[plurimath][DEPRECATION] simple is deprecated.")
     end
   end
 end

--- a/spec/plurimath/deprecation_spec.rb
+++ b/spec/plurimath/deprecation_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe Plurimath::Deprecation do
       end
 
       expect(Kernel).to have_received(:warn).once.with(
-        "[plurimath][DEPRECATION] #{feature} is deprecated. " \
-        "since 0.10. Use number_formatter.new_option instead. " \
+        "[plurimath][DEPRECATION] #{feature} is deprecated since 0.10. " \
+        "Use number_formatter.new_option instead. " \
         "Old option will be removed.",
       )
       expect(Plurimath::DeprecationError).to have_received(:new).once

--- a/spec/plurimath/math/number_spec.rb
+++ b/spec/plurimath/math/number_spec.rb
@@ -1,6 +1,13 @@
 require "spec_helper"
 
 RSpec.describe Plurimath::Math::Number do
+  around do |example|
+    previous_formatter = Plurimath.configuration.number_formatter
+    example.run
+  ensure
+    Plurimath.configuration.number_formatter = previous_formatter
+  end
+
   describe ".initialize" do
     it "returns instance of Number" do
       number = described_class.new(100)
@@ -126,6 +133,33 @@ RSpec.describe Plurimath::Math::Number do
 
       it "returns mathml string" do
         expect(formula).to eql("70")
+      end
+    end
+
+    context "with configured number formatter" do
+      let(:first_value) { "1234" }
+
+      it "formats the number" do
+        Plurimath.configuration.number_formatter = Plurimath::Formatter::Standard.new
+
+        expect(formula).to eql("1,234")
+      end
+
+      it "keeps explicit formatter precedence" do
+        configured_formatter = Class.new do
+          def localized_number(number)
+            "configured #{number}"
+          end
+        end
+
+        Plurimath.configuration.number_formatter = configured_formatter.new
+        formatter = Plurimath::Formatter::Standard.new
+
+        result = described_class.new(first_value).to_latex(
+          options: { formatter: formatter },
+        )
+
+        expect(result).to eql("1,234")
       end
     end
   end

--- a/spec/plurimath/math/number_spec.rb
+++ b/spec/plurimath/math/number_spec.rb
@@ -153,31 +153,21 @@ RSpec.describe Plurimath::Math::Number do
         end
 
         Plurimath.configuration.number_formatter = configured_formatter.new
-        formatter = Plurimath::Formatter::Standard.new
+        explicit_formatter = Plurimath::Formatter::Standard.new
 
         result = described_class.new(first_value).to_latex(
-          options: { formatter: formatter },
+          options: { formatter: explicit_formatter },
         )
 
         expect(result).to eql("1,234")
       end
+    end
 
-      it "does not resolve the configured formatter when explicit formatter is passed" do
-        configuration = instance_spy(Plurimath::Configuration)
-        formatter = Class.new do
-          def localized_number(number)
-            "explicit #{number}"
-          end
-        end.new
+    context "with nil formatter" do
+      let(:first_value) { "42" }
 
-        allow(Plurimath).to receive(:configuration).and_return(configuration)
-
-        result = described_class.new(first_value).to_latex(
-          options: { formatter: formatter },
-        )
-
-        expect(result).to eql("explicit 1234")
-        expect(configuration).not_to have_received(:number_formatter)
+      it "returns raw value" do
+        expect(formula).to eql("42")
       end
     end
   end

--- a/spec/plurimath/math/number_spec.rb
+++ b/spec/plurimath/math/number_spec.rb
@@ -161,6 +161,24 @@ RSpec.describe Plurimath::Math::Number do
 
         expect(result).to eql("1,234")
       end
+
+      it "does not resolve the configured formatter when explicit formatter is passed" do
+        configuration = instance_spy(Plurimath::Configuration)
+        formatter = Class.new do
+          def localized_number(number)
+            "explicit #{number}"
+          end
+        end.new
+
+        allow(Plurimath).to receive(:configuration).and_return(configuration)
+
+        result = described_class.new(first_value).to_latex(
+          options: { formatter: formatter },
+        )
+
+        expect(result).to eql("explicit 1234")
+        expect(configuration).not_to have_received(:number_formatter)
+      end
     end
   end
 


### PR DESCRIPTION
This PR adds generic `configuration` and `deprecation` foundation support for **Plurimath.**

This PR adds:
- `Plurimath.configuration` and `Plurimath.configure`
- `Configuration#number_formatter` as a configurable default formatter
- formatter precedence where explicit `formatter:` options still win over configured defaults
- centralized, Opal-safe deprecation handling with `:warn`, `:raise`, and `:silence`

This does not deprecate any existing behavior yet; it only adds the shared foundation for future configuration defaults and planned deprecation paths.

closes #421
