### PR TITLE
Fix MathML round-tripping across XML adapters

### DIFF
--- a/lib/plurimath/mathml/formula_transformation.rb
+++ b/lib/plurimath/mathml/formula_transformation.rb
@@ -27,8 +27,14 @@ module Plurimath
       # before building the Plurimath AST.
       def content_children(node)
         ordered_children(node).reject do |child|
-          child.is_a?(Mml::V4::Malignmark) || child.is_a?(Mml::V4::Maligngroup)
+          whitespace_child?(child) ||
+            child.is_a?(Mml::V4::Malignmark) ||
+            child.is_a?(Mml::V4::Maligngroup)
         end
+      end
+
+      def whitespace_child?(child)
+        child.is_a?(String) && child.strip.empty?
       end
 
       def default_fenced_open(fenced)

--- a/spec/plurimath/mathml_spec.rb
+++ b/spec/plurimath/mathml_spec.rb
@@ -42,31 +42,39 @@ RSpec.describe Plurimath::Mathml do
   end
 
   describe "MathML round-tripping" do
-    around do |example|
-      adapter = Mml::V4::Configuration.adapter
-      Mml::V4::Configuration.adapter = :nokogiri
-      example.run
-    ensure
-      Mml::V4::Configuration.adapter = adapter
+    shared_examples "compound script round-tripping" do |adapter_name|
+      around do |example|
+        adapter = Mml::V4::Configuration.adapter
+        Mml::V4::Configuration.adapter = adapter_name
+        example.run
+      ensure
+        Mml::V4::Configuration.adapter = adapter
+      end
+
+      it "round-trips pretty-printed compound script expressions" do
+        expressions = [
+          "y^2 = x^3",
+          "y^2 = x^3 + ax + b",
+          "x^3 + b",
+          "x^2 + y^2 + z^2",
+          "x_1 + y",
+          "x_1^2 + y",
+        ]
+
+        aggregate_failures do
+          expressions.each do |expression|
+            mathml = Plurimath::Math.parse(expression, "asciimath").to_mathml
+            round_tripped = Plurimath::Math.parse(mathml, "mathml").to_mathml
+
+            expect(round_tripped).to be_xml_equivalent_to(mathml)
+          end
+        end
+      end
     end
 
-    it "ignores adapter-exposed pretty-print whitespace in compound script expressions" do
-      expressions = [
-        "y^2 = x^3",
-        "y^2 = x^3 + ax + b",
-        "x^3 + b",
-        "x^2 + y^2 + z^2",
-        "x_1 + y",
-        "x_1^2 + y",
-      ]
-
-      aggregate_failures do
-        expressions.each do |expression|
-          mathml = Plurimath::Math.parse(expression, "asciimath").to_mathml
-          round_tripped = Plurimath::Math.parse(mathml, "mathml").to_mathml
-
-          expect(round_tripped).to be_xml_equivalent_to(mathml)
-        end
+    %i[ox oga nokogiri].each do |adapter_name|
+      context "with #{adapter_name} adapter" do
+        include_examples "compound script round-tripping", adapter_name
       end
     end
   end

--- a/spec/plurimath/mathml_spec.rb
+++ b/spec/plurimath/mathml_spec.rb
@@ -41,6 +41,36 @@ RSpec.describe Plurimath::Mathml do
     end
   end
 
+  describe "MathML round-tripping" do
+    around do |example|
+      adapter = Mml::V4::Configuration.adapter
+      Mml::V4::Configuration.adapter = :nokogiri
+      example.run
+    ensure
+      Mml::V4::Configuration.adapter = adapter
+    end
+
+    it "ignores adapter-exposed pretty-print whitespace in compound script expressions" do
+      expressions = [
+        "y^2 = x^3",
+        "y^2 = x^3 + ax + b",
+        "x^3 + b",
+        "x^2 + y^2 + z^2",
+        "x_1 + y",
+        "x_1^2 + y",
+      ]
+
+      aggregate_failures do
+        expressions.each do |expression|
+          mathml = Plurimath::Math.parse(expression, "asciimath").to_mathml
+          round_tripped = Plurimath::Math.parse(mathml, "mathml").to_mathml
+
+          expect(round_tripped).to be_xml_equivalent_to(mathml)
+        end
+      end
+    end
+  end
+
   describe ".to_asciimath .to_latex .to_mathml" do
     subject(:formula) { described_class.new(string).to_formula }
 


### PR DESCRIPTION
This PR:
- ignore whitespace-only mixed-content nodes when collecting MathML content operands
- preserve raw ordered mixed content for token/text handling
- add compound script round-trip coverage across Ox, Oga, and Nokogiri adapters

closes #435