### PR TITLE
Replace YAML.safe_load with explicit boolean coercion

### DIFF
--- a/lib/plurimath/cli.rb
+++ b/lib/plurimath/cli.rb
@@ -56,7 +56,7 @@ module Plurimath
       output_format  = options[:output_format]
       configure_xml_engine(input_format, output_format)
       formula = Plurimath::Math.parse(input_string, input_format)
-      return puts formula.to_display(output_format.to_sym) if YAML.safe_load(options[:math_rendering])
+      return puts formula.to_display(output_format.to_sym) if options[:math_rendering].to_s == "true"
 
       display_style  = options[:display_style]
       split          = options[:split_on_linebreak]

--- a/lib/plurimath/math/formula.rb
+++ b/lib/plurimath/math/formula.rb
@@ -413,7 +413,7 @@ options:)
       end
 
       def boolean_display_style(display_style = displaystyle)
-        YAML.safe_load(display_style.to_s)
+        display_style.to_s == "true"
       end
 
       def new_space(spacing, indent)

--- a/lib/plurimath/utility.rb
+++ b/lib/plurimath/utility.rb
@@ -552,7 +552,7 @@ lang: nil)
         if value.last.is_a?(Math::Function::UnaryFunction)
           value.last.parameter_one = value.shift if value.length > 1
           value.last.attributes = attrs.transform_values do |v|
-            YAML.safe_load(v)
+            v.to_s == "true"
           end
         end
         value


### PR DESCRIPTION
## Summary

Replaces three `YAML.safe_load(...)` call sites that existed solely to coerce a `"true"`/`"false"` string into a boolean, with an explicit `to_s == "true"` comparison.

- `Plurimath::Math::Formula#boolean_display_style` (`lib/plurimath/math/formula.rb`)
- `Plurimath::Utility#attr_is_accent` attribute hash transform (`lib/plurimath/utility.rb`)
- `Plurimath::Cli#convert` for the `-m/--math-rendering` flag (`lib/plurimath/cli.rb`)

## Why

`YAML` is not autoloaded in every Ruby runtime. Under [Opal](https://opalrb.com/) (Ruby → JavaScript compiler, used by [`plurimath-js`](https://github.com/plurimath/plurimath-js) to ship Plurimath to npm), Opal's stdlib `yaml.rb` ships as `# REMOVED: use nodejs/yaml` — so any code path that hits `YAML.safe_load` raises `NameError: uninitialized constant ... ::YAML`.

All three call sites are turning a CLI flag or attribute value (always `"true"` or `"false"`) into a boolean. `to_s == "true"` is:

1. Behavior-equivalent for the values these sites actually receive.
2. Clearer about intent (the call sites are *boolean coercion*, not YAML parsing).
3. Free of the implicit dependency on the `yaml` stdlib being loaded.

## Test plan

- [x] `bundle exec rspec spec/plurimath/omml_spec.rb spec/plurimath/mathml_spec.rb spec/plurimath/cli_spec.rb` — 134 examples, 0 failures.
- [x] Verified end-to-end under Opal in the plurimath-js build (these were the only blockers remaining in the Opal compile path).
