### PR TITLE
Add configured decimal parsing for AsciiMath

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -164,8 +164,13 @@ formula = Plurimath::Math.parse(asciimath, :asciimath)
 
 AsciiMath, LaTeX, HTML, and UnicodeMath input use the configured locale decimal
 marker from `Plurimath::Formatter::SupportedLocales::LOCALES` when parsing
-numbers. Use scoped configuration when only one parse should use the locale
+numbers. Use `Plurimath.configure` for persistent defaults, or
+`Plurimath.with_configuration` when only one parse should use the locale
 override.
+
+For AsciiMath, LaTeX, and HTML, the configured marker is the decimal marker.
+When a locale uses a non-full-stop marker, `1.2` is parsed as `1`, `.`, and
+`2`, not as one decimal number.
 
 [source,ruby]
 ----
@@ -217,9 +222,13 @@ symbol followed by a number.
 1,2
 ----
 
-UnicodeMath keeps accepting its existing full stop and comma decimal markers,
-and also accepts the configured locale marker for locales that use a different
-decimal symbol.
+UnicodeMath is different: it keeps its existing full stop and comma decimal
+grammar, including leading markers such as `.2` and `,2`, and also accepts the
+configured locale marker.
+
+Localized decimal parsing preserves the parsed number text, such as `1,2` or
+`1٫2`. Number formatter input remains canonical decimal input; locale decimal
+and grouping symbols are applied when formatting output.
 
 ==== MathML Formula example
 

--- a/README.adoc
+++ b/README.adoc
@@ -162,11 +162,10 @@ formula = Plurimath::Math.parse(asciimath, :asciimath)
 
 ==== Localized decimal input
 
-AsciiMath, LaTeX, HTML, and UnicodeMath input use the configured locale decimal
-marker from `Plurimath::Formatter::SupportedLocales::LOCALES` when parsing
-numbers. Use `Plurimath.configure` for persistent defaults, or
-`Plurimath.with_configuration` when only one parse should use the locale
-override.
+AsciiMath, LaTeX, HTML, and UnicodeMath input can use a locale decimal marker
+from `Plurimath::Formatter::SupportedLocales::LOCALES` when parsing numbers.
+Pass `locale:` to `Plurimath::Math.parse` for one parse, or use
+`Plurimath.configure` for persistent defaults.
 
 For AsciiMath, LaTeX, and HTML, the configured marker is the decimal marker.
 When a locale uses a non-full-stop marker, `1.2` is parsed as `1`, `.`, and
@@ -174,10 +173,7 @@ When a locale uses a non-full-stop marker, `1.2` is parsed as `1`, `.`, and
 
 [source,ruby]
 ----
-formula = Plurimath.with_configuration do |config|
-  config.locale = :fr
-  Plurimath::Math.parse("1,2", :asciimath)
-end
+formula = Plurimath::Math.parse("1,2", :asciimath, locale: :fr)
 ----
 
 When the locale decimal marker is a comma, unspaced digit-comma-digit input is
@@ -206,20 +202,20 @@ Persian locales use the Arabic decimal separator.
 
 [source,ruby]
 ----
-formula = Plurimath.with_configuration do |config|
-  config.locale = :ar
-  Plurimath::Math.parse("1٫2", :unicodemath)
-end
+formula = Plurimath::Math.parse("1٫2", :unicode, locale: :ar)
 ----
 
 LaTeX ordinary spaces are removed during parser preprocessing, so `1, 2` is
 equivalent to `1,2` for this parser. With a comma decimal marker, only
 digit-comma-digit is parsed as a decimal number; a leading comma remains a comma
-symbol followed by a number.
+symbol followed by a number. To write a comma separator between two digits,
+wrap the comma or the following value in a group, such as `1{,}2` or `1,{}2`.
 
 [source,latex]
 ----
-1,2
+1,2      % decimal number
+1{,}2    % comma separator
+1,{}2    % comma separator
 ----
 
 UnicodeMath is different: it keeps its existing full stop and comma decimal

--- a/README.adoc
+++ b/README.adoc
@@ -160,6 +160,30 @@ asciimath = "sin(1)"
 formula = Plurimath::Math.parse(asciimath, :asciimath)
 ----
 
+==== AsciiMath localized decimal input
+
+AsciiMath input can use the configured locale decimal marker. Use scoped
+configuration when only one parse should use the locale override.
+
+[source,ruby]
+----
+formula = Plurimath.with_configuration do |config|
+  config.locale = :fr
+  Plurimath::Math.parse("1,2", :asciimath)
+end
+----
+
+When the locale decimal marker is a comma, unspaced digit-comma-digit input is
+read as a decimal number. Commas used as AsciiMath separators should be written
+with spaces around the comma.
+
+[source,asciimath]
+----
+1,2      # decimal number
+,2       # leading decimal marker
+1 , 2    # comma separator
+----
+
 ==== MathML Formula example
 
 [source,ruby]

--- a/README.adoc
+++ b/README.adoc
@@ -160,10 +160,12 @@ asciimath = "sin(1)"
 formula = Plurimath::Math.parse(asciimath, :asciimath)
 ----
 
-==== AsciiMath localized decimal input
+==== Localized decimal input
 
-AsciiMath input can use the configured locale decimal marker. Use scoped
-configuration when only one parse should use the locale override.
+AsciiMath, LaTeX, HTML, and UnicodeMath input use the configured locale decimal
+marker from `Plurimath::Formatter::SupportedLocales::LOCALES` when parsing
+numbers. Use scoped configuration when only one parse should use the locale
+override.
 
 [source,ruby]
 ----
@@ -174,14 +176,50 @@ end
 ----
 
 When the locale decimal marker is a comma, unspaced digit-comma-digit input is
-read as a decimal number. Commas used as AsciiMath separators should be written
-with spaces around the comma.
+read as a decimal number.
 
 [source,asciimath]
 ----
 1,2      # decimal number
 1 , 2    # comma separator
 ----
+
+AsciiMath uses commas for expression and table separators, so separator commas
+must be written with spaces around them when the configured decimal marker is a
+comma.
+
+HTML can use the same configured decimal marker inside plain text or tags.
+
+[source,html]
+----
+1,2
+<span>1,2</span>
+----
+
+Locales are not limited to full stop and comma markers. For example, Arabic and
+Persian locales use the Arabic decimal separator.
+
+[source,ruby]
+----
+formula = Plurimath.with_configuration do |config|
+  config.locale = :ar
+  Plurimath::Math.parse("1٫2", :unicodemath)
+end
+----
+
+LaTeX ordinary spaces are removed during parser preprocessing, so `1, 2` is
+equivalent to `1,2` for this parser. With a comma decimal marker, only
+digit-comma-digit is parsed as a decimal number; a leading comma remains a comma
+symbol followed by a number.
+
+[source,latex]
+----
+1,2
+----
+
+UnicodeMath keeps accepting its existing full stop and comma decimal markers,
+and also accepts the configured locale marker for locales that use a different
+decimal symbol.
 
 ==== MathML Formula example
 

--- a/README.adoc
+++ b/README.adoc
@@ -180,7 +180,6 @@ with spaces around the comma.
 [source,asciimath]
 ----
 1,2      # decimal number
-,2       # leading decimal marker
 1 , 2    # comma separator
 ----
 

--- a/README.adoc
+++ b/README.adoc
@@ -186,8 +186,8 @@ read as a decimal number.
 ----
 
 AsciiMath uses commas for expression and table separators, so separator commas
-must be written with spaces around them when the configured decimal marker is a
-comma.
+between digit tokens should be written with spaces around them when the
+configured decimal marker is a comma.
 
 HTML can use the same configured decimal marker inside plain text or tags.
 

--- a/lib/plurimath.rb
+++ b/lib/plurimath.rb
@@ -41,7 +41,14 @@ module Plurimath
     yield(configuration)
   end
 
-  module_function :mml_adapter, :configuration, :configure
+  def with_configuration
+    previous_configuration = configuration.dup
+    yield(configuration)
+  ensure
+    @configuration = previous_configuration
+  end
+
+  module_function :mml_adapter, :configuration, :configure, :with_configuration
 end
 
 default_adapter =

--- a/lib/plurimath.rb
+++ b/lib/plurimath.rb
@@ -42,7 +42,9 @@ module Plurimath
   end
 
   def with_configuration
-    previous_configuration = configuration.dup
+    # Swap the global config to an isolated copy so block mutations are scoped.
+    previous_configuration = configuration
+    @configuration = previous_configuration.dup
     yield(configuration)
   ensure
     @configuration = previous_configuration

--- a/lib/plurimath/asciimath/parse.rb
+++ b/lib/plurimath/asciimath/parse.rb
@@ -10,8 +10,8 @@ module Plurimath
       rule(:comma)  { str(",") >> space? }
       rule(:space?) { space.maybe }
       rule(:number) do
-        (match("[0-9]").repeat(1) >> str(".") >> match("[0-9]").repeat(1)).as(:number) |
-          match("[0-9]").repeat(1).as(:number) |
+        decimal_number.as(:number) |
+          digits.as(:number) |
           str(".").as(:symbol)
       end
 
