### PR TITLE
Allow base prefix and postfix together for number formatting

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -725,7 +725,9 @@ When omitted, standard prefixes are used (`0b` for base 2, `0o` for base 8, `0x`
 ====
 
 `base_postfix`:: (`String` or `nil` value)
-If present, a postfix is appended to the converted number instead of using any base prefix.
+If present without `base_prefix`, a postfix is appended to the converted number
+instead of using the default base prefix. When `base_prefix` is also provided,
+the prefix and postfix are both rendered.
 This is applied after digit grouping.
 Because the formatter checks whether the `base_postfix` key is present, setting
 it to `nil` or an empty string omits both the postfix and the default base
@@ -735,6 +737,7 @@ prefix.
 [example]
 ====
 "255" with `base: 16, base_postfix: "_16"` => "ff_16"
+"255" with `base: 16, base_prefix: "16#", base_postfix: "_16"` => "16#ff_16"
 "255" with `base: 16, base_postfix: nil` => "ff"
 "255" with `base: 16, base_postfix: ""` => "ff"
 ====

--- a/lib/plurimath/formatter/numbers/base_notation.rb
+++ b/lib/plurimath/formatter/numbers/base_notation.rb
@@ -42,6 +42,7 @@ module Plurimath
 
         def base_prefix
           return options.base_prefix if options.base_prefix?
+          # A postfix without an explicit prefix opts out of the default prefix.
           return "" if options.base_postfix?
 
           DEFAULT_PREFIXES[base]

--- a/lib/plurimath/formatter/numbers/base_notation.rb
+++ b/lib/plurimath/formatter/numbers/base_notation.rb
@@ -25,9 +25,7 @@ module Plurimath
           rendered = upcase_hex? ? string.tr(Base::HEX_DIGITS, Base::HEX_DIGITS.upcase) : string
           return rendered if default?
 
-          return "#{rendered}#{options.base_postfix}" if options.base_postfix?
-
-          "#{base_prefix}#{rendered}"
+          "#{base_prefix}#{rendered}#{base_postfix}"
         end
 
         def default?
@@ -43,9 +41,16 @@ module Plurimath
         attr_reader :options
 
         def base_prefix
+          return "" if options.base_postfix? && !options.base_prefix?
           return options.base_prefix if options.base_prefix?
 
           DEFAULT_PREFIXES[base]
+        end
+
+        def base_postfix
+          return "" unless options.base_postfix?
+
+          options.base_postfix.to_s
         end
 
         def upcase_hex?

--- a/lib/plurimath/formatter/numbers/base_notation.rb
+++ b/lib/plurimath/formatter/numbers/base_notation.rb
@@ -41,15 +41,13 @@ module Plurimath
         attr_reader :options
 
         def base_prefix
-          return "" if options.base_postfix? && !options.base_prefix?
           return options.base_prefix if options.base_prefix?
+          return "" if options.base_postfix?
 
           DEFAULT_PREFIXES[base]
         end
 
         def base_postfix
-          return "" unless options.base_postfix?
-
           options.base_postfix.to_s
         end
 

--- a/spec/plurimath/formatter/numbers/base_notation_spec.rb
+++ b/spec/plurimath/formatter/numbers/base_notation_spec.rb
@@ -32,6 +32,18 @@ RSpec.describe Plurimath::Formatter::Numbers::BaseNotation do
       expect(notation.apply("ff")).to eq("ffh")
     end
 
+    it "uses base_postfix nil without the default prefix when provided" do
+      notation = described_class.new(options(base: 16, base_postfix: nil))
+
+      expect(notation.apply("ff")).to eq("ff")
+    end
+
+    it "uses an empty base_postfix without the default prefix when provided" do
+      notation = described_class.new(options(base: 16, base_postfix: ""))
+
+      expect(notation.apply("ff")).to eq("ff")
+    end
+
     it "combines explicit base_prefix and base_postfix when both are provided" do
       notation = described_class.new(options(base: 16, base_prefix: "0x", base_postfix: "h"))
 

--- a/spec/plurimath/formatter/numbers/base_notation_spec.rb
+++ b/spec/plurimath/formatter/numbers/base_notation_spec.rb
@@ -26,10 +26,16 @@ RSpec.describe Plurimath::Formatter::Numbers::BaseNotation do
       expect(notation.apply("ff")).to eq("16#ff")
     end
 
-    it "uses base_postfix before prefix when present" do
-      notation = described_class.new(options(base: 16, base_prefix: "0x", base_postfix: "h"))
+    it "uses base_postfix without the default prefix when provided alone" do
+      notation = described_class.new(options(base: 16, base_postfix: "h"))
 
       expect(notation.apply("ff")).to eq("ffh")
+    end
+
+    it "combines explicit base_prefix and base_postfix when both are provided" do
+      notation = described_class.new(options(base: 16, base_prefix: "0x", base_postfix: "h"))
+
+      expect(notation.apply("ff")).to eq("0xffh")
     end
 
     it "keeps the existing whole-rendered-string hex capitalization behavior" do

--- a/spec/plurimath/number_formatter_spec.rb
+++ b/spec/plurimath/number_formatter_spec.rb
@@ -715,7 +715,7 @@ RSpec.describe Plurimath::NumberFormatter do
       end
 
       context "base_postfix option" do
-        it "uses base_postfix instead of prefix when provided" do
+        it "uses base_postfix without the default prefix when provided alone" do
           output_string = formatter.localized_number("255",
                                                      format: base_format_defaults.merge(
                                                        base: 16, base_postfix: "_16",
@@ -730,11 +730,11 @@ RSpec.describe Plurimath::NumberFormatter do
           expect(output_string).to eql("BE,EF_h")
         end
 
-        it "base_postfix takes precedence even if base_prefix is also provided" do
+        it "combines base_prefix and base_postfix when both are provided" do
           output_string = formatter.localized_number("255",
                                                      format: base_format_defaults.merge(base: 16, base_prefix: "0x",
                                                                                         base_postfix: "h"))
-          expect(output_string).to eql("ffh")
+          expect(output_string).to eql("0xffh")
         end
       end
 
@@ -761,7 +761,7 @@ RSpec.describe Plurimath::NumberFormatter do
           expect(output_string).to eql("2,55")
         end
 
-        it "base_postfix takes precedence even if base_prefix is also provided" do
+        it "does not add prefix or postfix when base is 10" do
           output_string = formatter.localized_number("255",
                                                      format: base_format_defaults.merge(base: 10, base_prefix: "y^",
                                                                                         base_postfix: "_x"))
@@ -1427,7 +1427,7 @@ RSpec.describe Plurimath::NumberFormatter do
           end
         end
 
-        context "base_postfix with negative numbers and precedence over base_prefix" do
+        context "base_postfix with negative numbers and optional base_prefix" do
           it "uses base_postfix instead of prefix for a negative number" do
             output_string = formatter.localized_number("-255",
                                                        format: base_format_defaults.merge(
@@ -1436,11 +1436,11 @@ RSpec.describe Plurimath::NumberFormatter do
             expect(output_string).to eql("-ff_16")
           end
 
-          it "base_postfix still takes precedence when both base_prefix and base_postfix are provided" do
+          it "combines base_prefix and base_postfix when both are provided" do
             output_string = formatter.localized_number("255",
                                                        format: base_format_defaults.merge(base: 16, base_prefix: "0x",
                                                                                           base_postfix: "h"))
-            expect(output_string).to eql("ffh")
+            expect(output_string).to eql("0xffh")
           end
         end
 

--- a/spec/plurimath/number_formatter_spec.rb
+++ b/spec/plurimath/number_formatter_spec.rb
@@ -723,6 +723,22 @@ RSpec.describe Plurimath::NumberFormatter do
           expect(output_string).to eql("ff_16")
         end
 
+        it "uses base_postfix nil without the default prefix when provided" do
+          output_string = formatter.localized_number("255",
+                                                     format: base_format_defaults.merge(
+                                                       base: 16, base_postfix: nil,
+                                                     ))
+          expect(output_string).to eql("ff")
+        end
+
+        it "uses an empty base_postfix without the default prefix when provided" do
+          output_string = formatter.localized_number("255",
+                                                     format: base_format_defaults.merge(
+                                                       base: 16, base_postfix: "",
+                                                     ))
+          expect(output_string).to eql("ff")
+        end
+
         it "uppercases hex digits even when base_postfix is used" do
           output_string = formatter.localized_number("48879",
                                                      format: base_format_defaults.merge(base: 16, base_postfix: "_h",
@@ -1437,10 +1453,10 @@ RSpec.describe Plurimath::NumberFormatter do
           end
 
           it "combines base_prefix and base_postfix when both are provided" do
-            output_string = formatter.localized_number("255",
+            output_string = formatter.localized_number("-255",
                                                        format: base_format_defaults.merge(base: 16, base_prefix: "0x",
                                                                                           base_postfix: "h"))
-            expect(output_string).to eql("0xffh")
+            expect(output_string).to eql("-0xffh")
           end
         end
 


### PR DESCRIPTION
This PR:
- allow `base_prefix` and `base_postfix` to render together for non-decimal number formatting
- preserve postfix-only behavior where `base_postfix` suppresses the default base prefix
- keep base-10 output unchanged without prefix or postfix notation
- update formatter specs and **README**

depends on #423 
closes #431 