### PR TITLE
Implement HTML math parsing into Formula

### DIFF
--- a/lib/plurimath/html.rb
+++ b/lib/plurimath/html.rb
@@ -6,6 +6,7 @@ module Plurimath
     autoload :Parse, "#{__dir__}/html/parse"
     autoload :Parser, "#{__dir__}/html/parser"
     autoload :Transform, "#{__dir__}/html/transform"
+    autoload :TransformUtility, "#{__dir__}/html/transform_utility"
 
     attr_accessor :text
 

--- a/lib/plurimath/html/constants.rb
+++ b/lib/plurimath/html/constants.rb
@@ -38,6 +38,8 @@ module Plurimath
       SUB_SUP_CLASSES = {
         "&prod;": :prod,
         "&sum;": :sum,
+        "&#x220f;": :prod,
+        "&#x2211;": :sum,
         log: :log,
         lim: :lim,
         "∏": :prod,

--- a/lib/plurimath/html/parse.rb
+++ b/lib/plurimath/html/parse.rb
@@ -111,6 +111,7 @@ module Plurimath
       rule(:tag_parse) do
         parse_sub_sup_tags("table") |
           parse_sub_sup_tags("tr") |
+          # Formula has no header-cell node; HTML <th> is parsed as Td.
           parse_sub_sup_tags(%w[td th], "td") |
           wrapped_tag(sequence.as(:sequence))
       end
@@ -187,7 +188,7 @@ module Plurimath
       end
 
       def tag_attributes
-        (quoted_attribute_value | match["^>"]).repeat
+        (quoted_attribute_value | match["^<>"]).repeat
       end
 
       def quoted_attribute_value

--- a/lib/plurimath/html/parse.rb
+++ b/lib/plurimath/html/parse.rb
@@ -184,7 +184,11 @@ module Plurimath
       def html_tag_name(tag_name)
         return match["a-zA-Z"] >> match["a-zA-Z0-9:._-"].repeat unless tag_name
 
-        case_insensitive_string(tag_name)
+        case_insensitive_string(tag_name) >> tag_name_boundary
+      end
+
+      def tag_name_boundary
+        match["\\s/>"].present?
       end
 
       def tag_attributes

--- a/lib/plurimath/html/parse.rb
+++ b/lib/plurimath/html/parse.rb
@@ -6,11 +6,12 @@ module Plurimath
       rule(:space)   { match["\s"].repeat(1) }
       rule(:unary)   { array_to_expression(Constants::UNARY_CLASSES, :unary) }
       rule(:binary)  { str("lim").as(:binary) }
+      rule(:linebreak) { parse_void_tag("br").as(:linebreak) }
       rule(:sub_tag) { parse_sub_sup_tags("sub") }
       rule(:sup_tag) { parse_sub_sup_tags("sup") }
 
       rule(:mod) do
-        (parse_tag(:open) >> str("mod").as(:binary) >> parse_tag(:close)) |
+        wrapped_tag(str("mod").as(:binary)) |
           str("mod").as(:binary)
       end
 
@@ -27,12 +28,12 @@ module Plurimath
       end
 
       rule(:open_paren) do
-        (parse_tag(:open) >> lparen >> parse_tag(:close)) |
+        wrapped_tag(lparen) |
           lparen
       end
 
       rule(:close_paren) do
-        (parse_tag(:open) >> rparen >> parse_tag(:close)) |
+        wrapped_tag(rparen) |
           rparen
       end
 
@@ -57,12 +58,12 @@ module Plurimath
       end
 
       rule(:unary_functions) do
-        (parse_tag(:open) >> unary >> parse_tag(:close)) |
+        wrapped_tag(unary) |
           unary
       end
 
       rule(:binary_functions) do
-        (parse_tag(:open) >> binary >> parse_tag(:close)) |
+        wrapped_tag(binary) |
           binary
       end
 
@@ -73,11 +74,11 @@ module Plurimath
 
       rule(:symbol_text_or_tag) do
         tag_parse |
-          (str("&") >> match["a-zA-Z0-9"].repeat(2) >> str(";")).as(:symbol) |
+          html_entity.as(:symbol) |
           (match["0-9"].repeat(1) >> str(".") >> match["0-9"].repeat(1)).as(:number) |
           match["0-9"].repeat(1).as(:number) |
           match["a-zA-Z"].as(:text) |
-          match["^0-9a-zA-Z<>/(){}\\[\\]\s"].as(:symbol)
+          match["^0-9a-zA-Z<>(){}\\[\\]\s"].as(:symbol)
       end
 
       rule(:intermediate_exp) do
@@ -85,6 +86,7 @@ module Plurimath
           (symbol_text_or_tag.as(:sub_sup) >> sub_sup_tags) |
           sub_sup |
           parse_classes |
+          linebreak |
           symbol_text_or_tag |
           space
       end
@@ -109,8 +111,8 @@ module Plurimath
       rule(:tag_parse) do
         parse_sub_sup_tags("table") |
           parse_sub_sup_tags("tr") |
-          parse_sub_sup_tags("td") |
-          (parse_tag(:open) >> sequence.as(:sequence) >> parse_tag(:close))
+          parse_sub_sup_tags(%w[td th], "td") |
+          wrapped_tag(sequence.as(:sequence))
       end
 
       rule(:expression) do
@@ -136,15 +138,67 @@ module Plurimath
         str(string).as(name)
       end
 
-      def parse_tag(opts)
+      def parse_tag(opts, tag_name = nil, capture_name: nil)
         tag = str("<")
         tag = tag >> str("/") if opts == :close
-        tag = tag >> match(/\w+/).repeat
+        name_expression = html_tag_name(tag_name)
+        name_expression = name_expression.capture(capture_name) if capture_name
+        tag = tag >> name_expression
+        tag = tag >> tag_attributes if opts == :open
         tag >> str(">")
       end
 
-      def parse_sub_sup_tags(tag)
-        str("<#{tag}>") >> sequence.as(:"#{tag}_value") >> str("</#{tag}>")
+      def parse_void_tag(tag_name)
+        str("<") >> html_tag_name(tag_name) >> tag_attributes >> str(">")
+      end
+
+      def html_entity
+        (str("&#x") >> match["0-9a-fA-F"].repeat(1) >> str(";")) |
+          (str("&#") >> match["0-9"].repeat(1) >> str(";")) |
+          (str("&") >> match["a-zA-Z"] >> match["a-zA-Z0-9"].repeat >> str(";"))
+      end
+
+      def parse_sub_sup_tags(tag_names, transform_name = tag_names)
+        Array(tag_names).map do |tag_name|
+          parse_tag(:open, tag_name) >>
+            sequence.as(:"#{transform_name}_value") >>
+            parse_tag(:close, tag_name)
+        end.reduce(:|)
+      end
+
+      def wrapped_tag(expression)
+        scope do
+          parse_tag(:open, capture_name: :html_tag_name) >>
+            expression >>
+            matching_close_tag
+        end
+      end
+
+      def matching_close_tag
+        dynamic do |_source, context|
+          parse_tag(:close, context.captures[:html_tag_name].to_s)
+        end
+      end
+
+      def html_tag_name(tag_name)
+        return match["a-zA-Z"] >> match["a-zA-Z0-9:._-"].repeat unless tag_name
+
+        case_insensitive_string(tag_name)
+      end
+
+      def tag_attributes
+        (quoted_attribute_value | match["^>"]).repeat
+      end
+
+      def quoted_attribute_value
+        (str('"') >> match['^"'].repeat >> str('"')) |
+          (str("'") >> match["^'"].repeat >> str("'"))
+      end
+
+      def case_insensitive_string(value)
+        value.chars
+          .map { |char| char.match?(/[A-Za-z]/) ? match["#{char.downcase}#{char.upcase}"] : str(char) }
+          .reduce(:>>)
       end
     end
   end

--- a/lib/plurimath/html/parser.rb
+++ b/lib/plurimath/html/parser.rb
@@ -5,7 +5,6 @@ require "json"
 module Plurimath
   class Html
     class Parser
-      MATHML_ROOT_TAG = %r{<\s*/?\s*math(?:\s|/?>)}i
       HTML_ENTITY = /&(?:#x[0-9a-f]+|#\d+|[a-z][a-z0-9]+);/i
 
       attr_accessor :text
@@ -15,8 +14,6 @@ module Plurimath
       end
 
       def parse
-        validate_html_input!
-
         nodes = Parse.new.parse(normalized_text)
         nodes = JSON.parse(nodes.to_json, symbolize_names: true)
         transformed_tree = Transform.new.apply(nodes)
@@ -27,18 +24,11 @@ module Plurimath
 
       private
 
-      def validate_html_input!
-        return unless text.match?(MATHML_ROOT_TAG)
-
-        raise Parslet::ParseFailed,
-              "MathML input must be parsed with the MathML parser"
-      end
-
       def normalized_text
         text.gsub(HTML_ENTITY) do |entity|
           decoded_entity = Utility.html_entity_to_unicode(entity)
 
-          %w[< >].include?(decoded_entity) ? Utility.string_to_html_entity(decoded_entity) : decoded_entity
+          Utility.string_to_html_entity(decoded_entity)
         end
       end
     end

--- a/lib/plurimath/html/parser.rb
+++ b/lib/plurimath/html/parser.rb
@@ -1,23 +1,45 @@
 # frozen_string_literal: true
 
 require "json"
-require "cgi"
+
 module Plurimath
   class Html
     class Parser
+      MATHML_ROOT_TAG = %r{<\s*/?\s*math(?:\s|/?>)}i
+      HTML_ENTITY = /&(?:#x[0-9a-f]+|#\d+|[a-z][a-z0-9]+);/i
+
       attr_accessor :text
 
       def initialize(text)
-        @text = ::CGI.unescapeHTML(text)
+        @text = text.to_s
       end
 
       def parse
-        nodes = Parse.new.parse(text)
+        validate_html_input!
+
+        nodes = Parse.new.parse(normalized_text)
         nodes = JSON.parse(nodes.to_json, symbolize_names: true)
         transformed_tree = Transform.new.apply(nodes)
         return transformed_tree if transformed_tree.is_a?(Math::Formula)
 
         Math::Formula.new(transformed_tree)
+      end
+
+      private
+
+      def validate_html_input!
+        return unless text.match?(MATHML_ROOT_TAG)
+
+        raise Parslet::ParseFailed,
+              "MathML input must be parsed with the MathML parser"
+      end
+
+      def normalized_text
+        text.gsub(HTML_ENTITY) do |entity|
+          decoded_entity = Utility.html_entity_to_unicode(entity)
+
+          %w[< >].include?(decoded_entity) ? Utility.string_to_html_entity(decoded_entity) : decoded_entity
+        end
       end
     end
   end

--- a/lib/plurimath/html/transform.rb
+++ b/lib/plurimath/html/transform.rb
@@ -5,15 +5,28 @@ module Plurimath
     class Transform < Parslet::Transform
       rule(text: simple(:text))      { Math::Function::Text.new(text) }
       rule(unary: simple(:unary))    { Utility.get_class(unary).new }
-      rule(symbol: simple(:symbol))  do
-        Utility.symbols_class(symbol, lang: :html)
-      end
-      rule(number: simple(:number))  { Math::Number.new(number) }
+      rule(symbol: simple(:symbol)) { TransformUtility.symbol(symbol) }
+      rule(number: simple(:number)) { Math::Number.new(number) }
+      rule(linebreak: simple(:_linebreak)) { Math::Function::Linebreak.new }
       rule(expression: simple(:exp)) { exp }
+
+      rule(linebreak: simple(:_linebreak),
+           expression: simple(:expr)) do
+        [
+          Math::Function::Linebreak.new,
+          expr,
+        ]
+      end
+
+      rule(linebreak: simple(:_linebreak),
+           expression: sequence(:expr)) do
+        [Math::Function::Linebreak.new] + expr
+      end
 
       rule(expression: sequence(:exp))    { exp }
       rule(sequence: simple(:sequence))   { sequence }
       rule(tr_value: simple(:tr_value))   { Math::Function::Tr.new([tr_value]) }
+      rule(tr_value: sequence(:tr_value)) { Math::Function::Tr.new(tr_value) }
       rule(td_value: simple(:td_value))   { Math::Function::Td.new([td_value]) }
       rule(sequence: sequence(:sequence)) { sequence }
       rule(td_value: sequence(:td_value)) { Math::Function::Td.new(td_value) }
@@ -71,6 +84,22 @@ module Plurimath
         )
       end
 
+      rule(td_value: simple(:td_value),
+           expression: simple(:expr)) do
+        [
+          Math::Function::Td.new([td_value]),
+          expr,
+        ]
+      end
+
+      rule(td_value: simple(:td_value),
+           expression: sequence(:expr)) do
+        expr.insert(
+          0,
+          Math::Function::Td.new([td_value]),
+        )
+      end
+
       rule(unary_function: simple(:unary_function),
            sequence: simple(:sequence)) do
         Math::Formula.new(
@@ -104,14 +133,14 @@ module Plurimath
       rule(symbol: simple(:symbol),
            expression: simple(:expr)) do
         [
-          Utility.symbols_class(symbol, lang: :html),
+          TransformUtility.symbol(symbol),
           expr,
         ]
       end
 
       rule(symbol: simple(:symbol),
            expression: sequence(:expr)) do
-        [Utility.symbols_class(symbol, lang: :html)] + expr
+        [TransformUtility.symbol(symbol)] + expr
       end
 
       rule(number: simple(:number),
@@ -145,135 +174,205 @@ module Plurimath
       rule(symbol: simple(:symbol),
            parse_parenthesis: simple(:parse_paren)) do
         [
-          Utility.symbols_class(symbol, lang: :html),
+          TransformUtility.symbol(symbol),
           parse_paren,
         ]
       end
 
       rule(sub_sup: simple(:sub_sup),
            sub_value: simple(:sub_value)) do
-        if Utility.sub_sup_method?(sub_sup)
-          sub_sup.parameter_one = sub_value
-          sub_sup
-        else
-          Math::Function::Base.new(
-            sub_sup,
-            sub_value,
-          )
-        end
+        TransformUtility.sub_sup_value(sub_sup, sub_value: sub_value)
       end
 
       rule(sub_sup: simple(:sub_sup),
            sub_value: sequence(:sub_value)) do
-        if Utility.sub_sup_method?(sub_sup)
-          sub_sup.parameter_one = Utility.filter_values(sub_value)
-          sub_sup
-        else
-          Math::Function::Base.new(
-            sub_sup,
-            Utility.filter_values(sub_value),
-          )
-        end
+        TransformUtility.sub_sup_value(sub_sup, sub_value: sub_value)
       end
 
       rule(sub_sup: simple(:sub_sup),
            sup_value: simple(:sup_value)) do
-        if Utility.sub_sup_method?(sub_sup)
-          sub_sup.parameter_two = sup_value
-          sub_sup
-        else
-          Math::Function::Power.new(
-            sub_sup,
-            sup_value,
-          )
-        end
+        TransformUtility.sub_sup_value(sub_sup, sup_value: sup_value)
       end
 
       rule(sub_sup: simple(:sub_sup),
            sup_value: sequence(:sup_value)) do
-        if Utility.sub_sup_method?(sub_sup)
-          sub_sup.parameter_two = Utility.filter_values(sup_value)
-          sub_sup
-        else
-          Math::Function::Power.new(
-            sub_sup,
-            Utility.filter_values(sup_value),
-          )
-        end
+        TransformUtility.sub_sup_value(sub_sup, sup_value: sup_value)
       end
 
       rule(sub_sup: simple(:sub_sup),
            sub_value: simple(:sub_value),
            sup_value: simple(:sup_value)) do
-        if Utility.sub_sup_method?(sub_sup)
-          sub_sup.parameter_one = sub_value
-          sub_sup.parameter_two = sup_value
-          sub_sup
-        else
-          Math::Function::PowerBase.new(
-            sub_sup,
-            sub_value,
-            sup_value,
-          )
-        end
+        TransformUtility.sub_sup_value(sub_sup, sub_value: sub_value, sup_value: sup_value)
       end
 
       rule(sub_sup: simple(:sub_sup),
            sub_value: simple(:sub_value),
            sup_value: sequence(:sup_value)) do
-        if Utility.sub_sup_method?(sub_sup)
-          sub_sup.parameter_one = sub_value
-          sub_sup.parameter_two = Utility.filter_values(sup_value)
-          sub_sup
-        else
-          Math::Function::PowerBase.new(
-            sub_sup,
-            sub_value,
-            Utility.filter_values(sup_value),
-          )
-        end
+        TransformUtility.sub_sup_value(sub_sup, sub_value: sub_value, sup_value: sup_value)
       end
 
       rule(sub_sup: simple(:sub_sup),
            sub_value: sequence(:sub_value),
            sup_value: simple(:sup_value)) do
-        if Utility.sub_sup_method?(sub_sup)
-          sub_sup.parameter_one = Utility.filter_values(sub_value)
-          sub_sup.parameter_two = sup_value
-          sub_sup
-        else
-          Math::Function::PowerBase.new(
-            sub_sup,
-            Utility.filter_values(sub_value),
-            sup_value,
-          )
-        end
+        TransformUtility.sub_sup_value(sub_sup, sub_value: sub_value, sup_value: sup_value)
       end
 
       rule(sub_sup: simple(:sub_sup),
            sub_value: sequence(:sub_value),
            sup_value: sequence(:sup_value)) do
-        if Utility.sub_sup_method?(sub_sup)
-          sub_sup.parameter_one = Utility.filter_values(sub_value)
-          sub_sup.parameter_two = Utility.filter_values(sup_value)
-          sub_sup
-        else
-          Math::Function::PowerBase.new(
-            sub_sup,
-            Utility.filter_values(sub_value),
-            Utility.filter_values(sup_value),
-          )
-        end
+        TransformUtility.sub_sup_value(sub_sup, sub_value: sub_value, sup_value: sup_value)
       end
 
       rule(sub_sup: simple(:sub_sup),
            sup_value: sequence(:sup_value),
            expression: simple(:expression)) do
-        power = Math::Function::Power.new(
-          sub_sup,
-          Utility.filter_values(sup_value),
+        TransformUtility.append_expression(
+          TransformUtility.sub_sup_value(sub_sup, sup_value: sup_value),
+          expression,
         )
-        [power, expression]
+      end
+
+      rule(sub_sup: simple(:sub_sup),
+           sub_value: simple(:sub_value),
+           expression: simple(:expression)) do
+        TransformUtility.append_expression(
+          TransformUtility.sub_sup_value(sub_sup, sub_value: sub_value),
+          expression,
+        )
+      end
+
+      rule(sub_sup: simple(:sub_sup),
+           sub_value: simple(:sub_value),
+           expression: sequence(:expression)) do
+        TransformUtility.append_expression(
+          TransformUtility.sub_sup_value(sub_sup, sub_value: sub_value),
+          expression,
+        )
+      end
+
+      rule(sub_sup: simple(:sub_sup),
+           sub_value: sequence(:sub_value),
+           expression: simple(:expression)) do
+        TransformUtility.append_expression(
+          TransformUtility.sub_sup_value(sub_sup, sub_value: sub_value),
+          expression,
+        )
+      end
+
+      rule(sub_sup: simple(:sub_sup),
+           sub_value: sequence(:sub_value),
+           expression: sequence(:expression)) do
+        TransformUtility.append_expression(
+          TransformUtility.sub_sup_value(sub_sup, sub_value: sub_value),
+          expression,
+        )
+      end
+
+      rule(sub_sup: simple(:sub_sup),
+           sup_value: simple(:sup_value),
+           expression: simple(:expression)) do
+        TransformUtility.append_expression(
+          TransformUtility.sub_sup_value(sub_sup, sup_value: sup_value),
+          expression,
+        )
+      end
+
+      rule(sub_sup: simple(:sub_sup),
+           sup_value: simple(:sup_value),
+           expression: sequence(:expression)) do
+        TransformUtility.append_expression(
+          TransformUtility.sub_sup_value(sub_sup, sup_value: sup_value),
+          expression,
+        )
+      end
+
+      rule(sub_sup: simple(:sub_sup),
+           sup_value: sequence(:sup_value),
+           expression: sequence(:expression)) do
+        TransformUtility.append_expression(
+          TransformUtility.sub_sup_value(sub_sup, sup_value: sup_value),
+          expression,
+        )
+      end
+
+      rule(sub_sup: simple(:sub_sup),
+           sub_value: simple(:sub_value),
+           sup_value: simple(:sup_value),
+           expression: simple(:expression)) do
+        TransformUtility.append_expression(
+          TransformUtility.sub_sup_value(sub_sup, sub_value: sub_value, sup_value: sup_value),
+          expression,
+        )
+      end
+
+      rule(sub_sup: simple(:sub_sup),
+           sub_value: simple(:sub_value),
+           sup_value: simple(:sup_value),
+           expression: sequence(:expression)) do
+        TransformUtility.append_expression(
+          TransformUtility.sub_sup_value(sub_sup, sub_value: sub_value, sup_value: sup_value),
+          expression,
+        )
+      end
+
+      rule(sub_sup: simple(:sub_sup),
+           sub_value: simple(:sub_value),
+           sup_value: sequence(:sup_value),
+           expression: simple(:expression)) do
+        TransformUtility.append_expression(
+          TransformUtility.sub_sup_value(sub_sup, sub_value: sub_value, sup_value: sup_value),
+          expression,
+        )
+      end
+
+      rule(sub_sup: simple(:sub_sup),
+           sub_value: simple(:sub_value),
+           sup_value: sequence(:sup_value),
+           expression: sequence(:expression)) do
+        TransformUtility.append_expression(
+          TransformUtility.sub_sup_value(sub_sup, sub_value: sub_value, sup_value: sup_value),
+          expression,
+        )
+      end
+
+      rule(sub_sup: simple(:sub_sup),
+           sub_value: sequence(:sub_value),
+           sup_value: simple(:sup_value),
+           expression: simple(:expression)) do
+        TransformUtility.append_expression(
+          TransformUtility.sub_sup_value(sub_sup, sub_value: sub_value, sup_value: sup_value),
+          expression,
+        )
+      end
+
+      rule(sub_sup: simple(:sub_sup),
+           sub_value: sequence(:sub_value),
+           sup_value: simple(:sup_value),
+           expression: sequence(:expression)) do
+        TransformUtility.append_expression(
+          TransformUtility.sub_sup_value(sub_sup, sub_value: sub_value, sup_value: sup_value),
+          expression,
+        )
+      end
+
+      rule(sub_sup: simple(:sub_sup),
+           sub_value: sequence(:sub_value),
+           sup_value: sequence(:sup_value),
+           expression: simple(:expression)) do
+        TransformUtility.append_expression(
+          TransformUtility.sub_sup_value(sub_sup, sub_value: sub_value, sup_value: sup_value),
+          expression,
+        )
+      end
+
+      rule(sub_sup: simple(:sub_sup),
+           sub_value: sequence(:sub_value),
+           sup_value: sequence(:sup_value),
+           expression: sequence(:expression)) do
+        TransformUtility.append_expression(
+          TransformUtility.sub_sup_value(sub_sup, sub_value: sub_value, sup_value: sup_value),
+          expression,
+        )
       end
 
       rule(lparen: simple(:lparen),

--- a/lib/plurimath/html/transform.rb
+++ b/lib/plurimath/html/transform.rb
@@ -223,6 +223,9 @@ module Plurimath
         TransformUtility.sub_sup_value(sub_sup, sub_value: sub_value, sup_value: sup_value)
       end
 
+      # Parslet emits separate shapes for each sub/sup value combination and
+      # trailing expression form. Keep this cluster mechanical: build the
+      # sub/sup node, then append the remaining expression in input order.
       rule(sub_sup: simple(:sub_sup),
            sup_value: sequence(:sup_value),
            expression: simple(:expression)) do

--- a/lib/plurimath/html/transform_utility.rb
+++ b/lib/plurimath/html/transform_utility.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module Plurimath
+  class Html
+    module TransformUtility
+      CANONICAL_HTML_SYMBOLS = {
+        "!" => "&#x21;",
+        "%" => "&#x25;",
+        "-" => "&#x2212;",
+        "/" => "&#x2215;",
+      }.freeze
+
+      def symbol(symbol)
+        decoded_symbol = Utility.html_entity_to_unicode(symbol.to_s)
+        mapped_symbol = Utility.symbols_class(canonical_symbol(decoded_symbol), lang: :html)
+        return mapped_symbol unless mapped_symbol.instance_of?(Math::Symbols::Symbol)
+
+        Utility.symbols_class(decoded_symbol, lang: :html)
+      end
+
+      def append_expression(value, expression)
+        return [value] + expression if expression.is_a?(Array)
+
+        [value, expression]
+      end
+
+      def sub_sup_value(sub_sup, sub_value: nil, sup_value: nil)
+        normalized_sub_value = normalize_sub_sup_value(sub_value)
+        normalized_sup_value = normalize_sub_sup_value(sup_value)
+
+        if Utility.sub_sup_method?(sub_sup)
+          sub_sup.parameter_one = normalized_sub_value if normalized_sub_value
+          sub_sup.parameter_two = normalized_sup_value if normalized_sup_value
+          sub_sup
+        elsif normalized_sub_value && normalized_sup_value
+          Math::Function::PowerBase.new(
+            sub_sup,
+            normalized_sub_value,
+            normalized_sup_value,
+          )
+        elsif normalized_sup_value
+          Math::Function::Power.new(
+            sub_sup,
+            normalized_sup_value,
+          )
+        else
+          Math::Function::Base.new(
+            sub_sup,
+            normalized_sub_value,
+          )
+        end
+      end
+
+      def canonical_symbol(symbol)
+        CANONICAL_HTML_SYMBOLS.fetch(symbol) do
+          Utility.string_to_html_entity(symbol)
+        end
+      end
+
+      def normalize_sub_sup_value(value)
+        return Utility.filter_values(value) if value.is_a?(Array)
+
+        value
+      end
+
+      module_function :symbol, :append_expression, :sub_sup_value,
+                      :canonical_symbol, :normalize_sub_sup_value
+      private_class_method :canonical_symbol, :normalize_sub_sup_value
+    end
+  end
+end

--- a/lib/plurimath/html/transform_utility.rb
+++ b/lib/plurimath/html/transform_utility.rb
@@ -5,13 +5,10 @@ module Plurimath
     module TransformUtility
       module_function
 
-      # Raw Unicode symbols can reach this transform from literal HTML text.
-      # Keep Utility.symbols_class as the lookup path, trying the direct value
-      # first and then the HTML entity form used by the symbol tables.
+      HTML_ENTITY = /\A&(?:#x[0-9a-f]+|#\d+|[a-z][a-z0-9]+);\z/i
+
       def symbol(symbol)
-        known_html_symbol(symbol) ||
-          known_html_symbol(Utility.string_to_html_entity(symbol.to_s)) ||
-          Math::Symbols::Symbol.new(symbol)
+        Utility.symbols_class(normalize_symbol(symbol), lang: :html)
       end
 
       def append_expression(value, expression)
@@ -53,15 +50,11 @@ module Plurimath
         value
       end
 
-      def known_html_symbol(symbol)
-        parsed_symbol = Utility.symbols_class(symbol, lang: :html)
-        return if generic_symbol?(parsed_symbol)
+      def normalize_symbol(symbol)
+        symbol = symbol.to_s
+        return symbol if symbol.match?(HTML_ENTITY)
 
-        parsed_symbol
-      end
-
-      def generic_symbol?(symbol)
-        symbol.instance_of?(Math::Symbols::Symbol)
+        Utility.string_to_html_entity(symbol)
       end
     end
   end

--- a/lib/plurimath/html/transform_utility.rb
+++ b/lib/plurimath/html/transform_utility.rb
@@ -3,19 +3,15 @@
 module Plurimath
   class Html
     module TransformUtility
-      CANONICAL_HTML_SYMBOLS = {
-        "!" => "&#x21;",
-        "%" => "&#x25;",
-        "-" => "&#x2212;",
-        "/" => "&#x2215;",
-      }.freeze
+      module_function
 
+      # Raw Unicode symbols can reach this transform from literal HTML text.
+      # Keep Utility.symbols_class as the lookup path, trying the direct value
+      # first and then the HTML entity form used by the symbol tables.
       def symbol(symbol)
-        decoded_symbol = Utility.html_entity_to_unicode(symbol.to_s)
-        mapped_symbol = Utility.symbols_class(canonical_symbol(decoded_symbol), lang: :html)
-        return mapped_symbol unless mapped_symbol.instance_of?(Math::Symbols::Symbol)
-
-        Utility.symbols_class(decoded_symbol, lang: :html)
+        known_html_symbol(symbol) ||
+          known_html_symbol(Utility.string_to_html_entity(symbol.to_s)) ||
+          Math::Symbols::Symbol.new(symbol)
       end
 
       def append_expression(value, expression)
@@ -51,21 +47,22 @@ module Plurimath
         end
       end
 
-      def canonical_symbol(symbol)
-        CANONICAL_HTML_SYMBOLS.fetch(symbol) do
-          Utility.string_to_html_entity(symbol)
-        end
-      end
-
       def normalize_sub_sup_value(value)
         return Utility.filter_values(value) if value.is_a?(Array)
 
         value
       end
 
-      module_function :symbol, :append_expression, :sub_sup_value,
-                      :canonical_symbol, :normalize_sub_sup_value
-      private_class_method :canonical_symbol, :normalize_sub_sup_value
+      def known_html_symbol(symbol)
+        parsed_symbol = Utility.symbols_class(symbol, lang: :html)
+        return if generic_symbol?(parsed_symbol)
+
+        parsed_symbol
+      end
+
+      def generic_symbol?(symbol)
+        symbol.instance_of?(Math::Symbols::Symbol)
+      end
     end
   end
 end

--- a/lib/plurimath/math/function/lim.rb
+++ b/lib/plurimath/math/function/lim.rb
@@ -28,6 +28,12 @@ module Plurimath
           "\\#{class_name}#{first_value}#{second_value}"
         end
 
+        def to_html(options:)
+          first_value = "<i>#{parameter_one.to_html(options: options)}</i>" if parameter_one
+          second_value = "<i>#{parameter_two.to_html(options: options)}</i>" if parameter_two
+          "<i>lim</i>#{first_value}#{second_value}"
+        end
+
         def to_mathml_without_math_tag(intent, options:)
           first_value = Utility.ox_element("mo") << "lim"
           return first_value unless any_value_exist?

--- a/lib/plurimath/math/symbols/cdot.rb
+++ b/lib/plurimath/math/symbols/cdot.rb
@@ -9,7 +9,7 @@ module Plurimath
           mathml: ["&#x22c5;"],
           latex: [["cdot", "&#x22c5;"], parsing_wrapper(["*"], lang: :latex)],
           omml: ["&#x22c5;"],
-          html: ["&#x22c5;"],
+          html: ["&#x22c5;", "&sdot;"],
         }.freeze
 
         # output methods

--- a/lib/plurimath/math/symbols/exclam.rb
+++ b/lib/plurimath/math/symbols/exclam.rb
@@ -10,7 +10,7 @@ module Plurimath
           mathml: ["&#x21;"],
           latex: [["exclam", "!", "&#x21;"]],
           omml: ["&#x21;"],
-          html: ["&#x21;"],
+          html: ["&#x21;", "!"],
         }.freeze
 
         # output methods

--- a/lib/plurimath/math/symbols/minus.rb
+++ b/lib/plurimath/math/symbols/minus.rb
@@ -10,7 +10,7 @@ module Plurimath
           mathml: ["&#x2212;", "-"],
           latex: [["minus", "-", "&#x2212;"]],
           omml: ["&#x2212;"],
-          html: ["&#x2212;"],
+          html: ["&#x2212;", "-"],
         }.freeze
 
         # output methods

--- a/lib/plurimath/math/symbols/percent.rb
+++ b/lib/plurimath/math/symbols/percent.rb
@@ -10,7 +10,7 @@ module Plurimath
           mathml: ["&#x25;"],
           latex: [["percent", "%", "&#x25;"]],
           omml: ["&#x25;"],
-          html: ["&#x25;"],
+          html: ["&#x25;", "%"],
         }.freeze
 
         # output methods

--- a/lib/plurimath/math/symbols/pi.rb
+++ b/lib/plurimath/math/symbols/pi.rb
@@ -10,7 +10,7 @@ module Plurimath
           mathml: ["&#x3c0;", "&#x1d70b;"],
           latex: ["pi", "uppi", "&#x3c0;", "&#x1d70b;"],
           omml: ["&#x3c0;", "&#x1d70b;"],
-          html: ["&#x3C0;", "&#x1d70b;"],
+          html: ["&#x3C0;", "&#x3c0;", "&#x1d70b;"],
         }.freeze
 
         # output methods

--- a/lib/plurimath/math/symbols/slash.rb
+++ b/lib/plurimath/math/symbols/slash.rb
@@ -10,7 +10,7 @@ module Plurimath
           mathml: ["&#x2215;"],
           latex: [["divslash", "slash", "/", "&#x2215;"]],
           omml: ["&#x2215;"],
-          html: ["&#x2215;"],
+          html: ["&#x2215;", "/"],
         }.freeze
 
         # output methods

--- a/spec/plurimath/html/parse_spec.rb
+++ b/spec/plurimath/html/parse_spec.rb
@@ -338,7 +338,7 @@ RSpec.describe Plurimath::Html::Parse do
     end
 
     context "contains HTML math example #20" do
-      let(:string) { "<i>f</i>(<i>x</x>)" }
+      let(:string) { "<i>f</i>(<i>x</i>)" }
 
       it "returns abstract parsed tree" do
         int_exp = formula[:parse_parenthesis]
@@ -351,7 +351,7 @@ RSpec.describe Plurimath::Html::Parse do
     end
 
     context "contains HTML math example #21" do
-      let(:string) { "<i>f</i>(<i>g</i>(<i>x</x>))" }
+      let(:string) { "<i>f</i>(<i>g</i>(<i>x</i>))" }
 
       it "returns abstract parsed tree" do
         first_value        = formula[:parse_parenthesis]
@@ -456,7 +456,7 @@ RSpec.describe Plurimath::Html::Parse do
     end
 
     context "contains HTML math example #29" do
-      let(:string) { "<i>f</i><sup>-1</sup>(<i>x</x>)" }
+      let(:string) { "<i>f</i><sup>-1</sup>(<i>x</i>)" }
 
       it "returns abstract parsed tree" do
         sup_value   = formula[:sup_value]

--- a/spec/plurimath/html/parser_spec.rb
+++ b/spec/plurimath/html/parser_spec.rb
@@ -1264,6 +1264,10 @@ RSpec.describe Plurimath::Html::Parser do
             Plurimath::Math::Symbols::Times.new,
           ],
           [
+            "1 × 2",
+            Plurimath::Math::Symbols::Times.new,
+          ],
+          [
             "1 &sdot; 2",
             Plurimath::Math::Symbols::Cdot.new,
           ],