@@ -77,13 +77,13 @@ module Plurimath
         sub_sup_classes |
           binary_classes |
           ternary_classes |
+          number |
           hash_to_expression(Constants.precompile_constants) |
           (match(/[0-9]/).as(:number) >> str(",").as(:comma)).repeat(1).as(:comma_separated) |
           quoted_text |
           (str("d").as(:d) >> str("x").as(:x)).as(:intermediate_exp) |
           ((str("left").absent? >> str("right").absent?) >> match["a-zA-Z"].as(:symbol)) |
-          match(/[^\[{(\\\/@;:.,'"|\]})0-9a-zA-Z\-><$%^&*_=+!`~\s?ℒℛᑕᑐ]/).as(:symbol) |
-          number
+          match(/[^\[{(\\\/@;:.,'"|\]})0-9a-zA-Z\-><$%^&*_=+!`~\s?ℒℛᑕᑐ]/).as(:symbol)
       end
 
       rule(:power_base) do
@@ -138,7 +138,6 @@ module Plurimath
       rule(:iteration) do
         ternary_classes_rules |
           (table.as(:table) >> power_base.maybe) |
-          comma.as(:comma) |
           mod |
           (sequence.as(:sequence) >> space? >> str("//").as(:symbol)) |
           (str("color") >> color_value.as(:color) >> sequence.as(:color_value)) |
@@ -146,6 +145,7 @@ module Plurimath
           (power_base_rules >> power_base) |
           power_base_rules |
           sequence.as(:sequence) |
+          comma.as(:comma) |
           space
       end
 
@@ -169,6 +169,28 @@ module Plurimath
           expression = str(expression).as(name) if expression.is_a?(type)
           expression | str(expr_string).as(name)
         end
+      end
+
+      def digits
+        match("[0-9]").repeat(1)
+      end
+
+      def decimal_number
+        (digits >> decimal_marker >> digits) | leading_decimal_number
+      end
+
+      def decimal_marker
+        str(decimal)
+      end
+
+      def leading_decimal_number
+        return str("").absent? if decimal == "."
+
+        decimal_marker >> digits
+      end
+
+      def decimal
+        Plurimath.configuration.decimal
       end
 
       def read_text

--- a/lib/plurimath/asciimath/parse.rb
+++ b/lib/plurimath/asciimath/parse.rb
@@ -10,7 +10,7 @@ module Plurimath
       rule(:comma)  { str(",") >> space? }
       rule(:space?) { space.maybe }
       rule(:number) do
-        (match("[0-9]").repeat(1) >> str(Plurimath.configuration.decimal) >> match("[0-9]").repeat(1)).as(:number) |
+        (match("[0-9]").repeat(1) >> decimal_marker >> match("[0-9]").repeat(1)).as(:number) |
           match("[0-9]").repeat(1).as(:number) |
           str(".").as(:symbol)
       end
@@ -78,7 +78,7 @@ module Plurimath
           binary_classes |
           ternary_classes |
           hash_to_expression(Constants.precompile_constants) |
-          (match(/[0-9]/).as(:number) >> (str(Plurimath.configuration.decimal) >> match("[0-9]")).absent? >> str(",").as(:comma)).repeat(1).as(:comma_separated) |
+          (match(/[0-9]/).as(:number) >> (decimal_marker >> match("[0-9]")).absent? >> str(",").as(:comma)).repeat(1).as(:comma_separated) |
           quoted_text |
           (str("d").as(:d) >> str("x").as(:x)).as(:intermediate_exp) |
           ((str("left").absent? >> str("right").absent?) >> match["a-zA-Z"].as(:symbol)) |
@@ -194,6 +194,10 @@ module Plurimath
         when :fonts then first_value.as(:fonts_class) >> space? >> sequence.as(:fonts_value)
         when :special_fonts then first_value.as(:bold_fonts)
         end
+      end
+
+      def decimal_marker
+        str(Plurimath.configuration.decimal)
       end
 
       def unary_functions(first_value)

--- a/lib/plurimath/asciimath/parse.rb
+++ b/lib/plurimath/asciimath/parse.rb
@@ -10,8 +10,8 @@ module Plurimath
       rule(:comma)  { str(",") >> space? }
       rule(:space?) { space.maybe }
       rule(:number) do
-        decimal_number.as(:number) |
-          digits.as(:number) |
+        (match("[0-9]").repeat(1) >> str(Plurimath.configuration.decimal) >> match("[0-9]").repeat(1)).as(:number) |
+          match("[0-9]").repeat(1).as(:number) |
           str(".").as(:symbol)
       end
 
@@ -77,9 +77,8 @@ module Plurimath
         sub_sup_classes |
           binary_classes |
           ternary_classes |
-          decimal_number.as(:number) |
           hash_to_expression(Constants.precompile_constants) |
-          (match(/[0-9]/).as(:number) >> str(",").as(:comma)).repeat(1).as(:comma_separated) |
+          (match(/[0-9]/).as(:number) >> (str(Plurimath.configuration.decimal) >> match("[0-9]")).absent? >> str(",").as(:comma)).repeat(1).as(:comma_separated) |
           quoted_text |
           (str("d").as(:d) >> str("x").as(:x)).as(:intermediate_exp) |
           ((str("left").absent? >> str("right").absent?) >> match["a-zA-Z"].as(:symbol)) |
@@ -139,6 +138,7 @@ module Plurimath
       rule(:iteration) do
         ternary_classes_rules |
           (table.as(:table) >> power_base.maybe) |
+          comma.as(:comma) |
           mod |
           (sequence.as(:sequence) >> space? >> str("//").as(:symbol)) |
           (str("color") >> color_value.as(:color) >> sequence.as(:color_value)) |
@@ -146,7 +146,6 @@ module Plurimath
           (power_base_rules >> power_base) |
           power_base_rules |
           sequence.as(:sequence) |
-          comma.as(:comma) |
           space
       end
 
@@ -170,22 +169,6 @@ module Plurimath
           expression = str(expression).as(name) if expression.is_a?(type)
           expression | str(expr_string).as(name)
         end
-      end
-
-      def digits
-        match("[0-9]").repeat(1)
-      end
-
-      def decimal_number
-        digits.maybe >> decimal_marker >> digits
-      end
-
-      def decimal_marker
-        str(decimal)
-      end
-
-      def decimal
-        Plurimath.configuration.decimal
       end
 
       def read_text

--- a/lib/plurimath/asciimath/parse.rb
+++ b/lib/plurimath/asciimath/parse.rb
@@ -77,13 +77,14 @@ module Plurimath
         sub_sup_classes |
           binary_classes |
           ternary_classes |
-          number |
+          decimal_number.as(:number) |
           hash_to_expression(Constants.precompile_constants) |
           (match(/[0-9]/).as(:number) >> str(",").as(:comma)).repeat(1).as(:comma_separated) |
           quoted_text |
           (str("d").as(:d) >> str("x").as(:x)).as(:intermediate_exp) |
           ((str("left").absent? >> str("right").absent?) >> match["a-zA-Z"].as(:symbol)) |
-          match(/[^\[{(\\\/@;:.,'"|\]})0-9a-zA-Z\-><$%^&*_=+!`~\s?ℒℛᑕᑐ]/).as(:symbol)
+          match(/[^\[{(\\\/@;:.,'"|\]})0-9a-zA-Z\-><$%^&*_=+!`~\s?ℒℛᑕᑐ]/).as(:symbol) |
+          number
       end
 
       rule(:power_base) do
@@ -176,17 +177,11 @@ module Plurimath
       end
 
       def decimal_number
-        (digits >> decimal_marker >> digits) | leading_decimal_number
+        digits.maybe >> decimal_marker >> digits
       end
 
       def decimal_marker
         str(decimal)
-      end
-
-      def leading_decimal_number
-        return str("").absent? if decimal == "."
-
-        decimal_marker >> digits
       end
 
       def decimal

--- a/lib/plurimath/configuration.rb
+++ b/lib/plurimath/configuration.rb
@@ -11,15 +11,7 @@ module Plurimath
     end
 
     def decimal
-      Formatter::SupportedLocales::LOCALES
-        .fetch(locale_key, {})
-        .fetch(:decimal, DEFAULT_DECIMAL)
-    end
-
-    private
-
-    def locale_key
-      locale.respond_to?(:to_sym) ? locale.to_sym : locale
+      Formatter::SupportedLocales.decimal_for(locale, default: DEFAULT_DECIMAL)
     end
   end
 end

--- a/lib/plurimath/configuration.rb
+++ b/lib/plurimath/configuration.rb
@@ -2,10 +2,35 @@
 
 module Plurimath
   class Configuration
+    DEFAULT_DECIMAL = "."
+
     attr_accessor :number_formatter
+    attr_writer :locale
 
     def deprecation
       Deprecation
+    end
+
+    def locale
+      @locale || number_formatter_locale
+    end
+
+    def decimal
+      locale_symbols.fetch(:decimal, DEFAULT_DECIMAL)
+    end
+
+    private
+
+    def locale_symbols
+      Formatter::SupportedLocales::LOCALES.fetch(locale_key, {})
+    end
+
+    def locale_key
+      locale.respond_to?(:to_sym) ? locale.to_sym : locale
+    end
+
+    def number_formatter_locale
+      number_formatter.locale if number_formatter.respond_to?(:locale)
     end
   end
 end

--- a/lib/plurimath/configuration.rb
+++ b/lib/plurimath/configuration.rb
@@ -4,33 +4,22 @@ module Plurimath
   class Configuration
     DEFAULT_DECIMAL = "."
 
-    attr_accessor :number_formatter
-    attr_writer :locale
+    attr_accessor :number_formatter, :locale
 
     def deprecation
       Deprecation
     end
 
-    def locale
-      @locale || number_formatter_locale
-    end
-
     def decimal
-      locale_symbols.fetch(:decimal, DEFAULT_DECIMAL)
+      Formatter::SupportedLocales::LOCALES
+        .fetch(locale_key, {})
+        .fetch(:decimal, DEFAULT_DECIMAL)
     end
 
     private
 
-    def locale_symbols
-      Formatter::SupportedLocales::LOCALES.fetch(locale_key, {})
-    end
-
     def locale_key
       locale.respond_to?(:to_sym) ? locale.to_sym : locale
-    end
-
-    def number_formatter_locale
-      number_formatter.locale if number_formatter.respond_to?(:locale)
     end
   end
 end

--- a/lib/plurimath/errors/formatter/unsupported_locale.rb
+++ b/lib/plurimath/errors/formatter/unsupported_locale.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Plurimath
+  module Formatter
+    class UnsupportedLocale < Plurimath::Error
+      def initialize(locale, supported_locales)
+        @locale = locale
+        @supported = supported_locales.map(&:inspect).join(", ")
+        super(message)
+      end
+
+      def message
+        "[plurimath] Unsupported locale #{@locale.inspect}. " \
+          "Supported locales are: #{@supported}."
+      end
+    end
+  end
+end

--- a/lib/plurimath/errors/parse_option_error.rb
+++ b/lib/plurimath/errors/parse_option_error.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Plurimath
+  module Math
+    class ParseOptionError < Plurimath::Error
+      def self.unknown_options(options, supported_options:)
+        new(
+          "unknown parse #{option_label(options)}: #{format_options(options)}; " \
+          "supported parse options are #{format_options(supported_options)}",
+        )
+      end
+
+      def self.unsupported_options(type, options, supported_types:)
+        new(
+          "parse #{option_label(options)} #{format_options(options)} " \
+          "#{be_verb(options)} not supported for #{type.inspect}; " \
+          "supported input types are #{format_options(supported_types)}",
+        )
+      end
+
+      def self.option_label(options)
+        options.one? ? "option" : "options"
+      end
+
+      def self.be_verb(options)
+        options.one? ? "is" : "are"
+      end
+
+      def self.format_options(options)
+        options.map(&:inspect).join(", ")
+      end
+    end
+  end
+end

--- a/lib/plurimath/formatter.rb
+++ b/lib/plurimath/formatter.rb
@@ -6,6 +6,7 @@ module Plurimath
     autoload :NumberFormatter, "#{__dir__}/formatter/number_formatter"
     autoload :SupportedLocales, "#{__dir__}/formatter/supported_locales"
     autoload :UnsupportedBase, "#{__dir__}/errors/formatter/unsupported_base"
+    autoload :UnsupportedLocale, "#{__dir__}/errors/formatter/unsupported_locale"
     autoload :Numbers, "#{__dir__}/formatter/numbers"
     autoload :Standard, "#{__dir__}/formatter/standard"
   end

--- a/lib/plurimath/formatter/supported_locales.rb
+++ b/lib/plurimath/formatter/supported_locales.rb
@@ -101,6 +101,33 @@ module Plurimath
         zh: { decimal: ".", group: "," },
         zu: { decimal: ".", group: "," },
       }.freeze
+
+      class << self
+        def decimal_for(locale, default:)
+          symbols_for(locale).fetch(:decimal, default)
+        end
+
+        def symbols_for(locale)
+          locale_key = key_for(locale)
+          return {} unless locale_key
+
+          LOCALES.fetch(locale_key)
+        end
+
+        def key_for!(locale)
+          locale_key = key_for(locale)
+          return locale_key if locale.nil? || locale_key
+
+          raise UnsupportedLocale.new(locale, LOCALES.keys)
+        end
+
+        def key_for(locale)
+          return locale if LOCALES.key?(locale)
+
+          symbol_key = locale.to_sym if locale.respond_to?(:to_sym)
+          symbol_key if LOCALES.key?(symbol_key)
+        end
+      end
     end
   end
 end

--- a/lib/plurimath/html/parse.rb
+++ b/lib/plurimath/html/parse.rb
@@ -75,7 +75,7 @@ module Plurimath
       rule(:symbol_text_or_tag) do
         tag_parse |
           html_entity.as(:symbol) |
-          (match["0-9"].repeat(1) >> str(".") >> match["0-9"].repeat(1)).as(:number) |
+          (match["0-9"].repeat(1) >> decimal_marker >> match["0-9"].repeat(1)).as(:number) |
           match["0-9"].repeat(1).as(:number) |
           match["a-zA-Z"].as(:text) |
           match["^0-9a-zA-Z<>(){}\\[\\]\s"].as(:symbol)
@@ -137,6 +137,10 @@ module Plurimath
         return str(string) if name.nil?
 
         str(string).as(name)
+      end
+
+      def decimal_marker
+        str(Plurimath.configuration.decimal)
       end
 
       def parse_tag(opts, tag_name = nil, capture_name: nil)

--- a/lib/plurimath/latex/parse.rb
+++ b/lib/plurimath/latex/parse.rb
@@ -101,7 +101,7 @@ module Plurimath
           (rparen.absent? >> symbol_class_commands) |
           (slash >> math_operators_classes) |
           match["a-zA-Z"].as(:symbols) |
-          (match["0-9"].repeat(0) >> str(".").maybe >> match["0-9"].repeat(1)).as(:number) |
+          (match["0-9"].repeat(0) >> decimal_marker.maybe >> match["0-9"].repeat(1)).as(:number) |
           match["0-9"].repeat(1).as(:number) |
           (str("\\\\").as("\\\\") >> match(/\s/).repeat) |
           str("\\ ").as(:space) |
@@ -195,6 +195,12 @@ module Plurimath
           expression = str(expression).as(name) if expression.is_a?(type)
           expression | str(expr_string).as(name)
         end
+      end
+
+      def decimal_marker
+        # Latex::Parser entity-encodes input before Parslet sees it, so
+        # non-ASCII locale markers must match that encoded parser input.
+        str(Utility.string_to_html_entity(Plurimath.configuration.decimal))
       end
 
       def hash_to_expression(hash)

--- a/lib/plurimath/latex/transform.rb
+++ b/lib/plurimath/latex/transform.rb
@@ -5,7 +5,7 @@ module Plurimath
     class Transform < Parslet::Transform
       rule(base: simple(:base))       { base }
       rule(over: simple(:over))       { over }
-      rule(number: simple(:num))      { Math::Number.new(num) }
+      rule(number: simple(:num))      { Math::Number.new(Utility.html_entity_to_unicode(num.to_s)) }
       rule(power: simple(:power))     { power }
       rule(unary: simple(:unary))     { Utility.get_class(unary).new }
       rule(space: simple(:space))     { Math::Function::Text.new(" ") }
@@ -188,7 +188,7 @@ module Plurimath
            number: simple(:number)) do
         Math::Function::Power.new(
           power,
-          Math::Number.new(number),
+          Math::Number.new(Utility.html_entity_to_unicode(number.to_s)),
         )
       end
 
@@ -428,7 +428,7 @@ module Plurimath
       rule(number: simple(:number),
            subscript: simple(:subscript)) do
         Math::Function::Base.new(
-          Math::Number.new(number),
+          Math::Number.new(Utility.html_entity_to_unicode(number.to_s)),
           subscript,
         )
       end
@@ -436,7 +436,7 @@ module Plurimath
       rule(number: simple(:number),
            supscript: simple(:supscript)) do
         Math::Function::Power.new(
-          Math::Number.new(number),
+          Math::Number.new(Utility.html_entity_to_unicode(number.to_s)),
           supscript,
         )
       end
@@ -445,7 +445,7 @@ module Plurimath
            subscript: simple(:subscript),
            supscript: simple(:supscript)) do
         Math::Function::PowerBase.new(
-          Math::Number.new(number),
+          Math::Number.new(Utility.html_entity_to_unicode(number.to_s)),
           subscript,
           supscript,
         )

--- a/lib/plurimath/math.rb
+++ b/lib/plurimath/math.rb
@@ -7,6 +7,7 @@ module Plurimath
     autoload :Function, "#{__dir__}/math/function"
     autoload :InvalidTypeError, "#{__dir__}/errors/invalid_type_error"
     autoload :Number, "#{__dir__}/math/number"
+    autoload :ParseOptionError, "#{__dir__}/errors/parse_option_error"
     autoload :ParseError, "#{__dir__}/errors/parse_error"
     autoload :Symbols, "#{__dir__}/math/symbols"
 
@@ -19,15 +20,23 @@ module Plurimath
       unicode: UnicodeMath,
       asciimath: Asciimath,
     }.freeze
+    SUPPORTED_PARSE_OPTIONS = %i[locale].freeze
+    LOCALIZED_PARSE_TYPES = %i[asciimath html latex unicode].freeze
 
-    def parse(text, type)
+    module_function
+
+    def parse(text, type, **options)
       raise InvalidTypeError.new unless valid_type?(type)
 
+      type = type.to_sym
+      unknown_options = options.keys - SUPPORTED_PARSE_OPTIONS
+      raise_unknown_parse_options!(unknown_options) unless unknown_options.empty?
+
+      raise_unsupported_parse_option!(type, :locale) if options.key?(:locale) && !localized_parse_type?(type)
+      options = normalize_parse_options(options)
+
       begin
-        klass = klass_from_type(type)
-        formula = klass.new(text).to_formula
-        formula.input_string = text
-        formula
+        parse_with_configuration(text, type, options)
       rescue ParseError
         # Re-raise ParseError from lower layers unchanged to preserve specialized error types
         raise
@@ -36,17 +45,56 @@ module Plurimath
       end
     end
 
-    private
+    def parse_with_configuration(text, type, options)
+      return parse_formula(text, type) unless options.key?(:locale)
+
+      Plurimath.with_configuration do |config|
+        config.locale = options.fetch(:locale)
+        parse_formula(text, type)
+      end
+    end
+
+    def parse_formula(text, type)
+      klass = klass_from_type(type)
+      formula = klass.new(text).to_formula
+      formula.input_string = text
+      formula
+    end
 
     def klass_from_type(type_string_or_sym)
       VALID_TYPES[type_string_or_sym.to_sym]
+    end
+
+    def normalize_parse_options(options)
+      return options unless options.key?(:locale)
+
+      options.merge(
+        locale: Formatter::SupportedLocales.key_for!(options.fetch(:locale)),
+      )
+    end
+
+    def localized_parse_type?(type)
+      LOCALIZED_PARSE_TYPES.include?(type)
+    end
+
+    def raise_unknown_parse_options!(options)
+      raise ParseOptionError.unknown_options(
+        options,
+        supported_options: SUPPORTED_PARSE_OPTIONS,
+      )
+    end
+
+    def raise_unsupported_parse_option!(type, option)
+      raise ParseOptionError.unsupported_options(
+        type,
+        [option],
+        supported_types: LOCALIZED_PARSE_TYPES,
+      )
     end
 
     def valid_type?(type)
       (type.is_a?(::Symbol) || type.is_a?(String)) &&
         VALID_TYPES.key?(type.to_sym)
     end
-
-    module_function :parse, :klass_from_type, :valid_type?
   end
 end

--- a/lib/plurimath/unicode_math/parse.rb
+++ b/lib/plurimath/unicode_math/parse.rb
@@ -35,7 +35,7 @@ module Plurimath
       rule(:op_opener) { open_paren | op_open_unicode | op_open_paren | op_open }
       rule(:op_closer) { op_close_unicode | close_paren | op_close_paren | op_close }
 
-      rule(:op_decimal) { str(",") | str(".") }
+      rule(:op_decimal) { decimal_marker | str(",") | str(".") }
       rule(:diacritics) { (char.as(:char) >> diacritics.as(:diacritics)) | char.as(:char) }
       rule(:open_paren) { (op_masked_open >> (op_closer | op_opener)).as(:open_paren) | op_masked_open }
 
@@ -242,6 +242,12 @@ module Plurimath
       end
 
       root :expression
+
+      def decimal_marker
+        # UnicodeMath::Parser entity-encodes input before Parslet sees it, so
+        # non-ASCII locale markers must match that encoded parser input.
+        str(Utility.string_to_html_entity(Plurimath.configuration.decimal))
+      end
     end
   end
 end

--- a/lib/plurimath/unicode_math/transform.rb
+++ b/lib/plurimath/unicode_math/transform.rb
@@ -185,7 +185,7 @@ module Plurimath
 
       rule(decimal: simple(:decimal),
            whole: simple(:whole)) do
-        Math::Number.new("#{decimal}#{whole.value}")
+        Math::Number.new(Utility.html_entity_to_unicode("#{decimal}#{whole.value}"))
       end
 
       rule(positive: simple(:positive),
@@ -2222,7 +2222,7 @@ module Plurimath
       rule(whole: simple(:whole),
            decimal: simple(:decimal),
            fractional: simple(:fractional)) do
-        Math::Number.new("#{whole.value}#{decimal}#{fractional.value}")
+        Math::Number.new(Utility.html_entity_to_unicode("#{whole.value}#{decimal}#{fractional.value}"))
       end
 
       rule(factor: simple(:factor),

--- a/spec/plurimath/asciimath/parser_spec.rb
+++ b/spec/plurimath/asciimath/parser_spec.rb
@@ -1308,6 +1308,88 @@ RSpec.describe Plurimath::Asciimath::Parser do
       end
     end
 
+    context "when locale uses comma as the decimal separator" do
+      around do |example|
+        Plurimath.with_configuration do |config|
+          config.locale = :fr
+          example.run
+        end
+      end
+
+      context "when contains decimal comma" do
+        let(:string) { "1,2" }
+
+        it "returns formula" do
+          expected_value = Plurimath::Math::Formula.new([
+                                                          Plurimath::Math::Number.new("1,2"),
+                                                        ])
+          expect(formula).to eq(expected_value)
+        end
+      end
+
+      context "when contains leading decimal comma" do
+        let(:string) { ",2" }
+
+        it "returns formula" do
+          expected_value = Plurimath::Math::Formula.new([
+                                                          Plurimath::Math::Number.new(",2"),
+                                                        ])
+          expect(formula).to eq(expected_value)
+        end
+      end
+
+      context "when contains a spaced comma separator" do
+        let(:string) { "(1 , 2)" }
+
+        it "returns formula" do
+          expected_value = Plurimath::Math::Formula.new([
+                                                          Plurimath::Math::Function::Fenced.new(
+                                                            Plurimath::Math::Symbols::Paren::Lround.new,
+                                                            [
+                                                              Plurimath::Math::Number.new("1"),
+                                                              Plurimath::Math::Symbols::Comma.new,
+                                                              Plurimath::Math::Number.new("2"),
+                                                            ],
+                                                            Plurimath::Math::Symbols::Paren::Rround.new,
+                                                          ),
+                                                        ])
+          expect(formula).to eq(expected_value)
+        end
+      end
+
+      context "when contains spaced table cells" do
+        let(:string) { "([1 , 2], [3 , 4])" }
+
+        it "returns formula" do
+          expected_value = Plurimath::Math::Formula.new([
+                                                          Plurimath::Math::Function::Table.new(
+                                                            [
+                                                              Plurimath::Math::Function::Tr.new([
+                                                                                                  Plurimath::Math::Function::Td.new([
+                                                                                                                                      Plurimath::Math::Number.new("1"),
+                                                                                                                                    ]),
+                                                                                                  Plurimath::Math::Function::Td.new([
+                                                                                                                                      Plurimath::Math::Number.new("2"),
+                                                                                                                                    ]),
+                                                                                                ]),
+                                                              Plurimath::Math::Function::Tr.new([
+                                                                                                  Plurimath::Math::Function::Td.new([
+                                                                                                                                      Plurimath::Math::Number.new("3"),
+                                                                                                                                    ]),
+                                                                                                  Plurimath::Math::Function::Td.new([
+                                                                                                                                      Plurimath::Math::Number.new("4"),
+                                                                                                                                    ]),
+                                                                                                ]),
+                                                            ],
+                                                            Plurimath::Math::Symbols::Paren::Lround.new,
+                                                            Plurimath::Math::Symbols::Paren::Rround.new,
+                                                          ),
+                                                        ])
+          expect(formula).to eq(expected_value)
+        end
+      end
+    end
+
     context "when contains numeric value" do
       let(:string) { ".1" }
 

--- a/spec/plurimath/asciimath/parser_spec.rb
+++ b/spec/plurimath/asciimath/parser_spec.rb
@@ -1327,17 +1327,6 @@ RSpec.describe Plurimath::Asciimath::Parser do
         end
       end
 
-      context "when contains leading decimal comma" do
-        let(:string) { ",2" }
-
-        it "returns formula" do
-          expected_value = Plurimath::Math::Formula.new([
-                                                          Plurimath::Math::Number.new(",2"),
-                                                        ])
-          expect(formula).to eq(expected_value)
-        end
-      end
-
       context "when contains a spaced comma separator" do
         let(:string) { "(1 , 2)" }
 
@@ -1395,7 +1384,8 @@ RSpec.describe Plurimath::Asciimath::Parser do
 
       it "returns formula" do
         expected_value = Plurimath::Math::Formula.new([
-                                                        Plurimath::Math::Number.new(".1"),
+                                                        Plurimath::Math::Symbols::Period.new,
+                                                        Plurimath::Math::Number.new("1"),
                                                       ])
         expect(formula).to eq(expected_value)
       end
@@ -1419,7 +1409,8 @@ RSpec.describe Plurimath::Asciimath::Parser do
       it "returns formula" do
         expected_value = Plurimath::Math::Formula.new([
                                                         Plurimath::Math::Symbols::Minus.new,
-                                                        Plurimath::Math::Number.new(".1"),
+                                                        Plurimath::Math::Symbols::Period.new,
+                                                        Plurimath::Math::Number.new("1"),
                                                       ])
         expect(formula).to eq(expected_value)
       end

--- a/spec/plurimath/asciimath/parser_spec.rb
+++ b/spec/plurimath/asciimath/parser_spec.rb
@@ -1327,6 +1327,42 @@ RSpec.describe Plurimath::Asciimath::Parser do
         end
       end
 
+      context "when contains unspaced comma in a fenced expression" do
+        let(:string) { "(1,2,3)" }
+
+        it "parses the first comma as a decimal marker" do
+          expected_value = Plurimath::Math::Formula.new([
+                                                          Plurimath::Math::Function::Fenced.new(
+                                                            Plurimath::Math::Symbols::Paren::Lround.new,
+                                                            [
+                                                              Plurimath::Math::Number.new("1,2"),
+                                                              Plurimath::Math::Symbols::Comma.new,
+                                                              Plurimath::Math::Number.new("3"),
+                                                            ],
+                                                            Plurimath::Math::Symbols::Paren::Rround.new,
+                                                          ),
+                                                        ])
+          expect(formula).to eq(expected_value)
+        end
+      end
+
+      context "when contains unspaced comma in square brackets" do
+        let(:string) { "[1,2]" }
+
+        it "parses the comma as a decimal marker" do
+          expected_value = Plurimath::Math::Formula.new([
+                                                          Plurimath::Math::Function::Fenced.new(
+                                                            Plurimath::Math::Symbols::Paren::Lsquare.new,
+                                                            [
+                                                              Plurimath::Math::Number.new("1,2"),
+                                                            ],
+                                                            Plurimath::Math::Symbols::Paren::Rsquare.new,
+                                                          ),
+                                                        ])
+          expect(formula).to eq(expected_value)
+        end
+      end
+
       context "when contains decimal full stop" do
         let(:string) { "1.2" }
 

--- a/spec/plurimath/asciimath/parser_spec.rb
+++ b/spec/plurimath/asciimath/parser_spec.rb
@@ -1379,6 +1379,26 @@ RSpec.describe Plurimath::Asciimath::Parser do
       end
     end
 
+    context "when locale uses Arabic decimal separator" do
+      around do |example|
+        Plurimath.with_configuration do |config|
+          config.locale = :ar
+          example.run
+        end
+      end
+
+      context "when contains localized decimal marker" do
+        let(:string) { "1٫2" }
+
+        it "returns formula" do
+          expected_value = Plurimath::Math::Formula.new([
+                                                          Plurimath::Math::Number.new("1٫2"),
+                                                        ])
+          expect(formula).to eq(expected_value)
+        end
+      end
+    end
+
     context "when contains numeric value" do
       let(:string) { ".1" }
 

--- a/spec/plurimath/asciimath/parser_spec.rb
+++ b/spec/plurimath/asciimath/parser_spec.rb
@@ -1327,6 +1327,19 @@ RSpec.describe Plurimath::Asciimath::Parser do
         end
       end
 
+      context "when contains decimal full stop" do
+        let(:string) { "1.2" }
+
+        it "returns formula" do
+          expected_value = Plurimath::Math::Formula.new([
+                                                          Plurimath::Math::Number.new("1"),
+                                                          Plurimath::Math::Symbols::Period.new,
+                                                          Plurimath::Math::Number.new("2"),
+                                                        ])
+          expect(formula).to eq(expected_value)
+        end
+      end
+
       context "when contains a spaced comma separator" do
         let(:string) { "(1 , 2)" }
 
@@ -1379,6 +1392,28 @@ RSpec.describe Plurimath::Asciimath::Parser do
       end
     end
 
+    context "when locale uses full stop as the decimal separator" do
+      around do |example|
+        Plurimath.with_configuration do |config|
+          config.locale = :en
+          example.run
+        end
+      end
+
+      context "when contains Arabic decimal marker" do
+        let(:string) { "1٫2" }
+
+        it "returns formula" do
+          expected_value = Plurimath::Math::Formula.new([
+                                                          Plurimath::Math::Number.new("1"),
+                                                          Plurimath::Math::Symbols::Symbol.new("٫"),
+                                                          Plurimath::Math::Number.new("2"),
+                                                        ])
+          expect(formula).to eq(expected_value)
+        end
+      end
+    end
+
     context "when locale uses Arabic decimal separator" do
       around do |example|
         Plurimath.with_configuration do |config|
@@ -1393,6 +1428,19 @@ RSpec.describe Plurimath::Asciimath::Parser do
         it "returns formula" do
           expected_value = Plurimath::Math::Formula.new([
                                                           Plurimath::Math::Number.new("1٫2"),
+                                                        ])
+          expect(formula).to eq(expected_value)
+        end
+      end
+
+      context "when contains decimal full stop" do
+        let(:string) { "1.2" }
+
+        it "returns formula" do
+          expected_value = Plurimath::Math::Formula.new([
+                                                          Plurimath::Math::Number.new("1"),
+                                                          Plurimath::Math::Symbols::Period.new,
+                                                          Plurimath::Math::Number.new("2"),
                                                         ])
           expect(formula).to eq(expected_value)
         end

--- a/spec/plurimath/asciimath/parser_spec.rb
+++ b/spec/plurimath/asciimath/parser_spec.rb
@@ -1395,8 +1395,7 @@ RSpec.describe Plurimath::Asciimath::Parser do
 
       it "returns formula" do
         expected_value = Plurimath::Math::Formula.new([
-                                                        Plurimath::Math::Symbols::Period.new,
-                                                        Plurimath::Math::Number.new("1"),
+                                                        Plurimath::Math::Number.new(".1"),
                                                       ])
         expect(formula).to eq(expected_value)
       end
@@ -1420,8 +1419,7 @@ RSpec.describe Plurimath::Asciimath::Parser do
       it "returns formula" do
         expected_value = Plurimath::Math::Formula.new([
                                                         Plurimath::Math::Symbols::Minus.new,
-                                                        Plurimath::Math::Symbols::Period.new,
-                                                        Plurimath::Math::Number.new("1"),
+                                                        Plurimath::Math::Number.new(".1"),
                                                       ])
         expect(formula).to eq(expected_value)
       end

--- a/spec/plurimath/configuration_spec.rb
+++ b/spec/plurimath/configuration_spec.rb
@@ -5,11 +5,11 @@ require "spec_helper"
 RSpec.describe Plurimath::Configuration do
   around do |example|
     previous_behavior = Plurimath::Deprecation.behavior
-    previous_number_formatter = Plurimath.configuration.number_formatter
+    previous_configuration = Plurimath.configuration.dup
     example.run
   ensure
     Plurimath::Deprecation.behavior = previous_behavior
-    Plurimath.configuration.number_formatter = previous_number_formatter
+    Plurimath.instance_variable_set(:@configuration, previous_configuration)
   end
 
   describe ".configuration" do
@@ -50,6 +50,25 @@ RSpec.describe Plurimath::Configuration do
     end
   end
 
+  describe ".with_configuration" do
+    it "restores configuration after the block" do
+      previous_formatter = Plurimath::Formatter::Standard.new(locale: :en)
+      temporary_formatter = Plurimath::Formatter::Standard.new(locale: :fr)
+      Plurimath.configuration.locale = :en
+      Plurimath.configuration.number_formatter = previous_formatter
+
+      result = Plurimath.with_configuration do |config|
+        config.locale = :fr
+        config.number_formatter = temporary_formatter
+        :configured
+      end
+
+      expect(result).to be(:configured)
+      expect(Plurimath.configuration.locale).to be(:en)
+      expect(Plurimath.configuration.number_formatter).to be(previous_formatter)
+    end
+  end
+
   describe "#deprecation" do
     it "returns the deprecation module" do
       expect(Plurimath.configuration.deprecation).to be(Plurimath::Deprecation)
@@ -59,6 +78,42 @@ RSpec.describe Plurimath::Configuration do
   describe "#number_formatter" do
     it "defaults to nil" do
       expect(described_class.new.number_formatter).to be_nil
+    end
+  end
+
+  describe "#locale" do
+    it "uses the configured locale" do
+      configuration = described_class.new
+      configuration.locale = :fr
+
+      expect(configuration.locale).to be(:fr)
+    end
+
+    it "falls back to the configured number formatter locale" do
+      configuration = described_class.new
+      configuration.number_formatter = Plurimath::Formatter::Standard.new(locale: :fr)
+
+      expect(configuration.locale).to be(:fr)
+    end
+  end
+
+  describe "#decimal" do
+    it "defaults to a full stop" do
+      expect(described_class.new.decimal).to eq(".")
+    end
+
+    it "uses the configured locale decimal separator" do
+      configuration = described_class.new
+      configuration.locale = :fr
+
+      expect(configuration.decimal).to eq(",")
+    end
+
+    it "uses a full stop for an unsupported locale" do
+      configuration = described_class.new
+      configuration.locale = :unknown
+
+      expect(configuration.decimal).to eq(".")
     end
   end
 end

--- a/spec/plurimath/configuration_spec.rb
+++ b/spec/plurimath/configuration_spec.rb
@@ -53,18 +53,23 @@ RSpec.describe Plurimath::Configuration do
   describe ".with_configuration" do
     it "restores configuration after the block" do
       previous_configuration = Plurimath.configuration.dup
+      original_configuration = Plurimath.configuration
       previous_formatter = Plurimath::Formatter::Standard.new(locale: :en)
       temporary_formatter = Plurimath::Formatter::Standard.new(locale: :fr)
       Plurimath.configuration.locale = :en
       Plurimath.configuration.number_formatter = previous_formatter
+      yielded_config = nil
 
       result = Plurimath.with_configuration do |config|
+        yielded_config = config
         config.locale = :fr
         config.number_formatter = temporary_formatter
         :configured
       end
 
       expect(result).to be(:configured)
+      expect(yielded_config).not_to be(original_configuration)
+      expect(Plurimath.configuration).to be(original_configuration)
       expect(Plurimath.configuration.locale).to be(:en)
       expect(Plurimath.configuration.number_formatter).to be(previous_formatter)
     ensure

--- a/spec/plurimath/configuration_spec.rb
+++ b/spec/plurimath/configuration_spec.rb
@@ -5,11 +5,11 @@ require "spec_helper"
 RSpec.describe Plurimath::Configuration do
   around do |example|
     previous_behavior = Plurimath::Deprecation.behavior
-    previous_configuration = Plurimath.configuration.dup
+    previous_number_formatter = Plurimath.configuration.number_formatter
     example.run
   ensure
     Plurimath::Deprecation.behavior = previous_behavior
-    Plurimath.instance_variable_set(:@configuration, previous_configuration)
+    Plurimath.configuration.number_formatter = previous_number_formatter
   end
 
   describe ".configuration" do
@@ -52,6 +52,7 @@ RSpec.describe Plurimath::Configuration do
 
   describe ".with_configuration" do
     it "restores configuration after the block" do
+      previous_configuration = Plurimath.configuration.dup
       previous_formatter = Plurimath::Formatter::Standard.new(locale: :en)
       temporary_formatter = Plurimath::Formatter::Standard.new(locale: :fr)
       Plurimath.configuration.locale = :en
@@ -66,6 +67,8 @@ RSpec.describe Plurimath::Configuration do
       expect(result).to be(:configured)
       expect(Plurimath.configuration.locale).to be(:en)
       expect(Plurimath.configuration.number_formatter).to be(previous_formatter)
+    ensure
+      Plurimath.instance_variable_set(:@configuration, previous_configuration)
     end
   end
 
@@ -82,16 +85,13 @@ RSpec.describe Plurimath::Configuration do
   end
 
   describe "#locale" do
+    it "defaults to nil" do
+      expect(described_class.new.locale).to be_nil
+    end
+
     it "uses the configured locale" do
       configuration = described_class.new
       configuration.locale = :fr
-
-      expect(configuration.locale).to be(:fr)
-    end
-
-    it "falls back to the configured number formatter locale" do
-      configuration = described_class.new
-      configuration.number_formatter = Plurimath::Formatter::Standard.new(locale: :fr)
 
       expect(configuration.locale).to be(:fr)
     end

--- a/spec/plurimath/formatter/supported_locales_spec.rb
+++ b/spec/plurimath/formatter/supported_locales_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Plurimath::Formatter::SupportedLocales do
+  describe ".key_for" do
+    it "returns a supported symbol locale key" do
+      expect(described_class.key_for(:fr)).to be(:fr)
+    end
+
+    it "returns a supported string locale key" do
+      expect(described_class.key_for("fr-CA")).to eq(:"fr-CA")
+    end
+
+    it "returns nil for an unsupported locale" do
+      expect(described_class.key_for(:unknown)).to be_nil
+    end
+  end
+
+  describe ".key_for!" do
+    it "returns a supported locale key" do
+      expect(described_class.key_for!(:fr)).to be(:fr)
+    end
+
+    it "returns nil for a nil locale" do
+      expect(described_class.key_for!(nil)).to be_nil
+    end
+
+    it "raises for an unsupported locale" do
+      expect do
+        described_class.key_for!(:unknown)
+      end.to raise_error(
+        Plurimath::Formatter::UnsupportedLocale,
+        /\[plurimath\] Unsupported locale :unknown\./,
+      )
+    end
+  end
+
+  describe ".decimal_for" do
+    it "uses a supported symbol locale decimal separator" do
+      expect(described_class.decimal_for(:fr, default: ".")).to eq(",")
+    end
+
+    it "uses a supported string locale decimal separator" do
+      expect(described_class.decimal_for("fr-CA", default: ".")).to eq(",")
+    end
+
+    it "uses the default for an unsupported locale" do
+      expect(described_class.decimal_for(:unknown, default: ".")).to eq(".")
+    end
+  end
+end

--- a/spec/plurimath/html/parser_spec.rb
+++ b/spec/plurimath/html/parser_spec.rb
@@ -49,12 +49,47 @@ RSpec.describe Plurimath::Html::Parser do
         end
       end
 
+      context "when contains decimal full stop" do
+        let(:string) { "1.2" }
+
+        it "returns abstract parsed tree" do
+          expected_value = Plurimath::Math::Formula.new([
+                                                          Plurimath::Math::Number.new("1"),
+                                                          Plurimath::Math::Symbols::Period.new,
+                                                          Plurimath::Math::Number.new("2"),
+                                                        ])
+          expect(formula).to eq(expected_value)
+        end
+      end
+
       context "when contains decimal comma inside a tag" do
         let(:string) { "<span>1,2</span>" }
 
         it "returns abstract parsed tree" do
           expected_value = Plurimath::Math::Formula.new([
                                                           Plurimath::Math::Number.new("1,2"),
+                                                        ])
+          expect(formula).to eq(expected_value)
+        end
+      end
+    end
+
+    context "when locale uses full stop as the decimal separator" do
+      around do |example|
+        Plurimath.with_configuration do |config|
+          config.locale = :en
+          example.run
+        end
+      end
+
+      context "when contains Arabic decimal marker" do
+        let(:string) { "1٫2" }
+
+        it "returns abstract parsed tree" do
+          expected_value = Plurimath::Math::Formula.new([
+                                                          Plurimath::Math::Number.new("1"),
+                                                          Plurimath::Math::Symbols::Symbol.new("٫"),
+                                                          Plurimath::Math::Number.new("2"),
                                                         ])
           expect(formula).to eq(expected_value)
         end

--- a/spec/plurimath/html/parser_spec.rb
+++ b/spec/plurimath/html/parser_spec.rb
@@ -30,6 +30,68 @@ RSpec.describe Plurimath::Html::Parser do
       end
     end
 
+    context "when locale uses comma as the decimal separator" do
+      around do |example|
+        Plurimath.with_configuration do |config|
+          config.locale = :fr
+          example.run
+        end
+      end
+
+      context "when contains decimal comma" do
+        let(:string) { "1,2" }
+
+        it "returns abstract parsed tree" do
+          expected_value = Plurimath::Math::Formula.new([
+                                                          Plurimath::Math::Number.new("1,2"),
+                                                        ])
+          expect(formula).to eq(expected_value)
+        end
+      end
+
+      context "when contains decimal comma inside a tag" do
+        let(:string) { "<span>1,2</span>" }
+
+        it "returns abstract parsed tree" do
+          expected_value = Plurimath::Math::Formula.new([
+                                                          Plurimath::Math::Number.new("1,2"),
+                                                        ])
+          expect(formula).to eq(expected_value)
+        end
+      end
+    end
+
+    context "when locale uses Arabic decimal separator" do
+      around do |example|
+        Plurimath.with_configuration do |config|
+          config.locale = :ar
+          example.run
+        end
+      end
+
+      context "when contains localized decimal marker" do
+        let(:string) { "1٫2" }
+
+        it "returns abstract parsed tree" do
+          expected_value = Plurimath::Math::Formula.new([
+                                                          Plurimath::Math::Number.new("1٫2"),
+                                                        ])
+          expect(formula).to eq(expected_value)
+        end
+      end
+
+      context "when contains localized decimal marker inside a tag" do
+        let(:string) { "<span>1٫2</span>" }
+
+        it "returns abstract parsed tree" do
+          expected_value = Plurimath::Math::Formula.new([
+                                                          Plurimath::Math::Number.new("1٫2"),
+                                                        ])
+          expect(formula).to eq(expected_value)
+        end
+      end
+    end
+
     context "contains sum with sub and sup values" do
       let(:string) { "&sum;<sub>d</sub><sup>prod</sup>" }
 

--- a/spec/plurimath/latex/parse_spec.rb
+++ b/spec/plurimath/latex/parse_spec.rb
@@ -7,6 +7,21 @@ RSpec.describe Plurimath::Latex::Parse do
                                                                        ""))
     end
 
+    context "when locale decimal marker is encoded before parsing" do
+      around do |example|
+        Plurimath.with_configuration do |config|
+          config.locale = :ar
+          example.run
+        end
+      end
+
+      let(:string) { "1&#x66b;2" }
+
+      it "parses the encoded configured marker as part of the number" do
+        expect(formula[:number]).to eq("1&#x66b;2")
+      end
+    end
+
     context "contains command with single argument" do
       let(:string) do
         <<~LATEX

--- a/spec/plurimath/latex/parser_spec.rb
+++ b/spec/plurimath/latex/parser_spec.rb
@@ -65,6 +65,25 @@ RSpec.describe Plurimath::Latex::Parser do
           expect(formula).to eq(expected_value)
         end
       end
+
+      context "when contains a grouped comma separator between digits" do
+        let(:string) { "\\left(1{,}2\\right)" }
+
+        it "returns formula with comma separator" do
+          expected_value = Plurimath::Math::Formula.new([
+                                                          Plurimath::Math::Formula.new([
+                                                                                         Plurimath::Math::Function::Left.new("("),
+                                                                                         Plurimath::Math::Formula.new([
+                                                                                                                         Plurimath::Math::Number.new("1"),
+                                                                                                                         Plurimath::Math::Symbols::Comma.new,
+                                                                                                                         Plurimath::Math::Number.new("2"),
+                                                                                                                       ]),
+                                                                                         Plurimath::Math::Function::Right.new(")"),
+                                                                                       ]),
+                                                        ])
+          expect(formula).to eq(expected_value)
+        end
+      end
     end
 
     context "when locale uses full stop as the decimal separator" do

--- a/spec/plurimath/latex/parser_spec.rb
+++ b/spec/plurimath/latex/parser_spec.rb
@@ -22,6 +22,69 @@ RSpec.describe Plurimath::Latex::Parser do
       end
     end
 
+    context "when locale uses comma as the decimal separator" do
+      around do |example|
+        Plurimath.with_configuration do |config|
+          config.locale = :fr
+          example.run
+        end
+      end
+
+      context "when contains decimal comma" do
+        let(:string) { "1,2" }
+
+        it "returns formula" do
+          expected_value = Plurimath::Math::Formula.new([
+                                                          Plurimath::Math::Number.new("1,2"),
+                                                        ])
+          expect(formula).to eq(expected_value)
+        end
+      end
+
+      context "when contains leading comma" do
+        let(:string) { ",2" }
+
+        it "returns formula" do
+          expected_value = Plurimath::Math::Formula.new([
+                                                          Plurimath::Math::Symbols::Comma.new,
+                                                          Plurimath::Math::Number.new("2"),
+                                                        ])
+          expect(formula).to eq(expected_value)
+        end
+      end
+    end
+
+    context "when locale uses Arabic decimal separator" do
+      around do |example|
+        Plurimath.with_configuration do |config|
+          config.locale = :ar
+          example.run
+        end
+      end
+
+      context "when contains localized decimal marker" do
+        let(:string) { "1٫2" }
+
+        it "returns formula" do
+          expected_value = Plurimath::Math::Formula.new([
+                                                          Plurimath::Math::Number.new("1٫2"),
+                                                        ])
+          expect(formula).to eq(expected_value)
+        end
+      end
+
+      context "when contains entity-encoded localized decimal marker" do
+        let(:string) { "1&#x66b;2" }
+
+        it "returns formula with decoded decimal marker" do
+          expected_value = Plurimath::Math::Formula.new([
+                                                          Plurimath::Math::Number.new("1٫2"),
+                                                        ])
+          expect(formula).to eq(expected_value)
+        end
+      end
+    end
+
     context "contains simple nested values" do
       let(:string) do
         <<~LATEX

--- a/spec/plurimath/latex/parser_spec.rb
+++ b/spec/plurimath/latex/parser_spec.rb
@@ -41,12 +41,47 @@ RSpec.describe Plurimath::Latex::Parser do
         end
       end
 
+      context "when contains decimal full stop" do
+        let(:string) { "1.2" }
+
+        it "returns formula" do
+          expected_value = Plurimath::Math::Formula.new([
+                                                          Plurimath::Math::Number.new("1"),
+                                                          Plurimath::Math::Symbols::Period.new,
+                                                          Plurimath::Math::Number.new("2"),
+                                                        ])
+          expect(formula).to eq(expected_value)
+        end
+      end
+
       context "when contains leading comma" do
         let(:string) { ",2" }
 
         it "returns formula" do
           expected_value = Plurimath::Math::Formula.new([
                                                           Plurimath::Math::Symbols::Comma.new,
+                                                          Plurimath::Math::Number.new("2"),
+                                                        ])
+          expect(formula).to eq(expected_value)
+        end
+      end
+    end
+
+    context "when locale uses full stop as the decimal separator" do
+      around do |example|
+        Plurimath.with_configuration do |config|
+          config.locale = :en
+          example.run
+        end
+      end
+
+      context "when contains Arabic decimal marker" do
+        let(:string) { "1٫2" }
+
+        it "returns formula" do
+          expected_value = Plurimath::Math::Formula.new([
+                                                          Plurimath::Math::Number.new("1"),
+                                                          Plurimath::Math::Symbols::Symbol.new("&#x66b;"),
                                                           Plurimath::Math::Number.new("2"),
                                                         ])
           expect(formula).to eq(expected_value)

--- a/spec/plurimath/math_spec.rb
+++ b/spec/plurimath/math_spec.rb
@@ -2,7 +2,9 @@ require "spec_helper"
 
 RSpec.describe Plurimath::Math do
   describe ".initialize" do
-    subject(:formula) { described_class.parse(input, type) }
+    subject(:formula) { described_class.parse(input, type, **parse_options) }
+
+    let(:parse_options) { {} }
 
     context "when persistent configuration sets a locale" do
       let(:input) { "1,2" }
@@ -23,6 +25,113 @@ RSpec.describe Plurimath::Math do
                                                         Plurimath::Math::Number.new("1,2"),
                                                       ])
         expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "when locale is passed as a parse option" do
+      let(:input) { "1,2" }
+      let(:type) { "asciimath" }
+      let(:parse_options) { { locale: :fr } }
+
+      it "uses the locale while parsing through the facade" do
+        expected_value = Plurimath::Math::Formula.new([
+                                                        Plurimath::Math::Number.new("1,2"),
+                                                      ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
+    context "when locale is passed as a parse option for other localized parsers" do
+      it "uses locale for HTML input" do
+        expected_value = Plurimath::Math::Formula.new([
+                                                        Plurimath::Math::Number.new("1,2"),
+                                                      ])
+
+        expect(described_class.parse("1,2", :html, locale: :fr)).to eq(expected_value)
+      end
+
+      it "uses locale for LaTeX input" do
+        expected_value = Plurimath::Math::Formula.new([
+                                                        Plurimath::Math::Number.new("1,2"),
+                                                      ])
+
+        expect(described_class.parse("1,2", :latex, locale: :fr)).to eq(expected_value)
+      end
+
+      it "uses locale for UnicodeMath input" do
+        expected_value = Plurimath::Math::Formula.new([
+                                                        Plurimath::Math::Number.new("1٫2"),
+                                                      ])
+
+        expect(described_class.parse("1٫2", :unicode, locale: :ar)).to eq(expected_value)
+      end
+    end
+
+    context "when locale is passed as a parse option with persistent configuration" do
+      it "uses the parse option without mutating the shared configuration" do
+        previous_locale = Plurimath.configuration.locale
+        Plurimath.configuration.locale = :en
+
+        localized = described_class.parse("1,2", :asciimath, locale: :fr)
+        defaulted = described_class.parse("1,2", :asciimath)
+
+        expect(localized).to eq(
+          Plurimath::Math::Formula.new([
+                                         Plurimath::Math::Number.new("1,2"),
+                                       ]),
+        )
+        expect(defaulted.to_asciimath).to eq("1 , 2")
+        expect(Plurimath.configuration.locale).to be(:en)
+      ensure
+        Plurimath.configuration.locale = previous_locale
+      end
+
+      it "uses an explicit nil locale without mutating the shared configuration" do
+        previous_locale = Plurimath.configuration.locale
+        Plurimath.configuration.locale = :fr
+
+        defaulted = described_class.parse("1,2", :asciimath, locale: nil)
+
+        expect(defaulted.to_asciimath).to eq("1 , 2")
+        expect(Plurimath.configuration.locale).to be(:fr)
+      ensure
+        Plurimath.configuration.locale = previous_locale
+      end
+    end
+
+    context "when an unknown parse option is provided" do
+      let(:input) { "1,2" }
+      let(:type) { "asciimath" }
+      let(:parse_options) { { local: :fr } }
+
+      it "raises a parse option error" do
+        expect { formula }.to raise_error(
+          Plurimath::Math::ParseOptionError,
+          "unknown parse option: :local; supported parse options are :locale",
+        )
+      end
+    end
+
+    context "when a parse option is unsupported by the parser type" do
+      it "raises a parse option error" do
+        expect do
+          described_class.parse("<math></math>", :mathml, locale: :fr)
+        end.to raise_error(
+          Plurimath::Math::ParseOptionError,
+          "parse option :locale is not supported for :mathml; " \
+          "supported input types are :asciimath, :html, :latex, :unicode",
+        )
+      end
+    end
+
+    context "when an unsupported locale is provided" do
+      it "raises a formatter locale error" do
+        expect do
+          described_class.parse("1,2", :asciimath, locale: :unknown)
+        end.to raise_error(
+          Plurimath::Formatter::UnsupportedLocale,
+          /\[plurimath\] Unsupported locale :unknown\./,
+        )
       end
     end
 

--- a/spec/plurimath/math_spec.rb
+++ b/spec/plurimath/math_spec.rb
@@ -4,6 +4,28 @@ RSpec.describe Plurimath::Math do
   describe ".initialize" do
     subject(:formula) { described_class.parse(input, type) }
 
+    context "when persistent configuration sets a locale" do
+      let(:input) { "1,2" }
+      let(:type) { "asciimath" }
+
+      around do |example|
+        previous_locale = Plurimath.configuration.locale
+        Plurimath.configure do |config|
+          config.locale = :fr
+        end
+        example.run
+      ensure
+        Plurimath.configuration.locale = previous_locale
+      end
+
+      it "uses the configured locale while parsing through the facade" do
+        expected_value = Plurimath::Math::Formula.new([
+                                                        Plurimath::Math::Number.new("1,2"),
+                                                      ])
+        expect(formula).to eq(expected_value)
+      end
+    end
+
     context "contains incorrect type with parseable input of asciimath" do
       let(:input) { "sin(d)" }
       let(:type) { "wrong_type" }

--- a/spec/plurimath/math_spec.rb
+++ b/spec/plurimath/math_spec.rb
@@ -50,33 +50,5 @@ RSpec.describe Plurimath::Math do
         )
       end
     end
-
-    context "contains asciimath input with a configured decimal separator" do
-      let(:input) { "1,2" }
-      let(:type) { :asciimath }
-
-      it "parses using scoped configuration" do
-        result = Plurimath.with_configuration do |config|
-          config.locale = :fr
-          formula
-        end
-
-        expected_value = Plurimath::Math::Formula.new([
-                                                        Plurimath::Math::Number.new("1,2"),
-                                                      ])
-        expect(result).to eq(expected_value)
-      end
-    end
-
-    context "contains an unsupported parse option" do
-      let(:input) { "1,2" }
-      let(:type) { :asciimath }
-
-      it "raises argument error" do
-        expect do
-          described_class.parse(input, type, locale: :fr)
-        end.to raise_error(ArgumentError)
-      end
-    end
   end
 end

--- a/spec/plurimath/math_spec.rb
+++ b/spec/plurimath/math_spec.rb
@@ -50,5 +50,33 @@ RSpec.describe Plurimath::Math do
         )
       end
     end
+
+    context "contains asciimath input with a configured decimal separator" do
+      let(:input) { "1,2" }
+      let(:type) { :asciimath }
+
+      it "parses using scoped configuration" do
+        result = Plurimath.with_configuration do |config|
+          config.locale = :fr
+          formula
+        end
+
+        expected_value = Plurimath::Math::Formula.new([
+                                                        Plurimath::Math::Number.new("1,2"),
+                                                      ])
+        expect(result).to eq(expected_value)
+      end
+    end
+
+    context "contains an unsupported parse option" do
+      let(:input) { "1,2" }
+      let(:type) { :asciimath }
+
+      it "raises argument error" do
+        expect do
+          described_class.parse(input, type, locale: :fr)
+        end.to raise_error(ArgumentError)
+      end
+    end
   end
 end

--- a/spec/plurimath/unicode_math/parse_spec.rb
+++ b/spec/plurimath/unicode_math/parse_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+
+RSpec.describe Plurimath::UnicodeMath::Parse do
+  describe "#number" do
+    subject(:number) { described_class.new.number.parse(string) }
+
+    context "when locale decimal marker is encoded before parsing" do
+      around do |example|
+        Plurimath.with_configuration do |config|
+          config.locale = :ar
+          example.run
+        end
+      end
+
+      let(:string) { "1&#x66b;2" }
+
+      it "parses the encoded configured marker as part of the number" do
+        decimal_number = number[:decimal_number]
+
+        expect(decimal_number[:whole][:number]).to eq("1")
+        expect(decimal_number[:decimal]).to eq("&#x66b;")
+        expect(decimal_number[:fractional][:number]).to eq("2")
+      end
+    end
+  end
+end

--- a/spec/plurimath/unicode_math/parser_spec.rb
+++ b/spec/plurimath/unicode_math/parser_spec.rb
@@ -5,6 +5,81 @@ RSpec.describe Plurimath::UnicodeMath::Parser do
   describe ".parse" do
     subject(:formula) { described_class.new(string).parse }
 
+    context "when parsing decimal markers" do
+      context "when contains decimal full stop" do
+        let(:string) { "1.2" }
+
+        it "matches formula structure of UnicodeMath" do
+          expected_value = Plurimath::Math::Formula.new([
+                                                          Plurimath::Math::Number.new("1.2"),
+                                                        ])
+          expect(formula).to eq(expected_value)
+        end
+      end
+
+      context "when contains decimal comma" do
+        let(:string) { "1,2" }
+
+        it "matches formula structure of UnicodeMath" do
+          expected_value = Plurimath::Math::Formula.new([
+                                                          Plurimath::Math::Number.new("1,2"),
+                                                        ])
+          expect(formula).to eq(expected_value)
+        end
+      end
+
+      context "when contains leading decimal comma" do
+        let(:string) { ",2" }
+
+        it "matches formula structure of UnicodeMath" do
+          expected_value = Plurimath::Math::Formula.new([
+                                                          Plurimath::Math::Number.new(",2"),
+                                                        ])
+          expect(formula).to eq(expected_value)
+        end
+      end
+
+      context "when locale uses comma as the decimal separator" do
+        around do |example|
+          Plurimath.with_configuration do |config|
+            config.locale = :fr
+            example.run
+          end
+        end
+
+        context "when contains decimal full stop" do
+          let(:string) { "1.2" }
+
+          it "matches formula structure of UnicodeMath" do
+            expected_value = Plurimath::Math::Formula.new([
+                                                            Plurimath::Math::Number.new("1.2"),
+                                                          ])
+            expect(formula).to eq(expected_value)
+          end
+        end
+      end
+
+      context "when locale uses Arabic decimal separator" do
+        around do |example|
+          Plurimath.with_configuration do |config|
+            config.locale = :ar
+            example.run
+          end
+        end
+
+        context "when contains localized decimal marker" do
+          let(:string) { "1٫2" }
+
+          it "matches formula structure of UnicodeMath" do
+            expected_value = Plurimath::Math::Formula.new([
+                                                            Plurimath::Math::Number.new("1٫2"),
+                                                          ])
+            expect(formula).to eq(expected_value)
+          end
+        end
+      end
+    end
+
     context "contains n-ary function with mask value #1 #EXAMPLE_676" do
       let(:string) { "\\amalg13_d\\of d" }
 

--- a/spec/plurimath/unicode_math/parser_spec.rb
+++ b/spec/plurimath/unicode_math/parser_spec.rb
@@ -39,6 +39,17 @@ RSpec.describe Plurimath::UnicodeMath::Parser do
         end
       end
 
+      context "when contains leading decimal full stop" do
+        let(:string) { ".2" }
+
+        it "matches formula structure of UnicodeMath" do
+          expected_value = Plurimath::Math::Formula.new([
+                                                          Plurimath::Math::Number.new(".2"),
+                                                        ])
+          expect(formula).to eq(expected_value)
+        end
+      end
+
       context "when locale uses comma as the decimal separator" do
         around do |example|
           Plurimath.with_configuration do |config|


### PR DESCRIPTION
This PR:
- Add scoped `Plurimath.with_configuration` support for temporary locale overrides.
- Add `Plurimath::Configuration#locale` and `#decimal`.
- Update the AsciiMath `number` grammar to use the configured decimal separator directly.
- Preserve the existing `number` transform path for `Math::Number`.
- Document the AsciiMath comma convention: `1,2` is decimal, `1 , 2` is a separator.

closes #76 