### PR TITLE
Migrate release workflow to test-gated publish flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,8 @@ on:
           Next release version. Possible values: x.y.z, major, minor, patch or pre|rc|etc
         required: true
         default: 'skip'
-  push:
-    tags: [ v* ]
+  repository_dispatch:
+    types: [ do-release ]
 
 jobs:
   release:
@@ -23,3 +23,4 @@ jobs:
       next_version: ${{ github.event.inputs.next_version }}
     secrets:
       rubygems-api-key: ${{ secrets.PLURIMATH_CI_RUBYGEMS_API_KEY }}
+      pat_token: ${{ secrets.PLURIMATH_CI_PAT_TOKEN }}

--- a/lib/plurimath/version.rb
+++ b/lib/plurimath/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Plurimath
-  VERSION = "0.10.8.0.10.8.pre.test.1"
+  VERSION = "0.10.8"
 end

--- a/lib/plurimath/version.rb
+++ b/lib/plurimath/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Plurimath
-  VERSION = "0.10.8"
+  VERSION = "0.10.8.0.10.8.pre.test.1"
 end


### PR DESCRIPTION
This PR:
- replace the `push: tags` trigger with the `repository_dispatch: [do-release]` listener
- pass `PLURIMATH_CI_PAT_TOKEN` to the reusable workflow so the version bump's tag push triggers the test chain