@@ -1520,6 +1524,33 @@ RSpec.describe Plurimath::Html::Parser do
                                                         Plurimath::Math::Function::Text.new("b"),
                                                       ])
         expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains a custom tag that starts with br" do
+      let(:string) { "<bravo>x</bravo>" }
+
+      it "treats it as a transparent HTML wrapper" do
+        expected_value = Plurimath::Math::Formula.new([
+                                                        Plurimath::Math::Function::Text.new("x"),
+                                                      ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains a self-closing custom tag that starts with br" do
+      let(:string) { "<bravo/>x" }
+
+      it "does not parse it as an HTML line break" do
+        expect { formula }.to raise_error(Parslet::ParseFailed)
+      end
+    end
+
+    context "contains a table cell tag that starts with td" do
+      let(:string) { "<table><tr><tdx>1</td></tr></table>" }
+
+      it "does not parse it as a table cell" do
+        expect { formula }.to raise_error(Parslet::ParseFailed)
       end
     end
 

--- a/spec/plurimath/html/parser_spec.rb
+++ b/spec/plurimath/html/parser_spec.rb
@@ -1523,6 +1523,14 @@ RSpec.describe Plurimath::Html::Parser do
       end
     end
 
+    context "contains a malformed unquoted attribute" do
+      let(:string) { "<span < bad>x</span>" }
+
+      it "does not accept the malformed HTML wrapper" do
+        expect { formula }.to raise_error(Parslet::ParseFailed)
+      end
+    end
+
     context "contains a mismatched wrapper tag" do
       let(:string) { "<i>x</x>" }
 

--- a/spec/plurimath/html/parser_spec.rb
+++ b/spec/plurimath/html/parser_spec.rb
@@ -3,8 +3,10 @@ require "spec_helper"
 RSpec.describe Plurimath::Html::Parser do
   describe ".parse" do
     subject(:formula) do
-      described_class.new(string.gsub(/\s/, "")).parse
+      described_class.new(parser_input).parse
     end
+
+    let(:parser_input) { string.gsub(/\s/, "") }
 
     context "basic parse rules for single character tag" do
       let(:string) { "<i>&sum;</i>" }
@@ -212,7 +214,7 @@ RSpec.describe Plurimath::Html::Parser do
 
       it "returns abstract parsed tree" do
         expected_value = Plurimath::Math::Formula.new([
-                                                        Plurimath::Math::Symbols::Symbol.new("ϑ"),
+                                                        Plurimath::Math::Symbols::Vartheta.new,
                                                         Plurimath::Math::Formula.new([
                                                                                        Plurimath::Math::Symbols::Paren::Lround.new,
                                                                                        Plurimath::Math::Function::Text.new("t"),
@@ -355,7 +357,7 @@ RSpec.describe Plurimath::Html::Parser do
                                                         Plurimath::Math::Function::Power.new(
                                                           Plurimath::Math::Function::Text.new("a"),
                                                           Plurimath::Math::Formula.new([
-                                                                                         Plurimath::Math::Symbols::Symbol.new("-"),
+                                                                                         Plurimath::Math::Symbols::Minus.new,
                                                                                          Plurimath::Math::Number.new("2"),
                                                                                        ]),
                                                         ),
@@ -372,7 +374,7 @@ RSpec.describe Plurimath::Html::Parser do
                                                         Plurimath::Math::Function::Base.new(
                                                           Plurimath::Math::Function::Text.new("a"),
                                                           Plurimath::Math::Formula.new([
-                                                                                         Plurimath::Math::Symbols::Symbol.new("-"),
+                                                                                         Plurimath::Math::Symbols::Minus.new,
                                                                                          Plurimath::Math::Number.new("2"),
                                                                                        ]),
                                                         ),
@@ -389,7 +391,7 @@ RSpec.describe Plurimath::Html::Parser do
                                                         Plurimath::Math::Function::Power.new(
                                                           Plurimath::Math::Function::Text.new("a"),
                                                           Plurimath::Math::Formula.new([
-                                                                                         Plurimath::Math::Symbols::Symbol.new("-"),
+                                                                                         Plurimath::Math::Symbols::Minus.new,
                                                                                          Plurimath::Math::Function::Text.new("n"),
                                                                                        ]),
                                                         ),
@@ -406,7 +408,7 @@ RSpec.describe Plurimath::Html::Parser do
                                                         Plurimath::Math::Function::Base.new(
                                                           Plurimath::Math::Function::Text.new("a"),
                                                           Plurimath::Math::Formula.new([
-                                                                                         Plurimath::Math::Symbols::Symbol.new("-"),
+                                                                                         Plurimath::Math::Symbols::Minus.new,
                                                                                          Plurimath::Math::Function::Text.new("n"),
                                                                                        ]),
                                                         ),
@@ -456,7 +458,7 @@ RSpec.describe Plurimath::Html::Parser do
     end
 
     context "contains HTML math example #20" do
-      let(:string) { "<i>f</i>(<i>x</x>)" }
+      let(:string) { "<i>f</i>(<i>x</i>)" }
 
       it "returns abstract parsed tree" do
         expected_value = Plurimath::Math::Formula.new([
@@ -472,7 +474,7 @@ RSpec.describe Plurimath::Html::Parser do
     end
 
     context "contains HTML math example #21" do
-      let(:string) { "<i>f</i>(<i>g</i>(<i>x</x>))" }
+      let(:string) { "<i>f</i>(<i>g</i>(<i>x</i>))" }
 
       it "returns abstract parsed tree" do
         expected_value = Plurimath::Math::Formula.new([
@@ -498,7 +500,7 @@ RSpec.describe Plurimath::Html::Parser do
       it "returns abstract parsed tree" do
         expected_value = Plurimath::Math::Formula.new([
                                                         Plurimath::Math::Function::Text.new("f"),
-                                                        Plurimath::Math::Symbols::Symbol.new("&sum;"),
+                                                        Plurimath::Math::Symbols::Sum.new,
                                                         Plurimath::Math::Formula.new([
                                                                                        Plurimath::Math::Symbols::Paren::Lround.new,
                                                                                        Plurimath::Math::Function::Text.new("n"),
@@ -557,7 +559,7 @@ RSpec.describe Plurimath::Html::Parser do
 
       it "returns abstract parsed tree" do
         expected_value = Plurimath::Math::Formula.new([
-                                                        Plurimath::Math::Symbols::Symbol.new("&omega;"),
+                                                        Plurimath::Math::Symbols::Omega.new,
                                                       ])
         expect(formula).to eq(expected_value)
       end
@@ -568,7 +570,7 @@ RSpec.describe Plurimath::Html::Parser do
 
       it "returns abstract parsed tree" do
         expected_value = Plurimath::Math::Formula.new([
-                                                        Plurimath::Math::Symbols::Symbol.new("&Omega;"),
+                                                        Plurimath::Math::Symbols::UpcaseOmega.new,
                                                       ])
         expect(formula).to eq(expected_value)
       end
@@ -579,9 +581,9 @@ RSpec.describe Plurimath::Html::Parser do
 
       it "returns abstract parsed tree" do
         expected_value = Plurimath::Math::Formula.new([
-                                                        Plurimath::Math::Symbols::Symbol.new("α"),
-                                                        Plurimath::Math::Symbols::Symbol.new("β"),
-                                                        Plurimath::Math::Symbols::Symbol.new("γ"),
+                                                        Plurimath::Math::Symbols::Alpha.new,
+                                                        Plurimath::Math::Symbols::Upbeta.new,
+                                                        Plurimath::Math::Symbols::Gamma.new,
                                                       ])
         expect(formula).to eq(expected_value)
       end
@@ -601,14 +603,14 @@ RSpec.describe Plurimath::Html::Parser do
     end
 
     context "contains HTML math example #29" do
-      let(:string) { "<i>f</i><sup>-1</sup>(<i>x</x>)" }
+      let(:string) { "<i>f</i><sup>-1</sup>(<i>x</i>)" }
 
       it "returns abstract parsed tree" do
         expected_value = Plurimath::Math::Formula.new([
                                                         Plurimath::Math::Function::Power.new(
                                                           Plurimath::Math::Function::Text.new("f"),
                                                           Plurimath::Math::Formula.new([
-                                                                                         Plurimath::Math::Symbols::Symbol.new("-"),
+                                                                                         Plurimath::Math::Symbols::Minus.new,
                                                                                          Plurimath::Math::Number.new("1"),
                                                                                        ]),
                                                         ),
@@ -1251,6 +1253,297 @@ RSpec.describe Plurimath::Html::Parser do
                                                         Plurimath::Math::Symbols::Paren::Rround.new,
                                                       ])
         expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains fake HTML math operator entities" do
+      it "parses multiplication, division, and dot operators" do
+        operator_examples = [
+          [
+            "1 &times; 2",
+            Plurimath::Math::Symbols::Times.new,
+          ],
+          [
+            "1 &sdot; 2",
+            Plurimath::Math::Symbols::Cdot.new,
+          ],
+          [
+            "1 ⋅ 2",
+            Plurimath::Math::Symbols::Cdot.new,
+          ],
+          [
+            "1 / 2",
+            Plurimath::Math::Symbols::Slash.new,
+          ],
+          [
+            "1 &divide; 2",
+            Plurimath::Math::Symbols::Div.new,
+          ],
+        ]
+
+        operator_examples.each do |input, operator|
+          parsed_formula = described_class.new(input).parse
+          expected_value = Plurimath::Math::Formula.new([
+                                                          Plurimath::Math::Number.new("1"),
+                                                          operator,
+                                                          Plurimath::Math::Number.new("2"),
+                                                        ])
+          expect(parsed_formula).to eq(expected_value)
+        end
+      end
+
+      it "parses equation and inequality entities" do
+        operator_examples = [
+          [
+            "1 &lt; 2",
+            "1",
+            Plurimath::Math::Symbols::Less.new,
+          ],
+          [
+            "1 &le; 2",
+            "1",
+            Plurimath::Math::Symbols::Le.new,
+          ],
+          [
+            "3 &gt; 2",
+            "3",
+            Plurimath::Math::Symbols::Greater.new,
+          ],
+          [
+            "3 &ge; 2",
+            "3",
+            Plurimath::Math::Symbols::Ge.new,
+          ],
+          [
+            "1 &ne; 2",
+            "1",
+            Plurimath::Math::Symbols::Ne.new,
+          ],
+        ]
+
+        operator_examples.each do |input, first_value, operator|
+          parsed_formula = described_class.new(input).parse
+          expected_value = Plurimath::Math::Formula.new([
+                                                          Plurimath::Math::Number.new(first_value),
+                                                          operator,
+                                                          Plurimath::Math::Number.new("2"),
+                                                        ])
+          expect(parsed_formula).to eq(expected_value)
+        end
+      end
+
+      it "parses ASCII punctuation through symbol classes when available" do
+        operator_examples = [
+          [
+            "-123",
+            [
+              Plurimath::Math::Symbols::Minus.new,
+              Plurimath::Math::Number.new("123"),
+            ],
+          ],
+          [
+            "4!",
+            [
+              Plurimath::Math::Number.new("4"),
+              Plurimath::Math::Symbols::Exclam.new,
+            ],
+          ],
+          [
+            "30%",
+            [
+              Plurimath::Math::Number.new("30"),
+              Plurimath::Math::Symbols::Percent.new,
+            ],
+          ],
+        ]
+
+        operator_examples.each do |input, expected_symbols|
+          expect(described_class.new(input).parse).to eq(
+            Plurimath::Math::Formula.new(expected_symbols),
+          )
+        end
+      end
+    end
+
+    context "contains fake HTML math logic and quantified entities" do
+      it "parses logic operators" do
+        expected_value = Plurimath::Math::Formula.new([
+                                                        Plurimath::Math::Symbols::Lnot.new,
+                                                        Plurimath::Math::Function::Text.new("p"),
+                                                        Plurimath::Math::Symbols::Land.new,
+                                                        Plurimath::Math::Function::Text.new("q"),
+                                                        Plurimath::Math::Symbols::Lor.new,
+                                                        Plurimath::Math::Function::Text.new("r"),
+                                                      ])
+
+        expect(described_class.new("&not;<i>p</i>&and;<i>q</i>&or;<i>r</i>").parse).to eq(expected_value)
+      end
+
+      it "parses quantified and infinity entities" do
+        expected_value = Plurimath::Math::Formula.new([
+                                                        Plurimath::Math::Symbols::Aa.new,
+                                                        Plurimath::Math::Function::Text.new("x"),
+                                                        Plurimath::Math::Symbols::Ee.new,
+                                                        Plurimath::Math::Function::Text.new("y"),
+                                                        Plurimath::Math::Symbols::Oo.new,
+                                                      ])
+
+        expect(described_class.new("&forall;<i>x</i>&exist;<i>y</i>&infin;").parse).to eq(expected_value)
+      end
+    end
+
+    context "contains semantic HTML with attributes" do
+      let(:string) { '<span class="math"><var>x</var><sup>2</sup></span>' }
+      let(:parser_input) { string }
+
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+                                                        Plurimath::Math::Function::Power.new(
+                                                          Plurimath::Math::Function::Text.new("x"),
+                                                          Plurimath::Math::Number.new("2"),
+                                                        ),
+                                                      ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains uppercase semantic tags" do
+      let(:string) { "<VAR>&#x2211;</VAR><SUB>i</SUB>" }
+
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+                                                        Plurimath::Math::Function::Sum.new(
+                                                          Plurimath::Math::Function::Text.new("i"),
+                                                        ),
+                                                      ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains an HTML line break" do
+      let(:string) { "a<br/>b" }
+
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+                                                        Plurimath::Math::Function::Text.new("a"),
+                                                        Plurimath::Math::Function::Linebreak.new,
+                                                        Plurimath::Math::Function::Text.new("b"),
+                                                      ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains table sections, header cells, and attributes" do
+      let(:string) { '<table class="matrix"><tbody><tr><th>x</th><td data-column="2">y</td></tr></tbody></table>' }
+      let(:parser_input) { string }
+
+      it "returns abstract parsed tree" do
+        expected_value = Plurimath::Math::Formula.new([
+                                                        Plurimath::Math::Function::Table.new([
+                                                                                               Plurimath::Math::Function::Tr.new([
+                                                                                                                                   Plurimath::Math::Function::Td.new([
+                                                                                                                                                                       Plurimath::Math::Function::Text.new("x"),
+                                                                                                                                                                     ]),
+                                                                                                                                   Plurimath::Math::Function::Td.new([
+                                                                                                                                                                       Plurimath::Math::Function::Text.new("y"),
+                                                                                                                                                                     ]),
+                                                                                                                                 ]),
+                                                                                             ]),
+                                                      ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains header cells without attributes" do
+      let(:string) { "<table><tr><th>x</th><td>y</td></tr></table>" }
+
+      it "aliases header cells to table cells" do
+        expected_value = Plurimath::Math::Formula.new([
+                                                        Plurimath::Math::Function::Table.new([
+                                                                                               Plurimath::Math::Function::Tr.new([
+                                                                                                                                   Plurimath::Math::Function::Td.new([
+                                                                                                                                                                       Plurimath::Math::Function::Text.new("x"),
+                                                                                                                                                                     ]),
+                                                                                                                                   Plurimath::Math::Function::Td.new([
+                                                                                                                                                                       Plurimath::Math::Function::Text.new("y"),
+                                                                                                                                                                     ]),
+                                                                                                                                 ]),
+                                                                                             ]),
+                                                      ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains custom wrapper elements" do
+      let(:string) { '<math-field data-input="html"><var>x</var><sup>2</sup></math-field>' }
+      let(:parser_input) { string }
+
+      it "treats custom elements as transparent HTML wrappers" do
+        expected_value = Plurimath::Math::Formula.new([
+                                                        Plurimath::Math::Function::Power.new(
+                                                          Plurimath::Math::Function::Text.new("x"),
+                                                          Plurimath::Math::Number.new("2"),
+                                                        ),
+                                                      ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains nested semantic wrappers with whitespace" do
+      let(:string) { '<section class="math"><p><em>a</em><sub>1</sub>+<strong>b</strong><sup>2</sup></p></section>' }
+      let(:parser_input) { string }
+
+      it "parses supported HTML wrappers and keeps math semantics" do
+        expected_value = Plurimath::Math::Formula.new([
+                                                        Plurimath::Math::Function::Base.new(
+                                                          Plurimath::Math::Function::Text.new("a"),
+                                                          Plurimath::Math::Number.new("1"),
+                                                        ),
+                                                        Plurimath::Math::Symbols::Plus.new,
+                                                        Plurimath::Math::Function::Power.new(
+                                                          Plurimath::Math::Function::Text.new("b"),
+                                                          Plurimath::Math::Number.new("2"),
+                                                        ),
+                                                      ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains HTML line break attributes" do
+      let(:string) { 'a<br class="line">b' }
+      let(:parser_input) { string }
+
+      it "parses the HTML line break" do
+        expected_value = Plurimath::Math::Formula.new([
+                                                        Plurimath::Math::Function::Text.new("a"),
+                                                        Plurimath::Math::Function::Linebreak.new,
+                                                        Plurimath::Math::Function::Text.new("b"),
+                                                      ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains a mismatched wrapper tag" do
+      let(:string) { "<i>x</x>" }
+
+      it "does not accept the HTML wrapper" do
+        expect { formula }.to raise_error(Parslet::ParseFailed)
+      end
+    end
+
+    context "contains a mismatched table cell tag" do
+      let(:string) { "<table><tr><td>x</th></tr></table>" }
+
+      it "does not accept the table structure" do
+        expect { formula }.to raise_error(Parslet::ParseFailed)
+      end
+    end
+
+    context "contains MathML" do
+      let(:string) { "<math><mi>x</mi></math>" }
+
+      it "does not parse it as HTML math" do
+        expect { formula }.to raise_error(Parslet::ParseFailed)
       end
     end
 

--- a/spec/plurimath/html/parser_spec.rb
+++ b/spec/plurimath/html/parser_spec.rb
@@ -1539,11 +1539,25 @@ RSpec.describe Plurimath::Html::Parser do
       end
     end
 
-    context "contains MathML" do
+    context "contains a math wrapper element" do
       let(:string) { "<math><mi>x</mi></math>" }
 
-      it "does not parse it as HTML math" do
-        expect { formula }.to raise_error(Parslet::ParseFailed)
+      it "treats it as a transparent HTML wrapper" do
+        expected_value = Plurimath::Math::Formula.new([
+                                                        Plurimath::Math::Function::Text.new("x"),
+                                                      ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains a custom wrapper that starts with math" do
+      let(:string) { "<mathematics>x</mathematics>" }
+
+      it "treats it as a transparent HTML wrapper" do
+        expected_value = Plurimath::Math::Formula.new([
+                                                        Plurimath::Math::Function::Text.new("x"),
+                                                      ])
+        expect(formula).to eq(expected_value)
       end
     end
 

--- a/spec/plurimath/html/to_html_round_trip_spec.rb
+++ b/spec/plurimath/html/to_html_round_trip_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe Plurimath::Html::Parser do

--- a/spec/plurimath/html/to_html_round_trip_spec.rb
+++ b/spec/plurimath/html/to_html_round_trip_spec.rb
@@ -1,0 +1,146 @@
+require "spec_helper"
+
+RSpec.describe Plurimath::Html::Parser do
+  describe ".parse" do
+    subject(:formula) do
+      described_class.new(html).parse
+    end
+
+    let(:formula_class) { Plurimath::Math::Formula }
+    let(:html) { exp.to_html.gsub(/\s/, "") }
+    let(:number_value) { Plurimath::Math::Number.new("2") }
+    let(:text_value) { Plurimath::Math::Function::Text.new("x") }
+
+    context "contains sqrt function output" do
+      let(:exp) do
+        formula_class.new([
+                            Plurimath::Math::Function::Sqrt.new(text_value),
+                          ])
+      end
+
+      it "round-trips the Formula to HTML output" do
+        expect(formula).to eq(exp)
+      end
+    end
+
+    context "contains sum function output" do
+      let(:exp) do
+        formula_class.new([
+                            Plurimath::Math::Function::Sum.new(
+                              text_value,
+                              number_value,
+                            ),
+                          ])
+      end
+
+      it "round-trips the Formula to HTML output" do
+        expect(formula).to eq(exp)
+      end
+    end
+
+    context "contains lim function output" do
+      let(:exp) do
+        formula_class.new([
+                            Plurimath::Math::Function::Lim.new(
+                              text_value,
+                              number_value,
+                            ),
+                          ])
+      end
+
+      it "round-trips the Formula to HTML output" do
+        expect(formula).to eq(exp)
+      end
+    end
+
+    context "contains mod function output" do
+      let(:exp) do
+        formula_class.new([
+                            Plurimath::Math::Function::Mod.new(
+                              text_value,
+                              number_value,
+                            ),
+                          ])
+      end
+
+      it "round-trips the Formula to HTML output" do
+        expect(formula).to eq(exp)
+      end
+    end
+
+    context "contains linebreak function output" do
+      let(:exp) do
+        formula_class.new([
+                            Plurimath::Math::Function::Linebreak.new,
+                          ])
+      end
+
+      it "round-trips the Formula to HTML output" do
+        expect(formula).to eq(exp)
+      end
+    end
+
+    context "contains table function output" do
+      let(:exp) do
+        formula_class.new([
+                            Plurimath::Math::Function::Table.new([
+                                                                   Plurimath::Math::Function::Tr.new([
+                                                                                                       Plurimath::Math::Function::Td.new([text_value]),
+                                                                                                     ]),
+                                                                 ]),
+                          ])
+      end
+
+      it "round-trips the Formula to HTML output" do
+        expect(formula).to eq(exp)
+      end
+    end
+
+    context "contains pi symbol output" do
+      let(:exp) do
+        formula_class.new([
+                            Plurimath::Math::Symbols::Pi.new,
+                          ])
+      end
+
+      it "round-trips the Formula to HTML output" do
+        expect(formula).to eq(exp)
+      end
+    end
+
+    context "contains ceil function output" do
+      let(:exp) do
+        formula_class.new([
+                            Plurimath::Math::Function::Ceil.new(text_value),
+                          ])
+      end
+
+      it "parses to delimiter symbols because the HTML output is glyph-based" do
+        expected_value = formula_class.new([
+                                             Plurimath::Math::Symbols::Paren::Lceil.new,
+                                             text_value,
+                                             Plurimath::Math::Symbols::Paren::Rceil.new,
+                                           ])
+
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "contains vec function output" do
+      let(:exp) do
+        formula_class.new([
+                            Plurimath::Math::Function::Vec.new(text_value),
+                          ])
+      end
+
+      it "parses to an arrow symbol because the HTML output is glyph-based" do
+        expected_value = formula_class.new([
+                                             Plurimath::Math::Symbols::Rightarrow.new,
+                                             text_value,
+                                           ])
+
+        expect(formula).to eq(expected_value)
+      end
+    end
+  end
+end

--- a/spec/plurimath/math/formula/html_spec.rb
+++ b/spec/plurimath/math/formula/html_spec.rb
@@ -1157,7 +1157,7 @@ RSpec.describe Plurimath::Math::Formula do
       end
 
       it "returns abstract parsed tree" do
-        expected_value = "<i>(3)</i><i>(e)</i>"
+        expected_value = "<i>lim</i><i>(3)</i><i>(e)</i>"
         expect(formula).to eq(expected_value)
       end
     end
@@ -1183,7 +1183,7 @@ RSpec.describe Plurimath::Math::Formula do
       end
 
       it "returns abstract parsed tree" do
-        expected_value = "<i>(3e)</i><i>(em)</i>"
+        expected_value = "<i>lim</i><i>(3e)</i><i>(em)</i>"
         expect(formula).to eq(expected_value)
       end
     end
@@ -1212,7 +1212,7 @@ RSpec.describe Plurimath::Math::Formula do
       end
 
       it "returns abstract parsed tree" do
-        expected_value = "<i>(3am)</i><i>(rest)</i>"
+        expected_value = "<i>lim</i><i>(3am)</i><i>(rest)</i>"
         expect(formula).to eq(expected_value)
       end
     end

--- a/spec/plurimath/math/function/lim_spec.rb
+++ b/spec/plurimath/math/function/lim_spec.rb
@@ -229,6 +229,15 @@ RSpec.describe Plurimath::Math::Function::Lim do
       described_class.new(first_value, second_value).to_html(options: {})
     end
 
+    context "contains no values" do
+      let(:first_value) { nil }
+      let(:second_value) { nil }
+
+      it "returns html string" do
+        expect(formula).to eql("<i>lim</i>")
+      end
+    end
+
     context "contains Symbol as value" do
       let(:first_value) { Plurimath::Math::Symbols::Symbol.new("n") }
       let(:second_value) do
@@ -241,7 +250,7 @@ RSpec.describe Plurimath::Math::Function::Lim do
       end
 
       it "returns html string" do
-        expect(formula).to eql("<i>n</i><i><i>&prod;</i><sub>&</sub><sup>so</sup></i>")
+        expect(formula).to eql("<i>lim</i><i>n</i><i><i>&prod;</i><sub>&</sub><sup>so</sup></i>")
       end
     end
 
@@ -250,7 +259,7 @@ RSpec.describe Plurimath::Math::Function::Lim do
       let(:second_value) { Plurimath::Math::Symbols::Symbol.new("n") }
 
       it "returns html string" do
-        expect(formula).to eql("<i>70</i><i>n</i>")
+        expect(formula).to eql("<i>lim</i><i>70</i><i>n</i>")
       end
     end
 
@@ -273,7 +282,7 @@ RSpec.describe Plurimath::Math::Function::Lim do
       end
 
       it "returns html string" do
-        expect(formula).to eql("<i><i>&sum;</i><sub>&</sub><sup>so</sup></i><i><i>&prod;</i><sub>&</sub><sup>so</sup></i>")
+        expect(formula).to eql("<i>lim</i><i><i>&sum;</i><sub>&</sub><sup>so</sup></i><i><i>&prod;</i><sub>&</sub><sup>so</sup></i>")
       end
     end
   end


### PR DESCRIPTION
This PR expands `Plurimath::Html` parsing so HTML math fragments can be converted into `Plurimath::Math::Formula` more completely and consistently.

## Changes

- Supports attributes on parsed HTML math tags.
- Supports case-insensitive HTML tag names.
- Validates matching opening and closing wrapper tags.
- Supports transparent wrapper elements, including custom and hyphenated tag names.
- Parses `<br>` and `<br/>` as linebreak functions.
- Parses `<th>` table cells the same way as `<td>`.
- Handles named, decimal, and hexadecimal HTML entities before transformation.
- Maps supported HTML symbols/entities to Plurimath symbol classes.
- Keeps subscript/superscript transformation behavior consistent through `Html::TransformUtility`.
- Adds parser specs for HTML entity operators, logic symbols, quantifiers, line breaks, table header cells, attributes, custom wrappers, and mismatched tags.

closes #29 
