### PR TITLE
Parse bare MathML accent names as literal identifiers

### DIFF
--- a/lib/plurimath/mathml/constants.rb
+++ b/lib/plurimath/mathml/constants.rb
@@ -174,6 +174,24 @@ module Plurimath
         "+": "+",
         "-": "-",
       }.freeze
+      # Over/under accent decorations. In MathML these are only ever expressed
+      # as <mover>/<munder> with a base (recovered from their diacritic
+      # CHARACTER), never as a bare <mi>/<mo> identifier word. So a bare token
+      # whose text is one of these names is a literal identifier (e.g. the unit
+      # "bar"), not the accent. See unitsml/unitsdb#123.
+      ACCENT_WORDS = %w[
+        bar overline ul hat vec tilde dot ddot obrace ubrace overleftrightarrow
+      ].freeze
+
+      # True when +string+ is a bare word naming an over/under accent. Such
+      # tokens are literal identifiers in MathML (the accent itself is a
+      # diacritic character inside <mover>/<munder>), so callers must not
+      # promote them to accent operators. AsciiMath/LaTeX word forms
+      # (bar(x), \bar{x}) are parsed elsewhere and never reach this predicate.
+      def self.accent_word?(string)
+        ACCENT_WORDS.include?(string&.strip)
+      end
+
       CLASSES = %w[
         mathfrak
         underset

--- a/lib/plurimath/utility.rb
+++ b/lib/plurimath/utility.rb
@@ -437,7 +437,7 @@ lang: nil)
         symbol = Mathml::Constants::UNICODE_SYMBOLS[unicode.strip.to_sym]
         if classes.include?(symbol&.strip)
           get_class(symbol.strip).new
-        elsif classes.any?(string&.strip)
+        elsif classes.any?(string&.strip) && !(lang == :mathml && Mathml::Constants.accent_word?(string))
           get_class(string.strip).new
         elsif omml
           text_classes(string,

--- a/spec/plurimath/mathml/parser_spec.rb
+++ b/spec/plurimath/mathml/parser_spec.rb
@@ -2164,4 +2164,41 @@ RSpec.describe Plurimath::Mathml::Parser do
       expect(formula).to eq(expected_value)
     end
   end
+
+  context "contains a bare <mi> whose name collides with an accent (unitsml/unitsdb#123)" do
+    let(:exp) do
+      <<~MATHML
+        <math xmlns='http://www.w3.org/1998/Math/MathML'>
+          <mi>bar</mi>
+        </math>
+      MATHML
+    end
+
+    it "treats the accent name as a literal symbol, not an overline accent" do
+      expected_value = Plurimath::Math::Formula.new([
+                                                      Plurimath::Math::Symbols::Symbol.new("bar"),
+                                                    ])
+      expect(formula).to eq(expected_value)
+    end
+  end
+
+  context "contains an upright <mi> whose name collides with an accent (unitsml/unitsdb#123)" do
+    let(:exp) do
+      <<~MATHML
+        <math xmlns='http://www.w3.org/1998/Math/MathML'>
+          <mi mathvariant='normal'>bar</mi>
+        </math>
+      MATHML
+    end
+
+    it "treats the upright identifier as a literal symbol, not an overline accent" do
+      expected_value = Plurimath::Math::Formula.new([
+                                                      Plurimath::Math::Function::FontStyle::Normal.new(
+                                                        Plurimath::Math::Symbols::Symbol.new("bar"),
+                                                        "normal",
+                                                      ),
+                                                    ])
+      expect(formula).to eq(expected_value)
+    end
+  end
 end

--- a/spec/plurimath/unitsml_spec.rb
+++ b/spec/plurimath/unitsml_spec.rb
@@ -108,4 +108,29 @@ RSpec.describe Plurimath::Unitsml do
       end
     end
   end
+
+  # Regression for unitsml/unitsdb#123. An accent name ("bar") rendered by
+  # UnitsML as a bare <mi> must stay a literal identifier, not be re-parsed as
+  # the overline accent. (Named-function unit names like "min"/"sec" are a
+  # separate, ambiguous case and are intentionally not addressed by this rule.)
+  describe "an accent-named unit (unitsml/unitsdb#123)" do
+    it "renders 'bar' as an upright unit identifier, not an overline accent" do
+      formula = Plurimath::Math.parse('1 "unitsml(bar)"', :asciimath)
+      mathml = <<~MATHML
+        <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+          <mstyle displaystyle="true">
+            <mn>1</mn>
+            <mo rspace="thickmathspace">&#x2062;</mo>
+            <mrow>
+              <mstyle mathvariant="normal">
+                <mi>bar</mi>
+              </mstyle>
+            </mrow>
+          </mstyle>
+        </math>
+      MATHML
+      expect(formula.to_mathml).to be_xml_equivalent_to(mathml)
+      expect(formula.to_latex).to eq('1 \mathrm{bar}')
+    end
+  end
 end


### PR DESCRIPTION
This PR:

- treats a bare accent-name `<mi>`/`<mo>` token in MathML (e.g. `<mi>bar</mi>`) as a literal identifier instead of an accent
- preserves MathML's own structural accents — `<mover>`/`<munder>` built from the diacritic character — unchanged
- leaves every other format untouched: AsciiMath `bar(d)`, LaTeX/UnicodeMath `\bar{d}`, and OMML keep their own accent forms

In MathML an over/under accent is expressed structurally (`<mover>…<mo>&#xaf;</mo></mover>`, the diacritic character), never as a word — so a bare accent name is just an identifier. Previously these accent names were parsed as baseless accents, so the UnitsML unit `bar` rendered as `¯` (U+00AF) instead of "bar".

**Breaking change:** in MathML, a bare accent-name `<mi>`/`<mo>` token now parses as a
literal identifier instead of an accent. Suggested release: **0.12.0** (pre-1.0
breaking change → minor bump).

Note: unit names that collide with a named *function* — such as `min`/`sec` — are out of scope here. Unlike an accent, a bare `<mi>min</mi>` is genuinely ambiguous (the `min` operator vs. an identifier), and a named function that has no MathML symbol — e.g. `sin`, written only as `<mi>sin</mi>` — must keep parsing as a function, so this collision cannot be resolved generically; it is tracked separately.

closes unitsml/unitsdb#123
