### PR TITLE
Restore Number#evaluate and align test formatters with canonical format_number protocol

### DIFF
--- a/lib/plurimath/math/number.rb
+++ b/lib/plurimath/math/number.rb
@@ -81,6 +81,15 @@ module Plurimath
         false
       end
 
+      def evaluate(_evaluator)
+        raw_value = value.to_s
+        return raw_value.to_i if raw_value.match?(/\A[+-]?\d+\z/)
+
+        Float(raw_value)
+      rescue ArgumentError
+        raise Errors::Evaluation::UnsupportedExpressionError, "number `#{raw_value}`"
+      end
+
       def mini_sized?
         mini_sub_sized || mini_sup_sized
       end

--- a/spec/plurimath/math/formula_spec.rb
+++ b/spec/plurimath/math/formula_spec.rb
@@ -1330,39 +1330,8 @@ RSpec.describe Plurimath::Math::Formula do
           },
         )
       end
-      let(:format_number_spy_class) do
-        Class.new(Plurimath::Formatter::Standard) do
-          def initialize(on_format_number: nil)
-            super()
-            @on_format_number = on_format_number
-          end
-
-          def format_number(formula, number)
-            @on_format_number&.call(formula, number)
-            localized_number(number.value.to_s)
-          end
-        end
-      end
-      let(:format_number_spy) do
-        format_number_spy_class.new(
-          on_format_number: proc { |formula, number|
-            received_formula << formula
-            received_numbers << number
-          },
-        )
-      end
 
       it "passes the root formula and number nodes to format_number" do
-        formula_obj.to_latex(formatter: format_number_spy)
-
-        expect(received_formula.first).to be_a(described_class)
-        expect(received_formula.first).to eq(formula_obj)
-        expect(received_numbers.first).to be_a(Plurimath::Math::Number)
-        expect(received_numbers.first.value).to eq("2024")
-        expect(received_numbers[1].value).to eq("1000000")
-      end
-
-      it "passes the root formula and number nodes to format" do
         formula_obj.to_latex(formatter: spy)
 
         expect(received_formula.first).to be_a(described_class)
@@ -1455,12 +1424,12 @@ module FormulaSpecFormatters
   end
 
   class YearFormatter < Plurimath::Formatter::Standard
-    def format(_formula, number)
+    def format_number(_formula, number, format: {})
       int_value = Integer(number.value, exception: false)
       if int_value && int_value > 1800 && int_value < 2200
         number.value.to_s
       else
-        localized_number(number.value.to_s)
+        localized_number(number.value.to_s, format: format)
       end
     end
   end
@@ -1471,9 +1440,9 @@ module FormulaSpecFormatters
       @on_format = on_format
     end
 
-    def format(formula, number)
+    def format_number(formula, number, format: {})
       @on_format&.call(formula, number)
-      localized_number(number.value.to_s)
+      localized_number(number.value.to_s, format: format)
     end
   end
 end


### PR DESCRIPTION
## Problem

The v0.11.2 release (PRs #443, #447, #450 squashed) shipped two regressions:

1. **Number#evaluate was accidentally deleted** during PR #447's NumberFormatter dispatch consolidation. Every `Formula#evaluate` spec (146 examples) failed with `unsupported expression: number \`2\``.

2. **Test formatters used the pre-#447 dual protocol** (`format(formula, number)` 2-arg and `format_number(formula, number)` 2-arg) while the new canonical signature is `format_number(formula, number, format: {})` 3-arg. The 10 contextual-number-formatting specs (issue #294) failed because spy callbacks never fired and the year-skip path was unreachable.

## Fix

**`lib/plurimath/math/number.rb`** — restore `Number#evaluate`:

```ruby
def evaluate(_evaluator)
  raw_value = value.to_s
  return raw_value.to_i if raw_value.match?(/\A[+-]?\d+\z/)

  Float(raw_value)
rescue ArgumentError
  raise Errors::Evaluation::UnsupportedExpressionError, "number \`#{raw_value}\`"
end
```

**`spec/plurimath/math/formula_spec.rb`** — align test formatters with the canonical protocol:

- `FormulaSpecFormatters::YearFormatter#format` → `#format_number(_formula, number, format: {})`
- `FormulaSpecFormatters::SpyFormatter#format` → `#format_number(formula, number, format: {})`
- Drop the redundant `format_number_spy_class` (now identical to `SpyFormatter` after protocol unification).
- Pass `format:` through to `localized_number` so per-element options survive the contextual override.

## Verification

- `bundle exec rspec spec/plurimath/formatter spec/plurimath/math`: **13,274 examples, 0 failures**
- `bundle exec rspec spec/plurimath/{mathml,latex,html,asciimath,unicode_math,omml}`: **2,688 examples, 0 failures**
- `bundle exec rspec spec/plurimath/integration/asciimath_spec.rb`: **21 examples, 0 failures**
- `bundle exec rspec spec/plurimath/{configuration,deprecation,cli,base_number_prefix,base_prefix_parsing,xml_engine}_spec.rb`: **134 examples, 0 failures**
- `bundle exec rubocop lib/plurimath/math/number.rb spec/plurimath/math/formula_spec.rb`: **clean**

## Notes

This is a patch-only fix for v0.11.2. Once merged, a v0.11.3 release would unblock downstream users.