### PR TITLE
Extract language-specific helpers from `Utility` into per-language modules

### DIFF
--- a/lib/plurimath/asciimath.rb
+++ b/lib/plurimath/asciimath.rb
@@ -6,6 +6,7 @@ module Plurimath
     autoload :Parse, "#{__dir__}/asciimath/parse"
     autoload :Parser, "#{__dir__}/asciimath/parser"
     autoload :Transform, "#{__dir__}/asciimath/transform"
+    autoload :Utility, "#{__dir__}/asciimath/utility"
 
     attr_accessor :text
 

--- a/lib/plurimath/asciimath/utility.rb
+++ b/lib/plurimath/asciimath/utility.rb
@@ -2,7 +2,7 @@
 
 module Plurimath
   class Asciimath
-    # AsciiMath-specific helpers extracted from Plurimath::Utility (A1 code-quality
+    # AsciiMath-specific helpers extracted from Plurimath::Utility (code-quality
     # refactor). Subclasses Utility so bareword `Utility.<generic>` calls inside
     # AsciiMath files keep resolving here and inherit the generic helpers.
     class Utility < Plurimath::Utility

--- a/lib/plurimath/asciimath/utility.rb
+++ b/lib/plurimath/asciimath/utility.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Plurimath
+  class Asciimath
+    # AsciiMath-specific helpers extracted from Plurimath::Utility (A1 code-quality
+    # refactor). Subclasses Utility so bareword `Utility.<generic>` calls inside
+    # AsciiMath files keep resolving here and inherit the generic helpers.
+    class Utility < Plurimath::Utility
+      class << self
+        def td_values(objects, slicer)
+          sliced = objects.slice_when { |object, _| symbol_value(object, slicer) }
+          tds = sliced.map do |slice|
+            Math::Function::Td.new(
+              slice.delete_if { |d| symbol_value(d, slicer) }.compact,
+            )
+          end
+          tds << Math::Function::Td.new([]) if symbol_value(objects.last, slicer)
+          tds
+        end
+
+        def td_value(td_object)
+          str_classes = [String, Parslet::Slice]
+          if str_classes.include?(td_object.class) && td_object.to_s.empty?
+            return Math::Function::Text.new(nil)
+          end
+
+          td_object
+        end
+
+        def frac_values(object)
+          case object
+          when Math::Formula
+            object.value.any? { |d| symbol_value(d, ",") }
+          when Array
+            object.any? { |d| symbol_value(d, ",") }
+          end
+        end
+
+        def asciimath_symbol_object(value, lang: :asciimath)
+          return if value.nil?
+
+          symbols = symbols_hash(lang)
+          return symbols[value&.to_s].new if symbols.key?(value&.to_s)
+
+          symbol_object(value&.to_s, lang: lang)
+        end
+      end
+    end
+  end
+end

--- a/lib/plurimath/html.rb
+++ b/lib/plurimath/html.rb
@@ -7,6 +7,7 @@ module Plurimath
     autoload :Parser, "#{__dir__}/html/parser"
     autoload :Transform, "#{__dir__}/html/transform"
     autoload :TransformUtility, "#{__dir__}/html/transform_utility"
+    autoload :Utility, "#{__dir__}/html/utility"
 
     attr_accessor :text
 

--- a/lib/plurimath/html/utility.rb
+++ b/lib/plurimath/html/utility.rb
@@ -2,7 +2,7 @@
 
 module Plurimath
   class Html
-    # Html-specific helper extracted from Plurimath::Utility (A1 code-quality
+    # Html-specific helper extracted from Plurimath::Utility (code-quality
     # refactor). Subclasses Utility so bareword `Utility.<generic>` calls inside
     # Html files keep resolving here and inherit the generic helpers.
     class Utility < Plurimath::Utility

--- a/lib/plurimath/html/utility.rb
+++ b/lib/plurimath/html/utility.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Plurimath
+  class Html
+    # Html-specific helper extracted from Plurimath::Utility (A1 code-quality
+    # refactor). Subclasses Utility so bareword `Utility.<generic>` calls inside
+    # Html files keep resolving here and inherit the generic helpers.
+    class Utility < Plurimath::Utility
+      class << self
+        def sub_sup_method?(sub_sup)
+          if sub_sup.methods.include?(:class_name)
+            Html::Constants::SUB_SUP_CLASSES.value?(sub_sup.class_name.to_sym)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/plurimath/latex.rb
+++ b/lib/plurimath/latex.rb
@@ -6,6 +6,7 @@ module Plurimath
     autoload :Parse, "#{__dir__}/latex/parse"
     autoload :Parser, "#{__dir__}/latex/parser"
     autoload :Transform, "#{__dir__}/latex/transform"
+    autoload :Utility, "#{__dir__}/latex/utility"
 
     attr_accessor :text
 

--- a/lib/plurimath/latex/utility.rb
+++ b/lib/plurimath/latex/utility.rb
@@ -2,7 +2,7 @@
 
 module Plurimath
   class Latex
-    # LaTeX-specific helpers extracted from Plurimath::Utility (A1 code-quality
+    # LaTeX-specific helpers extracted from Plurimath::Utility (code-quality
     # refactor). Subclasses Utility so bareword `Utility.<generic>` calls inside
     # LaTeX files keep resolving here and inherit the generic helpers.
     class Utility < Plurimath::Utility
@@ -55,14 +55,6 @@ module Plurimath
           options || {}
         end
 
-        # True when the row's first cell holds an Hline marker (a horizontal
-        # rule), reached through the tr -> first cell -> first content nesting.
-        def hline_row?(row)
-          first_cell = row&.parameter_one&.first
-          first_content = first_cell&.parameter_one&.first
-          first_content.is_a?(Math::Symbols::Hline)
-        end
-
         def organize_tds(tr_array, column_align, options)
           return tr_array if column_align.nil? || column_align.empty?
 
@@ -102,6 +94,16 @@ module Plurimath
                     Latex::Constants::LEFT_RIGHT_PARENTHESIS[paren.to_sym]
                   end
           get_class(function).new(paren)
+        end
+
+        private
+
+        # True when the row's first cell holds an Hline marker (a horizontal
+        # rule), reached through the tr -> first cell -> first content nesting.
+        def hline_row?(row)
+          first_cell = row&.parameter_one&.first
+          first_content = first_cell&.parameter_one&.first
+          first_content.is_a?(Math::Symbols::Hline)
         end
       end
     end

--- a/lib/plurimath/latex/utility.rb
+++ b/lib/plurimath/latex/utility.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+module Plurimath
+  class Latex
+    # LaTeX-specific helpers extracted from Plurimath::Utility (A1 code-quality
+    # refactor). Subclasses Utility so bareword `Utility.<generic>` calls inside
+    # LaTeX files keep resolving here and inherit the generic helpers.
+    class Utility < Plurimath::Utility
+      class << self
+        def organize_table(array, column_align: nil, options: nil)
+          table = []
+          table_data = []
+          table_row = []
+          organize_options(array, column_align) if options
+          string_columns = column_align&.map { |column| column.is_a?(Math::Symbols::Paren) ? "|" : column.value }
+          array.each do |data|
+            if data&.separate_table
+              table_row << Math::Function::Td.new(filter_table_data(table_data).compact)
+              table_data = []
+              if data.linebreak?
+                organize_tds(table_row.flatten, string_columns.dup, options)
+                table << Math::Function::Tr.new(table_row)
+                table_row = []
+              end
+              next
+            end
+            table_data << data
+          end
+          table_row << Math::Function::Td.new(table_data.compact) if table_data
+          unless table_row.nil? || table_row.empty?
+            organize_tds(table_row.flatten, string_columns.dup, options)
+            table << Math::Function::Tr.new(table_row)
+          end
+          unless column_align.nil? || column_align.empty?
+            table_separator(string_columns, table,
+                            symbol: "|")
+          end
+          table
+        end
+
+        def organize_options(table_data, column_align)
+          return column_align if column_align.length <= 1
+
+          align = [column_align&.shift]
+          table_data.insert(0, *column_align)
+          align
+        end
+
+        def table_options(table_data)
+          rowline = ""
+          table_data.each do |tr|
+            rowline += hline_row?(tr) ? "solid " : "none "
+          end
+          options = { rowline: rowline.strip } if rowline.include?("solid")
+          options || {}
+        end
+
+        # True when the row's first cell holds an Hline marker (a horizontal
+        # rule), reached through the tr -> first cell -> first content nesting.
+        def hline_row?(row)
+          first_cell = row&.parameter_one&.first
+          first_content = first_cell&.parameter_one&.first
+          first_content.is_a?(Math::Symbols::Hline)
+        end
+
+        def organize_tds(tr_array, column_align, options)
+          return tr_array if column_align.nil? || column_align.empty?
+
+          column_align.reject! { |string| string == "|" }
+          column_align = column_align * tr_array.length if options
+          tr_array.map.with_index do |td, ind|
+            columnalign = Plurimath::Utility::ALIGNMENT_LETTERS[column_align[ind]&.to_sym]
+            td.parameter_two = { columnalign: columnalign } if columnalign
+          end
+        end
+
+        def filter_table_data(table_data)
+          table_data.each_with_index do |object, ind|
+            if object.is_a?(Math::Symbols::Minus)
+              table_data[ind] = Math::Formula.new(
+                [object, table_data.delete_at(ind.next)],
+              )
+            end
+          end
+          table_data
+        end
+
+        def table_td(object)
+          new_object = case object
+                       when Math::Function::Td
+                         object
+                       else
+                         Math::Function::Td.new([object])
+                       end
+          Array(new_object)
+        end
+
+        def left_right_objects(paren, function)
+          paren = if paren.to_s.match?(/\\\{|\\\}/)
+                    paren.to_s.gsub("\\", "")
+                  else
+                    Latex::Constants::LEFT_RIGHT_PARENTHESIS[paren.to_sym]
+                  end
+          get_class(function).new(paren)
+        end
+      end
+    end
+  end
+end

--- a/lib/plurimath/omml.rb
+++ b/lib/plurimath/omml.rb
@@ -22,6 +22,7 @@ module Plurimath
     autoload :FormulaTransformation, "#{__dir__}/omml/formula_transformation"
     autoload :Parser, "#{__dir__}/omml/parser"
     autoload :Translator, "#{__dir__}/omml/translator"
+    autoload :Utility, "#{__dir__}/omml/utility"
     autoload :UnsupportedNodeError,
              "#{__dir__}/errors/omml/unsupported_node_error"
 

--- a/lib/plurimath/omml/utility.rb
+++ b/lib/plurimath/omml/utility.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Plurimath
+  class Omml
+    # Omml-specific helper extracted from Plurimath::Utility (A1 code-quality
+    # refactor). Subclasses Utility so bareword `Utility.<generic>` calls inside
+    # Omml files keep resolving here and inherit the generic helpers.
+    class Utility < Plurimath::Utility
+      class << self
+        def valid_class(object)
+          text = object.extract_class_name_from_text
+          (object.extractable? && Asciimath::Constants::SUB_SUP_CLASSES.include?(text)) ||
+            Latex::Constants::SYMBOLS[text.to_sym] == :power_base
+        end
+      end
+    end
+  end
+end

--- a/lib/plurimath/omml/utility.rb
+++ b/lib/plurimath/omml/utility.rb
@@ -2,7 +2,7 @@
 
 module Plurimath
   class Omml
-    # Omml-specific helper extracted from Plurimath::Utility (A1 code-quality
+    # Omml-specific helper extracted from Plurimath::Utility (code-quality
     # refactor). Subclasses Utility so bareword `Utility.<generic>` calls inside
     # Omml files keep resolving here and inherit the generic helpers.
     class Utility < Plurimath::Utility

--- a/lib/plurimath/unicode_math.rb
+++ b/lib/plurimath/unicode_math.rb
@@ -7,6 +7,7 @@ module Plurimath
     autoload :Parser, "#{__dir__}/unicode_math/parser"
     autoload :ParsingRules, "#{__dir__}/unicode_math/parsing_rules"
     autoload :Transform, "#{__dir__}/unicode_math/transform"
+    autoload :Utility, "#{__dir__}/unicode_math/utility"
 
     attr_accessor :text
 

--- a/lib/plurimath/unicode_math/utility.rb
+++ b/lib/plurimath/unicode_math/utility.rb
@@ -2,7 +2,7 @@
 
 module Plurimath
   class UnicodeMath
-    # UnicodeMath-specific helpers extracted from Plurimath::Utility (A1 code-quality
+    # UnicodeMath-specific helpers extracted from Plurimath::Utility (code-quality
     # refactor). Subclasses Utility so that bareword `Utility.<generic>` calls inside
     # UnicodeMath files keep resolving here and inherit the generic helpers.
     class Utility < Plurimath::Utility

--- a/lib/plurimath/unicode_math/utility.rb
+++ b/lib/plurimath/unicode_math/utility.rb
@@ -1,0 +1,256 @@
+# frozen_string_literal: true
+
+module Plurimath
+  class UnicodeMath
+    # UnicodeMath-specific helpers extracted from Plurimath::Utility (A1 code-quality
+    # refactor). Subclasses Utility so that bareword `Utility.<generic>` calls inside
+    # UnicodeMath files keep resolving here and inherit the generic helpers.
+    class Utility < Plurimath::Utility
+      class << self
+        def unicode_accents(accents, lang: :unicodemath)
+          if accents.is_a?(Math::Function::BinaryFunction)
+            accents
+          elsif accents.any? { |acc| acc&.dig(:first_value)&.is_a?(Array) }
+            accent_value = accents.first[:first_value].pop
+            first_value = accents.first[:first_value]
+            accents.first[:first_value] = accent_value
+            Math::Formula.new(
+              first_value + [transform_accents(accents, lang: lang)],
+            )
+          else
+            transform_accents(accents, lang: lang)
+          end
+        end
+
+        def transform_accents(accents, lang:)
+          accents.reduce do |function, accent|
+            if function.is_a?(Hash)
+              if function[:prime_accent_symbols]
+                Math::Function::Power.new(
+                  unfenced_value(
+                    accent_value(function, lang: lang), paren_specific: true
+                  ),
+                  accent_value(accent, lang: lang),
+                )
+              else
+                Math::Function::Overset.new(
+                  accent_value(accent, lang: lang),
+                  unfenced_value(
+                    accent_value(function, lang: lang), paren_specific: true
+                  ),
+                  { accent: true },
+                )
+              end
+            elsif accent[:prime_accent_symbols]
+              Math::Function::Power.new(
+                unfenced_value(function, paren_specific: true),
+                accent_value(accent, lang: lang),
+              )
+            else
+              Math::Function::Overset.new(
+                accent_value(accent, lang: lang),
+                unfenced_value(function, paren_specific: true),
+                { accent: true },
+              )
+            end
+          end
+        end
+
+        def accent_value(accent, lang:)
+          if accent[:accent_symbols]
+            symbols_class(
+              UnicodeMath::Constants::ACCENT_SYMBOLS[accent[:accent_symbols].to_sym] || accent[:accent_symbols], lang: lang
+            )
+          else
+            accent[:first_value] || filter_values(accent[:prime_accent_symbols])
+          end
+        end
+
+        def unicode_fractions(fractions)
+          frac_arr = UnicodeMath::Constants::UNICODE_FRACTIONS[fractions.to_sym]
+          Math::Function::Frac.new(
+            Math::Number.new(frac_arr.first.to_s),
+            Math::Number.new(frac_arr.last.to_s),
+            { displaystyle: false, unicodemath_fraction: true },
+          )
+        end
+
+        def updated_primes(prime)
+          filter_values(
+            prime.to_s.scan(Plurimath::Utility::UNICODE_REGEX).map do |str|
+              symbols_class(str, lang: :unicodemath)
+            end,
+          )
+        end
+
+        def fractions(numerator, denominator, options = nil)
+          frac_class = Math::Function::Frac
+          if denominator.is_a?(frac_class)
+            if denominator.parameter_one.is_a?(frac_class)
+              recursion_fraction(denominator, numerator, options)
+            else
+              denominator.parameter_one = frac_class.new(
+                unfenced_value(numerator, paren_specific: true),
+                unfenced_value(denominator.parameter_one, paren_specific: true),
+                options,
+              )
+            end
+            denominator
+          else
+            frac_class.new(
+              unfenced_value(numerator, paren_specific: true),
+              unfenced_value(denominator, paren_specific: true),
+              options,
+            )
+          end
+        end
+
+        def recursion_fraction(frac, numerator, options)
+          frac_class = Math::Function::Frac
+          new_numerator = frac.parameter_one
+          if new_numerator.is_a?(frac_class)
+            recursion_fraction(new_numerator, numerator, options)
+          else
+            frac.parameter_one = frac_class.new(
+              unfenced_value(numerator, paren_specific: true),
+              unfenced_value(frac.parameter_one, paren_specific: true),
+              options,
+            )
+            frac
+          end
+        end
+
+        def recursive_sub(sub_script, sub_recursion)
+          base_class = Math::Function::Base
+          if sub_recursion.is_a?(base_class)
+            if sub_recursion.parameter_one.is_a?(base_class)
+              base_recursion(sub_script, sub_recursion)
+            else
+              sub_recursion.parameter_one = base_class.new(sub_script,
+                                                           sub_recursion.parameter_one)
+            end
+            sub_recursion
+          else
+            base_class.new(
+              sub_script,
+              sub_recursion,
+            )
+          end
+        end
+
+        def base_recursion(sub_script, sub_recursion)
+          base_class = Math::Function::Base
+          new_sub = sub_recursion.parameter_one
+          if new_sub.is_a?(base_class)
+            base_recursion(sub_script, new_sub)
+          else
+            sub_recursion.parameter_one = base_class.new(sub_script, new_sub)
+          end
+          sub_recursion
+        end
+
+        def recursive_sup(sup_script, sup_recursion)
+          power_class = Math::Function::Power
+          if sup_recursion.is_a?(power_class)
+            if sup_recursion.parameter_one.is_a?(power_class)
+              sup_recursion(sup_script, sup_recursion)
+            else
+              sup_recursion.parameter_one = power_class.new(sup_script,
+                                                            sup_recursion.parameter_one)
+            end
+            sup_recursion
+          else
+            power_class.new(
+              sup_script,
+              sup_recursion,
+            )
+          end
+        end
+
+        def sup_recursion(sup_script, sup_recursion)
+          power_class = Math::Function::Power
+          new_sup = sup_recursion.parameter_one
+          if new_sup.is_a?(power_class)
+            sup_recursion(sup_script, new_sup)
+          else
+            sup_recursion.parameter_one = power_class.new(sup_script, new_sup)
+          end
+          sup_recursion
+        end
+
+        def base_is_prime?(base)
+          symbol_prime?(base.parameter_two) ||
+            primes_constants.key(base.parameter_two.value)
+        end
+
+        def symbol_prime?(obj)
+          obj&.class&.const_defined?(:INPUT) &&
+            primes_constants&.key(hexcode_in_input(obj))
+        end
+
+        def base_is_sub_or_sup?(base)
+          case base
+          when Math::Formula
+            base_is_sub_or_sup?(base.value.first)
+          when Math::Function::Fenced
+            base_is_sub_or_sup?(base.parameter_two.first)
+          when Math::Symbols::Symbol, Math::Number
+            base.mini_sub_sized || base_mini_sup_sized
+          end
+        end
+
+        def identity_matrix(size)
+          matrix = Array.new(size) { Array.new(size, 0) }
+          size.times { |i| matrix[i][i] = 1 }
+          matrix.map do |tr|
+            tr.map.with_index do |td, i|
+              tr[i] = Math::Function::Td.new([Math::Number.new(td.to_s)])
+            end
+            Math::Function::Tr.new(tr)
+          end
+        end
+
+        def enclosure_attrs(mask)
+          raise "enclosure mask is not between 0 and 255" if mask.nil? || mask.negative? || mask > 255
+
+          ret = ""
+          unless mask.nil?
+            mask ^= 15
+            bin_mask = mask.to_s(2).reverse
+            classes = bin_mask.chars.each_with_index.filter_map do |bit, i|
+              Plurimath::Utility::MASK_CLASSES[2**i] if bit == "1"
+            end
+            ret = classes.join(" ")
+          end
+          ret
+        end
+
+        def slashed_values(value)
+          decoded = HTMLEntities.new.decode(value)
+          if decoded.to_s.match?(/^\w+/)
+            Math::Function::Text.new("\\#{decoded}")
+          else
+            Math::Symbols::Symbol.new(decoded, true)
+          end
+        end
+
+        def sequence_slashed_values(values, lang:)
+          values.each.with_index do |value, index|
+            decoded = HTMLEntities.new.decode(value.value)
+            slashed = if index.zero?
+                        slashed_values(value.value)
+                      elsif decoded.match?(/[0-9]/)
+                        Math::Number.new(decoded)
+                      else
+                        symbols_class(
+                          decoded, lang: lang
+                        )
+                      end
+            values[index] = slashed
+          end
+          values
+        end
+      end
+    end
+  end
+end

--- a/lib/plurimath/utility.rb
+++ b/lib/plurimath/utility.rb
@@ -161,88 +161,8 @@ module Plurimath
     }.freeze
 
     class << self
-      def organize_table(array, column_align: nil, options: nil)
-        table = []
-        table_data = []
-        table_row = []
-        organize_options(array, column_align) if options
-        string_columns = column_align&.map { |column| column.is_a?(Math::Symbols::Paren) ? "|" : column.value }
-        array.each do |data|
-          if data&.separate_table
-            table_row << Math::Function::Td.new(filter_table_data(table_data).compact)
-            table_data = []
-            if data.linebreak?
-              organize_tds(table_row.flatten, string_columns.dup, options)
-              table << Math::Function::Tr.new(table_row)
-              table_row = []
-            end
-            next
-          end
-          table_data << data
-        end
-        table_row << Math::Function::Td.new(table_data.compact) if table_data
-        unless table_row.nil? || table_row.empty?
-          organize_tds(table_row.flatten, string_columns.dup, options)
-          table << Math::Function::Tr.new(table_row)
-        end
-        unless column_align.nil? || column_align.empty?
-          table_separator(string_columns, table,
-                          symbol: "|")
-        end
-        table
-      end
-
-      def organize_options(table_data, column_align)
-        return column_align if column_align.length <= 1
-
-        align = [column_align&.shift]
-        table_data.insert(0, *column_align)
-        align
-      end
-
-      def table_options(table_data)
-        rowline = ""
-        table_data.map do |tr|
-          if tr&.parameter_one&.first&.parameter_one&.first.is_a?(Math::Symbols::Hline)
-            rowline += "solid "
-          else
-            rowline += "none "
-          end
-        end
-        options = { rowline: rowline.strip } if rowline.include?("solid")
-        options || {}
-      end
-
-      def organize_tds(tr_array, column_align, options)
-        return tr_array if column_align.nil? || column_align.empty?
-
-        column_align.reject! { |string| string == "|" }
-        column_align = column_align * tr_array.length if options
-        tr_array.map.with_index do |td, ind|
-          columnalign = ALIGNMENT_LETTERS[column_align[ind]&.to_sym]
-          td.parameter_two = { columnalign: columnalign } if columnalign
-        end
-      end
-
-      def filter_table_data(table_data)
-        table_data.each_with_index do |object, ind|
-          if object.is_a?(Math::Symbols::Minus)
-            table_data[ind] = Math::Formula.new(
-              [object, table_data.delete_at(ind.next)],
-            )
-          end
-        end
-        table_data
-      end
-
       def get_table_class(text)
         Object.const_get("Plurimath::Math::Function::Table::#{capitalize(text)}")
-      end
-
-      def sub_sup_method?(sub_sup)
-        if sub_sup.methods.include?(:class_name)
-          Html::Constants::SUB_SUP_CLASSES.value?(sub_sup.class_name.to_sym)
-        end
       end
 
       def get_class(text)
@@ -394,32 +314,12 @@ module Plurimath
         fonts_array.find { |d| d.is_a?(Hash) && d[key] }
       end
 
-      def td_values(objects, slicer)
-        sliced = objects.slice_when { |object, _| symbol_value(object, slicer) }
-        tds = sliced.map do |slice|
-          Math::Function::Td.new(
-            slice.delete_if { |d| symbol_value(d, slicer) }.compact,
-          )
-        end
-        tds << Math::Function::Td.new([]) if symbol_value(objects.last, slicer)
-        tds
-      end
-
       def symbol_value(object, value)
         (object.is_a?(Math::Symbols::Comma) if value&.include?(",")) ||
           (object.is_a?(Math::Symbols::Minus) if value&.include?("-")) ||
           (object.is_a?(Math::Symbols::Paren::Vert) if value&.include?("|")) ||
           (object.is_a?(Math::Symbols::Symbol) && object&.value&.include?(value)) ||
           (value == "\\\\" && object.is_a?(Math::Function::Linebreak))
-      end
-
-      def td_value(td_object)
-        str_classes = [String, Parslet::Slice]
-        if str_classes.include?(td_object.class) && td_object.to_s.empty?
-          return Math::Function::Text.new(nil)
-        end
-
-        td_object
       end
 
       def mathml_unary_classes(text_array, omml: false, unicode_only: false,
@@ -615,25 +515,6 @@ lang: nil)
           object.options.empty?
       end
 
-      def frac_values(object)
-        case object
-        when Math::Formula
-          object.value.any? { |d| symbol_value(d, ",") }
-        when Array
-          object.any? { |d| symbol_value(d, ",") }
-        end
-      end
-
-      def table_td(object)
-        new_object = case object
-                     when Math::Function::Td
-                       object
-                     else
-                       Math::Function::Td.new([object])
-                     end
-        Array(new_object)
-      end
-
       def symbol_object(value, lang: nil)
         value = case value
                 when "ℒ" then "{:"
@@ -645,36 +526,12 @@ lang: nil)
         symbols_class(value, lang: lang)
       end
 
-      def asciimath_symbol_object(value, lang: :asciimath)
-        return if value.nil?
-
-        symbols = symbols_hash(lang)
-        return symbols[value&.to_s].new if symbols.key?(value&.to_s)
-
-        symbol_object(value&.to_s, lang: lang)
-      end
-
       def validate_left_right(fields = [])
         fields.each do |field|
           if field.is_a?(Math::Formula) && field.value.first.is_a?(Math::Function::Left)
             field.left_right_wrapper = true
           end
         end
-      end
-
-      def left_right_objects(paren, function)
-        paren = if paren.to_s.match?(/\\\{|\\\}/)
-                  paren.to_s.gsub("\\", "")
-                else
-                  Latex::Constants::LEFT_RIGHT_PARENTHESIS[paren.to_sym]
-                end
-        get_class(function).new(paren)
-      end
-
-      def valid_class(object)
-        text = object.extract_class_name_from_text
-        (object.extractable? && Asciimath::Constants::SUB_SUP_CLASSES.include?(text)) ||
-          Latex::Constants::SYMBOLS[text.to_sym] == :power_base
       end
 
       def mrow_left_right(mrow = [])
@@ -840,189 +697,6 @@ lang: nil)
         end
       end
 
-      def unicode_accents(accents, lang: :unicodemath)
-        if accents.is_a?(Math::Function::BinaryFunction)
-          accents
-        elsif accents.any? { |acc| acc&.dig(:first_value)&.is_a?(Array) }
-          accent_value = accents.first[:first_value].pop
-          first_value = accents.first[:first_value]
-          accents.first[:first_value] = accent_value
-          Math::Formula.new(
-            first_value + [transform_accents(accents, lang: lang)],
-          )
-        else
-          transform_accents(accents, lang: lang)
-        end
-      end
-
-      def transform_accents(accents, lang:)
-        accents.reduce do |function, accent|
-          if function.is_a?(Hash)
-            if function[:prime_accent_symbols]
-              Math::Function::Power.new(
-                unfenced_value(
-                  accent_value(function, function: true,
-                                         lang: lang), paren_specific: true
-                ),
-                accent_value(accent, lang: lang),
-              )
-            else
-              Math::Function::Overset.new(
-                accent_value(accent, lang: lang),
-                unfenced_value(
-                  accent_value(function, function: true,
-                                         lang: lang), paren_specific: true
-                ),
-                { accent: true },
-              )
-            end
-          elsif accent[:prime_accent_symbols]
-            Math::Function::Power.new(
-              unfenced_value(function, paren_specific: true),
-              accent_value(accent, lang: lang),
-            )
-          else
-            Math::Function::Overset.new(
-              accent_value(accent, lang: lang),
-              unfenced_value(function, paren_specific: true),
-              { accent: true },
-            )
-          end
-        end
-      end
-
-      def accent_value(accent, lang:, function: false)
-        if accent[:accent_symbols]
-          symbols_class(
-            UnicodeMath::Constants::ACCENT_SYMBOLS[accent[:accent_symbols].to_sym] || accent[:accent_symbols], lang: lang
-          )
-        else
-          accent[:first_value] || filter_values(accent[:prime_accent_symbols])
-        end
-      end
-
-      def unicode_fractions(fractions)
-        frac_arr = UnicodeMath::Constants::UNICODE_FRACTIONS[fractions.to_sym]
-        Math::Function::Frac.new(
-          Math::Number.new(frac_arr.first.to_s),
-          Math::Number.new(frac_arr.last.to_s),
-          { displaystyle: false, unicodemath_fraction: true },
-        )
-      end
-
-      def updated_primes(prime)
-        filter_values(
-          prime.to_s.scan(UNICODE_REGEX).map do |str|
-            symbols_class(str, lang: :unicodemath)
-          end,
-        )
-      end
-
-      def fractions(numerator, denominator, options = nil)
-        frac_class = Math::Function::Frac
-        if denominator.is_a?(frac_class)
-          if denominator.parameter_one.is_a?(frac_class)
-            recursion_fraction(denominator, numerator, options)
-          else
-            denominator.parameter_one = frac_class.new(
-              unfenced_value(numerator, paren_specific: true),
-              unfenced_value(denominator.parameter_one, paren_specific: true),
-              options,
-            )
-          end
-          denominator
-        else
-          frac_class.new(
-            unfenced_value(numerator, paren_specific: true),
-            unfenced_value(denominator, paren_specific: true),
-            options,
-          )
-        end
-      end
-
-      def recursion_fraction(frac, numerator, options)
-        frac_class = Math::Function::Frac
-        new_numerator = frac.parameter_one
-        if new_numerator.is_a?(frac_class)
-          recursion_fraction(new_numerator, numerator, options)
-        else
-          frac.parameter_one = frac_class.new(
-            unfenced_value(numerator, paren_specific: true),
-            unfenced_value(frac.parameter_one, paren_specific: true),
-            options,
-          )
-          frac
-        end
-      end
-
-      def recursive_sub(sub_script, sub_recursion)
-        base_class = Math::Function::Base
-        if sub_recursion.is_a?(base_class)
-          if sub_recursion.parameter_one.is_a?(base_class)
-            base_recursion(sub_script, sub_recursion)
-          else
-            sub_recursion.parameter_one = base_class.new(sub_script,
-                                                         sub_recursion.parameter_one)
-          end
-          sub_recursion
-        else
-          base_class.new(
-            sub_script,
-            sub_recursion,
-          )
-        end
-      end
-
-      def base_recursion(sub_script, sub_recursion)
-        base_class = Math::Function::Base
-        new_sub = sub_recursion.parameter_one
-        if new_sub.is_a?(base_class)
-          base_recursion(sub_script, new_sub)
-        else
-          sub_recursion.parameter_one = base_class.new(sub_script, new_sub)
-        end
-        sub_recursion
-      end
-
-      def recursive_sup(sup_script, sup_recursion)
-        power_class = Math::Function::Power
-        if sup_recursion.is_a?(power_class)
-          if sup_recursion.parameter_one.is_a?(power_class)
-            sup_recursion(sup_script, sup_recursion)
-          else
-            sup_recursion.parameter_one = power_class.new(sup_script,
-                                                          sup_recursion.parameter_one)
-          end
-          sup_recursion
-        else
-          power_class.new(
-            sup_script,
-            sup_recursion,
-          )
-        end
-      end
-
-      def sup_recursion(sup_script, sup_recursion)
-        power_class = Math::Function::Power
-        new_sup = sup_recursion.parameter_one
-        if new_sup.is_a?(power_class)
-          sup_recursion(sup_script, new_sup)
-        else
-          sup_recursion.parameter_one = power_class.new(sup_script, new_sup)
-        end
-        sup_recursion
-      end
-
-      def base_is_prime?(base)
-        symbol_prime?(base.parameter_two) ||
-          primes_constants.key(base.parameter_two.value)
-      end
-
-      def symbol_prime?(obj)
-        obj&.class&.const_defined?(:INPUT) &&
-          primes_constants&.key(hexcode_in_input(obj))
-      end
-
       def primes_constants
         primes = {}
         primes
@@ -1036,74 +710,11 @@ lang: nil)
         end
       end
 
-      def base_is_sub_or_sup?(base)
-        case base
-        when Math::Formula
-          base_is_sub_or_sup?(base.value.first)
-        when Math::Function::Fenced
-          base_is_sub_or_sup?(base.parameter_two.first)
-        when Math::Symbols::Symbol, Math::Number
-          base.mini_sub_sized || base_mini_sup_sized
-        end
-      end
-
-      def identity_matrix(size)
-        matrix = Array.new(size) { Array.new(size, 0) }
-        size.times { |i| matrix[i][i] = 1 }
-        matrix.map do |tr|
-          tr.map.with_index do |td, i|
-            tr[i] = Math::Function::Td.new([Math::Number.new(td.to_s)])
-          end
-          Math::Function::Tr.new(tr)
-        end
-      end
-
-      def enclosure_attrs(mask)
-        raise "enclosure mask is not between 0 and 255" if mask.nil? || mask.negative? || mask > 255
-
-        ret = ""
-        unless mask.nil?
-          mask ^= 15
-          bin_mask = mask.to_s(2).reverse
-          classes = bin_mask.chars.each_with_index.filter_map do |bit, i|
-            MASK_CLASSES[2**i] if bit == "1"
-          end
-          ret = classes.join(" ")
-        end
-        ret
-      end
-
       def notations_to_mask(notations)
         mask = notations.split.map do |notation|
           MASK_CLASSES.key(notation)
         end
         mask.inject(*:+) ^ 15
-      end
-
-      def slashed_values(value)
-        decoded = HTMLEntities.new.decode(value)
-        if decoded.to_s.match?(/^\w+/)
-          Math::Function::Text.new("\\#{decoded}")
-        else
-          Math::Symbols::Symbol.new(decoded, true)
-        end
-      end
-
-      def sequence_slashed_values(values, lang:)
-        values.each.with_index do |value, index|
-          decoded = HTMLEntities.new.decode(value.value)
-          slashed = if index.zero?
-                      slashed_values(value.value)
-                    elsif decoded.match?(/[0-9]/)
-                      Math::Number.new(decoded)
-                    else
-                      symbols_class(
-                        decoded, lang: lang
-                      )
-                    end
-          values[index] = slashed
-        end
-        values
       end
 
       def math_display_text_objects(object)

--- a/spec/plurimath/asciimath/utility_spec.rb
+++ b/spec/plurimath/asciimath/utility_spec.rb
@@ -1,0 +1,185 @@
+require "spec_helper"
+
+# Characterization specs (phase A0 of the language-utility split).
+#
+# These examples pin the CURRENT behavior of the AsciiMath-side table/symbol
+# helpers before they move to language-specific utility modules.
+# Expectations were derived by running the code, not from intent — oddities
+# are pinned as-is and flagged with `# quirk:` comments rather than "fixed".
+RSpec.describe Plurimath::Asciimath::Utility do
+  def number(value)
+    Plurimath::Math::Number.new(value)
+  end
+
+  def td(values, options = nil)
+    Plurimath::Math::Function::Td.new(values, options)
+  end
+
+  def slice(string)
+    Parslet::Slice.new(Parslet::Position.new(string, 0), string)
+  end
+
+  describe ".td_values" do
+    it "slices objects into Tds on Comma with a ',' slicer" do
+      result = described_class.td_values(
+        [number("1"), Plurimath::Math::Symbols::Comma.new, number("2")],
+        ",",
+      )
+
+      expect(result).to eq([td([number("1")]), td([number("2")])])
+    end
+
+    it "slices on a generic Symbol whose value contains the slicer" do
+      result = described_class.td_values(
+        [number("1"), Plurimath::Math::Symbols::Symbol.new(","), number("2")],
+        ",",
+      )
+
+      expect(result).to eq([td([number("1")]), td([number("2")])])
+    end
+
+    # quirk: a trailing separator appends an extra empty Td.
+    it "appends an empty Td when the last object is a separator" do
+      result = described_class.td_values(
+        [number("1"), Plurimath::Math::Symbols::Comma.new],
+        ",",
+      )
+
+      expect(result).to eq([td([number("1")]), td([])])
+    end
+
+    it "returns a single Td when no separator is present" do
+      result = described_class.td_values([number("1"), number("2")], ",")
+
+      expect(result).to eq([td([number("1"), number("2")])])
+    end
+
+    it "returns an empty array for empty input" do
+      expect(described_class.td_values([], ",")).to eq([])
+    end
+  end
+
+  describe ".td_value" do
+    it "converts an empty String to Text.new(nil)" do
+      expect(described_class.td_value("")).to eq(
+        Plurimath::Math::Function::Text.new(nil),
+      )
+    end
+
+    it "converts an empty Parslet::Slice to Text.new(nil)" do
+      expect(described_class.td_value(slice(""))).to eq(
+        Plurimath::Math::Function::Text.new(nil),
+      )
+    end
+
+    it "returns a non-empty String unchanged" do
+      input = "abc"
+
+      expect(described_class.td_value(input)).to be(input)
+    end
+
+    it "returns a non-empty Parslet::Slice unchanged" do
+      input = slice("x")
+      result = described_class.td_value(input)
+
+      expect(result).to be(input)
+      expect(result).to be_a(Parslet::Slice)
+    end
+
+    it "returns non-string objects unchanged" do
+      input = Plurimath::Math::Formula.new([number("1")])
+
+      expect(described_class.td_value(input)).to be(input)
+    end
+  end
+
+  describe ".frac_values" do
+    it "returns true for a Formula containing a Comma" do
+      formula = Plurimath::Math::Formula.new(
+        [number("1"), Plurimath::Math::Symbols::Comma.new, number("2")],
+      )
+
+      expect(described_class.frac_values(formula)).to be(true)
+    end
+
+    it "returns false for a Formula without a Comma" do
+      formula = Plurimath::Math::Formula.new([number("1")])
+
+      expect(described_class.frac_values(formula)).to be(false)
+    end
+
+    it "returns false for an empty Formula" do
+      expect(described_class.frac_values(Plurimath::Math::Formula.new([]))).to be(false)
+    end
+
+    it "returns true for an Array containing a Comma" do
+      array = [number("1"), Plurimath::Math::Symbols::Comma.new]
+
+      expect(described_class.frac_values(array)).to be(true)
+    end
+
+    it "returns false for an Array without a Comma" do
+      expect(described_class.frac_values([number("1")])).to be(false)
+    end
+
+    # quirk: the case statement has no else branch, so anything that is not
+    # a Formula or an Array (including nil) yields nil rather than false.
+    it "returns nil for non-Formula, non-Array input" do
+      expect(described_class.frac_values(number("1"))).to be_nil
+      expect(described_class.frac_values(nil)).to be_nil
+    end
+  end
+
+  describe ".asciimath_symbol_object" do
+    it "returns nil for nil input" do
+      expect(described_class.asciimath_symbol_object(nil)).to be_nil
+    end
+
+    it "resolves a known symbol name to its symbol class" do
+      expect(described_class.asciimath_symbol_object("alpha")).to eq(
+        Plurimath::Math::Symbols::Alpha.new,
+      )
+      expect(described_class.asciimath_symbol_object("+")).to eq(
+        Plurimath::Math::Symbols::Plus.new,
+      )
+      expect(described_class.asciimath_symbol_object(",")).to eq(
+        Plurimath::Math::Symbols::Comma.new,
+      )
+    end
+
+    it "accepts Parslet::Slice input" do
+      expect(described_class.asciimath_symbol_object(slice("alpha"))).to eq(
+        Plurimath::Math::Symbols::Alpha.new,
+      )
+    end
+
+    it "falls back to paren classes for paren tokens" do
+      expect(described_class.asciimath_symbol_object("(")).to eq(
+        Plurimath::Math::Symbols::Paren::Lround.new,
+      )
+    end
+
+    # quirk: the special glyphs ℒ and ℛ are remapped (via symbol_object) to
+    # the "{:" / ":}" open/close paren classes.
+    it "remaps ℒ and ℛ to OpenParen and CloseParen" do
+      expect(described_class.asciimath_symbol_object("ℒ")).to eq(
+        Plurimath::Math::Symbols::Paren::OpenParen.new,
+      )
+      expect(described_class.asciimath_symbol_object("ℛ")).to eq(
+        Plurimath::Math::Symbols::Paren::CloseParen.new,
+      )
+    end
+
+    # quirk: function words like "sum" are not in the asciimath symbols
+    # table, so they come back as a generic Symbol with the literal value
+    # rather than the Sum function class.
+    it "wraps unknown tokens in a generic Symbol carrying the value" do
+      expect(described_class.asciimath_symbol_object("sum")).to eq(
+        Plurimath::Math::Symbols::Symbol.new("sum"),
+      )
+      expect(described_class.asciimath_symbol_object("zzznotasymbol")).to eq(
+        Plurimath::Math::Symbols::Symbol.new("zzznotasymbol"),
+      )
+    end
+  end
+end

--- a/spec/plurimath/html/utility_spec.rb
+++ b/spec/plurimath/html/utility_spec.rb
@@ -1,0 +1,34 @@
+require "spec_helper"
+
+# Characterization specs (phase A0 of the language-utility split).
+#
+# These examples pin the CURRENT behavior of the HTML-side sub/sup helper
+# before it moves to a language-specific utility module. Expectations were
+# derived by running the code, not from intent — oddities are pinned as-is
+# and flagged with `# quirk:` comments rather than "fixed".
+RSpec.describe Plurimath::Html::Utility do
+  def number(value)
+    Plurimath::Math::Number.new(value)
+  end
+
+  describe ".sub_sup_method?" do
+    it "returns true for functions registered in Html SUB_SUP_CLASSES" do
+      expect(described_class.sub_sup_method?(Plurimath::Math::Function::Log.new)).to be(true)
+      expect(described_class.sub_sup_method?(Plurimath::Math::Function::Lim.new)).to be(true)
+      expect(described_class.sub_sup_method?(Plurimath::Math::Function::Sum.new)).to be(true)
+      expect(described_class.sub_sup_method?(Plurimath::Math::Function::Prod.new)).to be(true)
+    end
+
+    it "returns false for math objects outside SUB_SUP_CLASSES" do
+      expect(described_class.sub_sup_method?(Plurimath::Math::Function::Sin.new)).to be(false)
+      expect(described_class.sub_sup_method?(Plurimath::Math::Symbols::Symbol.new("x"))).to be(false)
+      expect(described_class.sub_sup_method?(number("1"))).to be(false)
+    end
+
+    # quirk: objects without a #class_name method skip the check entirely,
+    # so the method returns nil instead of false.
+    it "returns nil for objects that do not respond to class_name" do
+      expect(described_class.sub_sup_method?("plain string")).to be_nil
+    end
+  end
+end

--- a/spec/plurimath/latex/utility_spec.rb
+++ b/spec/plurimath/latex/utility_spec.rb
@@ -1,0 +1,326 @@
+require "spec_helper"
+
+# Characterization specs (phase A0 of the language-utility split).
+#
+# These examples pin the CURRENT behavior of the LaTeX-side table/symbol
+# helpers before they move to language-specific utility modules.
+# Expectations were derived by running the code, not from intent — oddities
+# are pinned as-is and flagged with `# quirk:` comments rather than "fixed".
+RSpec.describe Plurimath::Latex::Utility do
+  def number(value)
+    Plurimath::Math::Number.new(value)
+  end
+
+  def td(values, options = nil)
+    Plurimath::Math::Function::Td.new(values, options)
+  end
+
+  def tr(tds)
+    Plurimath::Math::Function::Tr.new(tds)
+  end
+
+  def slice(string)
+    Parslet::Slice.new(Parslet::Position.new(string, 0), string)
+  end
+
+  def ampersand
+    Plurimath::Math::Symbols::Ampersand.new
+  end
+
+  def linebreak
+    Plurimath::Math::Function::Linebreak.new
+  end
+
+  describe ".organize_table" do
+    it "wraps a separator-free array into a single Tr containing a single Td" do
+      result = described_class.organize_table([number("1"), number("2")])
+
+      expect(result).to eq([tr([td([number("1"), number("2")])])])
+    end
+
+    it "splits cells on Ampersand and rows on Linebreak" do
+      result = described_class.organize_table(
+        [
+          number("1"), ampersand, number("2"), linebreak,
+          number("3"), ampersand, number("4")
+        ],
+      )
+
+      expect(result).to eq(
+        [
+          tr([td([number("1")]), td([number("2")])]),
+          tr([td([number("3")]), td([number("4")])]),
+        ],
+      )
+    end
+
+    it "splits cells on a generic Symbol whose value is '&'" do
+      result = described_class.organize_table(
+        [number("1"), Plurimath::Math::Symbols::Symbol.new("&"), number("2")],
+      )
+
+      expect(result).to eq([tr([td([number("1")]), td([number("2")])])])
+    end
+
+    # quirk: a trailing linebreak produces an extra trailing row holding one
+    # empty Td, because the post-loop flush appends Td([]) even when no data
+    # followed the linebreak.
+    it "appends an extra empty row after a trailing Linebreak" do
+      result = described_class.organize_table([number("1"), linebreak])
+
+      expect(result).to eq(
+        [
+          tr([td([number("1")])]),
+          tr([td([])]),
+        ],
+      )
+    end
+
+    # quirk: an empty input array still yields one row with one empty Td
+    # (the post-loop flush runs on the empty accumulator).
+    it "returns one row with one empty Td for an empty array" do
+      expect(described_class.organize_table([])).to eq([tr([td([])])])
+    end
+
+    # quirk: Minus merging (filter_table_data) only runs on cells flushed by
+    # a separator; a Minus followed by a value inside such a cell is folded
+    # into a nested Formula([minus, next_object]).
+    it "merges Minus with its next sibling into a Formula in separator-flushed cells" do
+      minus = Plurimath::Math::Symbols::Minus.new
+      result = described_class.organize_table(
+        [number("1"), minus, number("2"), ampersand, number("3")],
+      )
+
+      expect(result).to eq(
+        [
+          tr(
+            [
+              td(
+                [
+                  number("1"),
+                  Plurimath::Math::Formula.new(
+                    [Plurimath::Math::Symbols::Minus.new, number("2")],
+                  ),
+                ],
+              ),
+              td([number("3")]),
+            ],
+          ),
+        ],
+      )
+    end
+
+    # quirk: the final cell of the input is flushed without filter_table_data,
+    # so the same Minus + value sequence stays un-merged there.
+    it "does not merge Minus in the final (post-loop) cell" do
+      result = described_class.organize_table(
+        [Plurimath::Math::Symbols::Minus.new, number("2")],
+      )
+
+      expect(result).to eq(
+        [tr([td([Plurimath::Math::Symbols::Minus.new, number("2")])])],
+      )
+    end
+
+    it "applies column_align letters as Td columnalign attributes" do
+      result = described_class.organize_table(
+        [number("1"), ampersand, number("2")],
+        column_align: [
+          Plurimath::Math::Symbols::Symbol.new("c"),
+          Plurimath::Math::Symbols::Symbol.new("r"),
+        ],
+      )
+
+      expect(result).to eq(
+        [
+          tr(
+            [
+              td([number("1")], { columnalign: "center" }),
+              td([number("2")], { columnalign: "right" }),
+            ],
+          ),
+        ],
+      )
+    end
+
+    it "treats an empty column_align like no column_align" do
+      result = described_class.organize_table([number("1")], column_align: [])
+
+      expect(result).to eq([tr([td([number("1")])])])
+    end
+
+    it "inserts a Td([Vert]) separator cell for a Paren in column_align" do
+      result = described_class.organize_table(
+        [number("1"), ampersand, number("2")],
+        column_align: [
+          Plurimath::Math::Symbols::Paren::Vert.new,
+          Plurimath::Math::Symbols::Symbol.new("c"),
+          Plurimath::Math::Symbols::Symbol.new("r"),
+        ],
+      )
+
+      expect(result).to eq(
+        [
+          tr(
+            [
+              td([Plurimath::Math::Symbols::Paren::Vert.new]),
+              td([number("1")], { columnalign: "center" }),
+              td([number("2")], { columnalign: "right" }),
+            ],
+          ),
+        ],
+      )
+    end
+
+    it "replicates a single column_align across every Td when options is truthy" do
+      column_align = [Plurimath::Math::Symbols::Symbol.new("c")]
+      result = described_class.organize_table(
+        [number("1"), ampersand, number("2")],
+        column_align: column_align,
+        options: true,
+      )
+
+      expect(result).to eq(
+        [
+          tr(
+            [
+              td([number("1")], { columnalign: "center" }),
+              td([number("2")], { columnalign: "center" }),
+            ],
+          ),
+        ],
+      )
+      expect(column_align).to eq([Plurimath::Math::Symbols::Symbol.new("c")])
+    end
+
+    # quirk: with options and more than one column_align entry,
+    # organize_options shifts the first align away (its return value is
+    # discarded), mutates column_align in place, and injects the remaining
+    # align symbols into the data array — so "r" becomes cell content AND
+    # the alignment applied to every Td.
+    it "drops the first align and injects the rest as data when options is truthy with multiple aligns" do
+      column_align = [
+        Plurimath::Math::Symbols::Symbol.new("c"),
+        Plurimath::Math::Symbols::Symbol.new("r"),
+      ]
+      array = [number("1"), ampersand, number("2")]
+      result = described_class.organize_table(
+        array,
+        column_align: column_align,
+        options: true,
+      )
+
+      expect(result).to eq(
+        [
+          tr(
+            [
+              td(
+                [Plurimath::Math::Symbols::Symbol.new("r"), number("1")],
+                { columnalign: "right" },
+              ),
+              td([number("2")], { columnalign: "right" }),
+            ],
+          ),
+        ],
+      )
+      expect(column_align).to eq([Plurimath::Math::Symbols::Symbol.new("r")])
+      expect(array.length).to eq(4)
+    end
+  end
+
+  describe ".table_options" do
+    it "returns a rowline entry marking Hline-led rows as solid" do
+      table = [
+        tr([td([Plurimath::Math::Symbols::Hline.new]), td([number("9")])]),
+        tr([td([number("1")])]),
+      ]
+
+      expect(described_class.table_options(table)).to eq({ rowline: "solid none" })
+    end
+
+    it "marks non-leading Hline rows in document order" do
+      table = [
+        tr([td([number("1")])]),
+        tr([td([Plurimath::Math::Symbols::Hline.new])]),
+      ]
+
+      expect(described_class.table_options(table)).to eq({ rowline: "none solid" })
+    end
+
+    it "returns an empty hash when no row starts with Hline" do
+      table = [tr([td([number("1")])]), tr([td([])])]
+
+      expect(described_class.table_options(table)).to eq({})
+    end
+
+    it "returns an empty hash for an empty table" do
+      expect(described_class.table_options([])).to eq({})
+    end
+  end
+
+  describe ".table_td" do
+    it "wraps an existing Td in an array without re-wrapping it" do
+      existing = td([number("1")])
+      result = described_class.table_td(existing)
+
+      expect(result).to eq([td([number("1")])])
+      expect(result.first).to be(existing)
+    end
+
+    it "wraps a non-Td object in a new Td" do
+      expect(described_class.table_td(number("5"))).to eq([td([number("5")])])
+    end
+
+    # quirk: nil is not filtered out — it becomes a Td whose parameter_one
+    # is [nil].
+    it "wraps nil into a Td containing [nil]" do
+      expect(described_class.table_td(nil)).to eq([td([nil])])
+    end
+  end
+
+  describe ".left_right_objects" do
+    it "builds a Left function from a plain paren via LEFT_RIGHT_PARENTHESIS" do
+      expect(described_class.left_right_objects("(", "left")).to eq(
+        Plurimath::Math::Function::Left.new("("),
+      )
+    end
+
+    it "builds a Right function from a plain paren" do
+      expect(described_class.left_right_objects(")", "right")).to eq(
+        Plurimath::Math::Function::Right.new(")"),
+      )
+    end
+
+    it "strips backslashes from escaped curly parens instead of using the lookup" do
+      expect(described_class.left_right_objects("\\{", "left")).to eq(
+        Plurimath::Math::Function::Left.new("{"),
+      )
+      expect(described_class.left_right_objects("\\}", "right")).to eq(
+        Plurimath::Math::Function::Right.new("}"),
+      )
+    end
+
+    it "maps named delimiters to their HTML entity" do
+      expect(described_class.left_right_objects("\\langle", "left")).to eq(
+        Plurimath::Math::Function::Left.new("&#x2329;"),
+      )
+      expect(described_class.left_right_objects("\\lfloor", "left")).to eq(
+        Plurimath::Math::Function::Left.new("&#x230a;"),
+      )
+    end
+
+    it "accepts Parslet::Slice input" do
+      expect(described_class.left_right_objects(slice("("), "left")).to eq(
+        Plurimath::Math::Function::Left.new("("),
+      )
+    end
+
+    # quirk: an unrecognized delimiter does not raise — the lookup returns
+    # nil and a paren-less Left is built.
+    it "builds a Left with nil paren for an unknown delimiter" do
+      expect(described_class.left_right_objects("unknown", "left")).to eq(
+        Plurimath::Math::Function::Left.new(nil),
+      )
+    end
+  end
+end

--- a/spec/plurimath/omml/utility_spec.rb
+++ b/spec/plurimath/omml/utility_spec.rb
@@ -1,0 +1,66 @@
+require "spec_helper"
+
+# Characterization specs (refactor phase A0) for the OMML-side token-resolution
+# class method. These pin CURRENT behavior on main — including known bugs, each
+# marked with a "# quirk:" comment — ahead of a strictly behavior-preserving
+# refactor. Do not "fix" an expectation here; behavior changes belong in a
+# later, separate PR together with the production-code change.
+RSpec.describe Plurimath::Omml::Utility do
+  describe ".valid_class" do
+    # Realistic OMML input: script_class_for(base) receives a Formula
+    # wrapping a single Function::Text (from omml_argument_value).
+    it "returns true for a Formula wrapping Text(\"lim\") (latex :power_base)" do
+      formula = Plurimath::Math::Formula.new([Plurimath::Math::Function::Text.new("lim")])
+
+      expect(described_class.valid_class(formula)).to be(true)
+    end
+
+    it "returns true for a Formula wrapping Text(\"log\")" do
+      formula = Plurimath::Math::Formula.new([Plurimath::Math::Function::Text.new("log")])
+
+      expect(described_class.valid_class(formula)).to be(true)
+    end
+
+    it "returns false for a Formula wrapping Text(\"sum\") (latex :ternary, not :power_base)" do
+      formula = Plurimath::Math::Formula.new([Plurimath::Math::Function::Text.new("sum")])
+
+      expect(described_class.valid_class(formula)).to be(false)
+    end
+
+    it "returns false for a Formula wrapping Text with a non-function word" do
+      formula = Plurimath::Math::Formula.new([Plurimath::Math::Function::Text.new("hello")])
+
+      expect(described_class.valid_class(formula)).to be(false)
+    end
+
+    it "returns false for a bare Text (core extract_class_name_from_text is \"\")" do
+      expect(described_class.valid_class(Plurimath::Math::Function::Text.new("lim")))
+        .to be(false)
+    end
+
+    it "returns false for a bare Number" do
+      expect(described_class.valid_class(Plurimath::Math::Number.new("3")))
+        .to be(false)
+    end
+
+    # quirk: Formula#extract_class_name_from_text returns nil when the
+    # single value is not a Function::Text, and valid_class calls
+    # nil.to_sym — raising NoMethodError instead of returning false.
+    it "raises NoMethodError for a Formula wrapping a non-Text value" do
+      formula = Plurimath::Math::Formula.new([Plurimath::Math::Number.new("3")])
+
+      expect { described_class.valid_class(formula) }.to raise_error(NoMethodError)
+    end
+
+    # quirk: FontStyle#extract_class_name_from_text always returns
+    # parameter_one.class_name ("text" for Text params — its first line is a
+    # no-op), so even FontStyle(Text("lim")) is not a valid class.
+    it "returns false for a FontStyle wrapping Text(\"lim\")" do
+      font_style = Plurimath::Math::Function::FontStyle.new(
+        Plurimath::Math::Function::Text.new("lim"), "mathrm"
+      )
+
+      expect(described_class.valid_class(font_style)).to be(false)
+    end
+  end
+end

--- a/spec/plurimath/unicode_math/utility_spec.rb
+++ b/spec/plurimath/unicode_math/utility_spec.rb
@@ -1,0 +1,756 @@
+require "spec_helper"
+
+# Characterization specs (refactor phase A0) for the UnicodeMath-side class
+# methods on Plurimath::Utility, ahead of their move to
+# Plurimath::UnicodeMath::Utility. These pin CURRENT behavior on main —
+# including known bugs, each marked with a "# quirk:" comment — for a
+# strictly behavior-preserving refactor. Do not "fix" an expectation here;
+# behavior changes belong in a later, separate PR together with the
+# production-code change.
+#
+# Input shapes mirror the real call sites in
+# lib/plurimath/unicode_math/transform.rb (and, for unfenced_value,
+# lib/plurimath/asciimath/transform.rb). The parser passes Parslet slices
+# where these specs pass plain Strings; the methods only call
+# to_s/to_sym/scan/decode on them, so behavior is identical (verified by
+# instrumenting the live parser).
+#
+# NOTE: the suite-wide around hook runs every example twice (Ox then Oga),
+# reusing the example instance. Several of these methods MUTATE their
+# arguments, so all mutable inputs are built inside the example body (or via
+# def helpers), never memoized with let.
+RSpec.describe Plurimath::UnicodeMath::Utility do
+  def symbol(value, *args, **kwargs)
+    Plurimath::Math::Symbols::Symbol.new(value, *args, **kwargs)
+  end
+
+  def number(value, **kwargs)
+    Plurimath::Math::Number.new(value, **kwargs)
+  end
+
+  def frac(numerator, denominator, options = {})
+    Plurimath::Math::Function::Frac.new(numerator, denominator, options)
+  end
+
+  def base(param_one, param_two)
+    Plurimath::Math::Function::Base.new(param_one, param_two)
+  end
+
+  def power(param_one, param_two)
+    Plurimath::Math::Function::Power.new(param_one, param_two)
+  end
+
+  def overset(param_one, param_two)
+    Plurimath::Math::Function::Overset.new(param_one, param_two, { accent: true })
+  end
+
+  def hat
+    Plurimath::Math::Symbols::Hat.new
+  end
+
+  def round_fenced(values, options = {})
+    Plurimath::Math::Function::Fenced.new(
+      Plurimath::Math::Symbols::Paren::Lround.new,
+      values,
+      Plurimath::Math::Symbols::Paren::Rround.new,
+      options,
+    )
+  end
+
+  def square_fenced(values)
+    Plurimath::Math::Function::Fenced.new(
+      Plurimath::Math::Symbols::Paren::Lsquare.new,
+      values,
+      Plurimath::Math::Symbols::Paren::Rsquare.new,
+    )
+  end
+
+  describe ".unicode_accents" do
+    context "when accents is already a BinaryFunction (prime-power route)" do
+      it "returns the object itself untouched" do
+        accents = power(symbol("a"), Plurimath::Math::Symbols::Sprime.new)
+
+        expect(described_class.unicode_accents(accents)).to be(accents)
+      end
+    end
+
+    context "with a single base and a known accent entity (input like 'â')" do
+      it "wraps the base in an accented Overset with the accent symbol class" do
+        accents = [
+          { first_value: symbol("a") },
+          { accent_symbols: "&#x302;" },
+        ]
+
+        expect(described_class.unicode_accents(accents))
+          .to eq(overset(hat, symbol("a")))
+      end
+    end
+
+    context "with a named accent (ACCENT_SYMBOLS key such as 'hat')" do
+      it "resolves the name through ACCENT_SYMBOLS to the symbol class" do
+        accents = [
+          { first_value: symbol("a") },
+          { accent_symbols: "hat" },
+        ]
+
+        expect(described_class.unicode_accents(accents))
+          .to eq(overset(hat, symbol("a")))
+      end
+    end
+
+    # quirk: "&#x303;" (combining tilde) has no dedicated symbols_class
+    # mapping on the :unicodemath path, so — unlike "&#x302;" → Hat — the
+    # accent lands as a generic Symbol carrying the raw entity string.
+    context "with the combining-tilde entity (input like 'ã')" do
+      it "uses a generic Symbol holding the raw entity as the accent" do
+        accents = [
+          { first_value: symbol("a") },
+          { accent_symbols: "&#x303;" },
+        ]
+
+        expect(described_class.unicode_accents(accents))
+          .to eq(overset(symbol("&#x303;"), symbol("a")))
+      end
+    end
+
+    context "when first_value is an Array (input like 'ab̂')" do
+      # quirk: this branch mutates the input — it pops the last element out
+      # of accents.first[:first_value] and reassigns the hash entry.
+      it "accents only the last element and keeps the rest alongside it" do
+        accents = [
+          { first_value: [symbol("a"), symbol("b")] },
+          { accent_symbols: "&#x302;" },
+        ]
+
+        expect(described_class.unicode_accents(accents)).to eq(
+          Plurimath::Math::Formula.new(
+            [symbol("a"), overset(hat, symbol("b"))],
+          ),
+        )
+      end
+    end
+
+    context "with two stacked accents (input like 'ẫ')" do
+      it "nests Oversets left to right" do
+        accents = [
+          { first_value: symbol("a") },
+          { accent_symbols: "&#x302;" },
+          { accent_symbols: "&#x303;" },
+        ]
+
+        expect(described_class.unicode_accents(accents)).to eq(
+          overset(symbol("&#x303;"), overset(hat, symbol("a"))),
+        )
+      end
+    end
+
+    # quirk: a trailing prime accent becomes a Power whose exponent is the
+    # RAW entity String ("&#x2032;"), not a Math object — filter_values
+    # passes non-Array/non-Formula input straight through.
+    context "with an accent followed by a prime (input like 'â′')" do
+      it "returns a Power with the raw prime entity string as exponent" do
+        accents = [
+          { first_value: symbol("a") },
+          { accent_symbols: "&#x302;" },
+          { prime_accent_symbols: "&#x2032;" },
+        ]
+
+        expect(described_class.unicode_accents(accents)).to eq(
+          power(overset(hat, symbol("a")), "&#x2032;"),
+        )
+      end
+    end
+
+    # quirk: when the prime hash immediately follows the base hash, the
+    # prime is treated as an ACCENT (Overset) whose accent slot holds the
+    # raw entity String — not as a Power exponent.
+    context "with a prime hash directly after the base hash" do
+      it "builds an Overset with the raw prime entity string on top" do
+        accents = [
+          { first_value: symbol("a") },
+          { prime_accent_symbols: "&#x2032;" },
+        ]
+
+        expect(described_class.unicode_accents(accents)).to eq(
+          Plurimath::Math::Function::Overset.new(
+            "&#x2032;", symbol("a"), { accent: true }
+          ),
+        )
+      end
+    end
+
+    # quirk: with a prime hash in FIRST position the prime string becomes
+    # the Power BASE and the following accent becomes the exponent.
+    context "with a prime hash in first position" do
+      it "returns Power(raw prime string, accent symbol)" do
+        accents = [
+          { prime_accent_symbols: "&#x2032;" },
+          { accent_symbols: "&#x302;" },
+        ]
+
+        expect(described_class.unicode_accents(accents))
+          .to eq(power("&#x2032;", hat))
+      end
+    end
+
+    context "when first_value is a plain round Fenced (input like '(a)̂')" do
+      it "unwraps the parens before accenting" do
+        accents = [
+          { first_value: round_fenced([symbol("a")]) },
+          { accent_symbols: "&#x302;" },
+        ]
+
+        expect(described_class.unicode_accents(accents))
+          .to eq(overset(hat, symbol("a")))
+      end
+    end
+  end
+
+  describe ".unicode_fractions" do
+    context "with a vulgar-fraction entity from UNICODE_FRACTIONS ('½')" do
+      it "returns a non-displaystyle Frac tagged as a unicodemath fraction" do
+        expect(described_class.unicode_fractions("&#xbd;")).to eq(
+          frac(
+            number("1"),
+            number("2"),
+            { displaystyle: false, unicodemath_fraction: true },
+          ),
+        )
+      end
+    end
+
+    # quirk: an entity missing from UNICODE_FRACTIONS crashes with
+    # NoMethodError (nil.first) instead of failing gracefully. The parser
+    # only feeds known fraction characters, so this is latent.
+    context "with an entity not present in UNICODE_FRACTIONS" do
+      it "raises NoMethodError on the nil lookup" do
+        expect { described_class.unicode_fractions("&#x9999;") }
+          .to raise_error(NoMethodError)
+      end
+    end
+  end
+
+  describe ".updated_primes" do
+    context "with a single ASCII-apostrophe entity (input like \"a'\")" do
+      it "returns a lone Sprime symbol" do
+        expect(described_class.updated_primes("&#x27;"))
+          .to eq(Plurimath::Math::Symbols::Sprime.new)
+      end
+    end
+
+    context "with repeated apostrophe entities (input like \"a'''\")" do
+      it "returns a Formula of one Sprime per entity" do
+        expect(described_class.updated_primes("&#x27;&#x27;&#x27;")).to eq(
+          Plurimath::Math::Formula.new(
+            [
+              Plurimath::Math::Symbols::Sprime.new,
+              Plurimath::Math::Symbols::Sprime.new,
+              Plurimath::Math::Symbols::Sprime.new,
+            ],
+          ),
+        )
+      end
+    end
+
+    context "with mixed prime entities (input like 'a′″')" do
+      it "maps each entity to its own symbol class" do
+        expect(described_class.updated_primes("&#x2032;&#x2033;")).to eq(
+          Plurimath::Math::Formula.new(
+            [
+              Plurimath::Math::Symbols::Prime.new,
+              Plurimath::Math::Symbols::Dprime.new,
+            ],
+          ),
+        )
+      end
+    end
+
+    # quirk: only "&#x...;" entities are scanned — a raw apostrophe (or any
+    # non-entity text) yields no matches and the method returns nil.
+    context "with a raw (non-entity) apostrophe" do
+      it "returns nil" do
+        expect(described_class.updated_primes("'")).to be_nil
+      end
+    end
+
+    context "with nil" do
+      it "returns nil" do
+        expect(described_class.updated_primes(nil)).to be_nil
+      end
+    end
+  end
+
+  describe ".fractions" do
+    context "with plain numerator and denominator and no options" do
+      it "returns a Frac without options" do
+        expect(described_class.fractions(symbol("a"), symbol("b")))
+          .to eq(frac(symbol("a"), symbol("b")))
+      end
+    end
+
+    context "with options" do
+      it "passes the options through to the Frac" do
+        result = described_class.fractions(
+          symbol("a"), symbol("b"), { displaystyle: false }
+        )
+
+        expect(result).to eq(
+          frac(symbol("a"), symbol("b"), { displaystyle: false }),
+        )
+      end
+    end
+
+    context "when the denominator is already a Frac (input like 'a/b/c')" do
+      it "mutates the denominator, nesting the new Frac as its numerator" do
+        denominator = frac(symbol("b"), symbol("c"))
+
+        result = described_class.fractions(symbol("a"), denominator)
+
+        expect(result).to be(denominator)
+        expect(result).to eq(
+          frac(frac(symbol("a"), symbol("b")), symbol("c")),
+        )
+      end
+    end
+
+    context "when the denominator nests Fracs (input like 'a/b/c/d')" do
+      it "recurses to the deepest numerator" do
+        denominator = frac(frac(symbol("b"), symbol("c")), symbol("d"))
+
+        result = described_class.fractions(symbol("a"), denominator, nil)
+
+        expect(result).to be(denominator)
+        expect(result).to eq(
+          frac(frac(frac(symbol("a"), symbol("b")), symbol("c")), symbol("d")),
+        )
+      end
+    end
+
+    context "with round-fenced operands (input like '(x)/(y)')" do
+      it "unwraps plain round parens on both sides" do
+        result = described_class.fractions(
+          round_fenced([symbol("x")]),
+          round_fenced([symbol("y")]),
+        )
+
+        expect(result).to eq(frac(symbol("x"), symbol("y")))
+      end
+    end
+  end
+
+  describe ".recursive_sub" do
+    context "when the recursion value is not a Base (input like 'x_a_b')" do
+      it "returns a new Base of the two values" do
+        expect(described_class.recursive_sub(symbol("a"), symbol("b")))
+          .to eq(base(symbol("a"), symbol("b")))
+      end
+    end
+
+    context "when the recursion value is a Base (input like 'x_a_b_c')" do
+      it "mutates it, nesting the script as the inner base" do
+        recursion = base(symbol("b"), symbol("c"))
+
+        result = described_class.recursive_sub(symbol("a"), recursion)
+
+        expect(result).to be(recursion)
+        expect(result).to eq(base(base(symbol("a"), symbol("b")), symbol("c")))
+      end
+    end
+
+    context "when the recursion value nests Bases (input like 'x_a_b_c_d')" do
+      it "recurses to the deepest parameter_one" do
+        recursion = base(base(symbol("b"), symbol("c")), symbol("d"))
+
+        result = described_class.recursive_sub(symbol("a"), recursion)
+
+        expect(result).to be(recursion)
+        expect(result).to eq(
+          base(base(base(symbol("a"), symbol("b")), symbol("c")), symbol("d")),
+        )
+      end
+    end
+  end
+
+  describe ".recursive_sup" do
+    context "when the recursion value is not a Power (input like 'y^a^b')" do
+      it "returns a new Power of the two values" do
+        expect(described_class.recursive_sup(symbol("a"), symbol("b")))
+          .to eq(power(symbol("a"), symbol("b")))
+      end
+    end
+
+    context "when the recursion value is a Power (input like 'y^a^b^c')" do
+      it "mutates it, nesting the script as the inner base" do
+        recursion = power(symbol("b"), symbol("c"))
+
+        result = described_class.recursive_sup(symbol("a"), recursion)
+
+        expect(result).to be(recursion)
+        expect(result).to eq(
+          power(power(symbol("a"), symbol("b")), symbol("c")),
+        )
+      end
+    end
+
+    context "when the recursion value nests Powers (input like 'y^a^b^c^d')" do
+      it "recurses to the deepest parameter_one" do
+        recursion = power(power(symbol("b"), symbol("c")), symbol("d"))
+
+        result = described_class.recursive_sup(symbol("a"), recursion)
+
+        expect(result).to be(recursion)
+        expect(result).to eq(
+          power(
+            power(power(symbol("a"), symbol("b")), symbol("c")),
+            symbol("d"),
+          ),
+        )
+      end
+    end
+  end
+
+  describe ".base_is_prime?" do
+    # quirk: despite the ? name, truthy results are the Hash#key lookup —
+    # a Symbol like :sprime or :prime — not true.
+    context "when the exponent is a prime symbol class (input like \"a'_b\")" do
+      it "returns the prime key :sprime for an Sprime exponent" do
+        prime_base = power(symbol("a"), Plurimath::Math::Symbols::Sprime.new)
+
+        expect(described_class.base_is_prime?(prime_base)).to eq(:sprime)
+      end
+
+      it "returns the prime key :prime for a Prime exponent" do
+        prime_base = power(symbol("a"), Plurimath::Math::Symbols::Prime.new)
+
+        expect(described_class.base_is_prime?(prime_base)).to eq(:prime)
+      end
+    end
+
+    context "when the exponent is a generic Symbol holding a prime entity" do
+      it "falls back to the value lookup and returns the prime key" do
+        prime_base = power(symbol("a"), symbol("&#x2032;"))
+
+        expect(described_class.base_is_prime?(prime_base)).to eq(:prime)
+      end
+    end
+
+    context "when the exponent is not a prime" do
+      it "returns nil for a Number exponent" do
+        expect(described_class.base_is_prime?(power(symbol("a"), number("2"))))
+          .to be_nil
+      end
+
+      it "returns nil for a non-prime Symbol exponent" do
+        expect(described_class.base_is_prime?(power(symbol("a"), symbol("b"))))
+          .to be_nil
+      end
+
+      it "returns nil for a Formula exponent (multiple primes)" do
+        exponent = Plurimath::Math::Formula.new(
+          [
+            Plurimath::Math::Symbols::Prime.new,
+            Plurimath::Math::Symbols::Dprime.new,
+          ],
+        )
+
+        expect(described_class.base_is_prime?(power(symbol("a"), exponent)))
+          .to be_nil
+      end
+    end
+  end
+
+  describe ".base_is_sub_or_sup?" do
+    context "with a mini-sub-sized Number (input like 'a₂')" do
+      it "returns true" do
+        expect(
+          described_class.base_is_sub_or_sup?(
+            number("2", mini_sub_sized: true),
+          ),
+        ).to be(true)
+      end
+    end
+
+    context "with a mini-sub-sized Symbol" do
+      it "returns true" do
+        expect(
+          described_class.base_is_sub_or_sup?(
+            symbol("a", mini_sub_sized: true),
+          ),
+        ).to be(true)
+      end
+    end
+
+    context "with a Formula wrapping a mini-sub-sized value" do
+      it "recurses into the first value and returns true" do
+        formula = Plurimath::Math::Formula.new(
+          [number("1", mini_sub_sized: true)],
+        )
+
+        expect(described_class.base_is_sub_or_sup?(formula)).to be(true)
+      end
+    end
+
+    context "with a Fenced wrapping a mini-sub-sized value" do
+      it "recurses into the first fenced value and returns true" do
+        fenced = round_fenced([number("1", mini_sub_sized: true)])
+
+        expect(described_class.base_is_sub_or_sup?(fenced)).to be(true)
+      end
+    end
+
+    # quirk: the second operand of the || is the typo `base_mini_sup_sized`
+    # (instead of `base.mini_sup_sized`), which is undefined on Utility. Any
+    # Symbol/Number whose mini_sub_sized is falsy therefore raises NameError
+    # — including mini_SUP_sized values, which can never return true.
+    context "with a Symbol that is not mini-sub-sized" do
+      it "raises NameError from the base_mini_sup_sized typo" do
+        expect { described_class.base_is_sub_or_sup?(symbol("a")) }
+          .to raise_error(NameError, /base_mini_sup_sized/)
+      end
+
+      it "raises NameError even when the symbol is mini-sup-sized" do
+        expect do
+          described_class.base_is_sub_or_sup?(
+            symbol("a", mini_sup_sized: true),
+          )
+        end.to raise_error(NameError, /base_mini_sup_sized/)
+      end
+    end
+
+    context "with a node outside the case branches" do
+      it "returns nil for a Text function" do
+        text = Plurimath::Math::Function::Text.new("x")
+
+        expect(described_class.base_is_sub_or_sup?(text)).to be_nil
+      end
+
+      it "returns nil for an empty Formula" do
+        formula = Plurimath::Math::Formula.new([])
+
+        expect(described_class.base_is_sub_or_sup?(formula)).to be_nil
+      end
+    end
+  end
+
+  describe ".identity_matrix" do
+    def td_number(digit)
+      Plurimath::Math::Function::Td.new([number(digit)])
+    end
+
+    context "with size 2 (input like '■2' after to_i)" do
+      it "returns Tr rows of Td-wrapped 1/0 numbers with 1s on the diagonal" do
+        expect(described_class.identity_matrix(2)).to eq(
+          [
+            Plurimath::Math::Function::Tr.new([td_number("1"), td_number("0")]),
+            Plurimath::Math::Function::Tr.new([td_number("0"), td_number("1")]),
+          ],
+        )
+      end
+    end
+
+    context "with size 1" do
+      it "returns a single row holding a single 1" do
+        expect(described_class.identity_matrix(1)).to eq(
+          [Plurimath::Math::Function::Tr.new([td_number("1")])],
+        )
+      end
+    end
+
+    context "with size 0" do
+      it "returns an empty array" do
+        expect(described_class.identity_matrix(0)).to eq([])
+      end
+    end
+  end
+
+  describe ".enclosure_attrs" do
+    # The mask's low nibble is XORed with 15, so 0 enables all four sides
+    # and 15 disables them; bits 16..128 map to the strike classes directly.
+    it "returns all four sides for mask 0" do
+      expect(described_class.enclosure_attrs(0)).to eq("top bottom left right")
+    end
+
+    it "returns 'bottom left right' for mask 1 (top removed)" do
+      expect(described_class.enclosure_attrs(1)).to eq("bottom left right")
+    end
+
+    it "returns 'bottom right' for mask 5" do
+      expect(described_class.enclosure_attrs(5)).to eq("bottom right")
+    end
+
+    it "returns an empty string for mask 15" do
+      expect(described_class.enclosure_attrs(15)).to eq("")
+    end
+
+    it "returns 'downdiagonalstrike' for mask 79" do
+      expect(described_class.enclosure_attrs(79)).to eq("downdiagonalstrike")
+    end
+
+    it "returns all strike classes for mask 255" do
+      expect(described_class.enclosure_attrs(255)).to eq(
+        "horizontalstrike verticalstrike downdiagonalstrike updiagonalstrike",
+      )
+    end
+
+    context "with an out-of-range or missing mask" do
+      it "raises for nil" do
+        expect { described_class.enclosure_attrs(nil) }
+          .to raise_error(RuntimeError, "enclosure mask is not between 0 and 255")
+      end
+
+      it "raises for a negative mask" do
+        expect { described_class.enclosure_attrs(-1) }
+          .to raise_error(RuntimeError, "enclosure mask is not between 0 and 255")
+      end
+
+      it "raises for a mask above 255" do
+        expect { described_class.enclosure_attrs(256) }
+          .to raise_error(RuntimeError, "enclosure mask is not between 0 and 255")
+      end
+    end
+  end
+
+  describe ".slashed_values" do
+    context "when the decoded value starts with a word character" do
+      it "returns a Text with a backslash prefix for digits" do
+        expect(described_class.slashed_values("12"))
+          .to eq(Plurimath::Math::Function::Text.new("\\12"))
+      end
+
+      it "returns a Text with a backslash prefix for letters" do
+        expect(described_class.slashed_values("alpha"))
+          .to eq(Plurimath::Math::Function::Text.new("\\alpha"))
+      end
+    end
+
+    context "when the decoded value is not a word character" do
+      it "returns a slashed Symbol with the decoded character" do
+        expect(described_class.slashed_values("&#x226e;"))
+          .to eq(symbol("≮", true))
+      end
+
+      it "returns a slashed Symbol for a bare backslash" do
+        expect(described_class.slashed_values("\\")).to eq(symbol("\\", true))
+      end
+    end
+  end
+
+  describe ".sequence_slashed_values" do
+    context "with a leading number node (input like '\\12ab')" do
+      it "slashes the first value and re-resolves the rest, mutating in place" do
+        values = [number("12"), symbol("ab")]
+
+        result = described_class.sequence_slashed_values(
+          values, lang: :unicodemath
+        )
+
+        expect(result).to be(values)
+        expect(result).to eq(
+          [Plurimath::Math::Function::Text.new("\\12"), symbol("ab")],
+        )
+      end
+    end
+
+    context "with digits after the first value" do
+      it "turns later digit values into Numbers" do
+        result = described_class.sequence_slashed_values(
+          [symbol("ab"), number("12")], lang: :unicodemath
+        )
+
+        expect(result).to eq(
+          [Plurimath::Math::Function::Text.new("\\ab"), number("12")],
+        )
+      end
+    end
+
+    context "with an entity after the first value" do
+      it "decodes it and resolves it through symbols_class" do
+        result = described_class.sequence_slashed_values(
+          [symbol("ab"), symbol("&#x2264;")], lang: :unicodemath
+        )
+
+        expect(result).to eq(
+          [Plurimath::Math::Function::Text.new("\\ab"), symbol("≤")],
+        )
+      end
+    end
+
+    context "with an empty array" do
+      it "returns the empty array" do
+        expect(described_class.sequence_slashed_values([], lang: :unicodemath))
+          .to eq([])
+      end
+    end
+  end
+
+  describe ".unfenced_value" do
+    context "with a plain round Fenced and paren_specific: true" do
+      it "unwraps a single-value Fenced to the value itself" do
+        fenced = round_fenced([symbol("x")])
+
+        expect(described_class.unfenced_value(fenced, paren_specific: true))
+          .to eq(symbol("x"))
+      end
+
+      it "unwraps a multi-value Fenced to a Formula" do
+        fenced = round_fenced([symbol("x"), symbol("y")])
+
+        expect(described_class.unfenced_value(fenced, paren_specific: true))
+          .to eq(Plurimath::Math::Formula.new([symbol("x"), symbol("y")]))
+      end
+    end
+
+    context "with a non-round Fenced" do
+      it "keeps the Fenced untouched when paren_specific: true" do
+        fenced = square_fenced([symbol("x")])
+
+        expect(described_class.unfenced_value(fenced, paren_specific: true))
+          .to be(fenced)
+      end
+
+      it "still unwraps it when paren_specific is false (default)" do
+        fenced = square_fenced([symbol("x")])
+
+        expect(described_class.unfenced_value(fenced)).to eq(symbol("x"))
+      end
+    end
+
+    context "with a round Fenced carrying paren options" do
+      it "keeps the Fenced untouched when paren_specific: true" do
+        fenced = round_fenced([symbol("x")], { open_paren: "(" })
+
+        expect(described_class.unfenced_value(fenced, paren_specific: true))
+          .to be(fenced)
+      end
+    end
+
+    context "with an Array" do
+      it "wraps multiple values in a Formula" do
+        expect(described_class.unfenced_value([symbol("x"), symbol("y")]))
+          .to eq(Plurimath::Math::Formula.new([symbol("x"), symbol("y")]))
+      end
+
+      it "unwraps a single-element array to the element" do
+        expect(described_class.unfenced_value([symbol("x")]))
+          .to eq(symbol("x"))
+      end
+
+      # quirk: an empty array filters down to nil, not an empty Formula.
+      it "returns nil for an empty array" do
+        expect(described_class.unfenced_value([])).to be_nil
+      end
+    end
+
+    context "with any other object" do
+      it "returns the object itself" do
+        value = symbol("x")
+
+        expect(described_class.unfenced_value(value)).to be(value)
+      end
+
+      it "returns nil for nil" do
+        expect(described_class.unfenced_value(nil)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/plurimath/utility_spec.rb
+++ b/spec/plurimath/utility_spec.rb
@@ -1,0 +1,1369 @@
+require "spec_helper"
+
+# Characterization specs (refactor phase A0) for the class methods that remain
+# on Plurimath::Utility after the language-utility split. These pin CURRENT
+# behavior on main — including known bugs, each marked with a "# quirk:"
+# comment — ahead of a strictly behavior-preserving refactor. Do not "fix" an
+# expectation here; behavior changes belong in a later, separate PR together
+# with the production-code change.
+#
+# XML helpers note: every example runs twice (Ox and Oga, via the around hook
+# in spec_helper). Assertions stick to engine-stable properties: node name,
+# attribute values, children, and the string produced by
+# Plurimath.xml_engine.dump(..., indent: 2), which is byte-identical across
+# engines for these structures. The one genuinely engine-dependent surface
+# (namespaced attribute hash keys / [] lookup keys) is asserted per-engine.
+RSpec.describe Plurimath::Utility do
+  def slice(string)
+    Parslet::Slice.new(Parslet::Position.new(string, 0), string)
+  end
+
+  # Whitespace-collapsed engine dump; the raw dump (indent: 2) is identical
+  # across Ox and Oga, collapsing makes the expectations single-line.
+  def dumped(element)
+    Plurimath.xml_engine.dump(element, indent: 2).gsub(/\n\s*/, "")
+  end
+
+  def oga_engine?
+    Plurimath.xml_engine == Plurimath::XmlEngine::Oga
+  end
+
+  describe ".mathml_unary_classes" do
+    context "branch 1: unicode character whose UNICODE_SYMBOLS name is in CLASSES" do
+      it "resolves the summation character to a Function::Sum instance" do
+        result = described_class.mathml_unary_classes(["∑"], lang: :mathml)
+
+        expect(result).to eq(Plurimath::Math::Function::Sum.new)
+      end
+
+      # quirk: a literal entity string is double-encoded by
+      # string_to_html_entity ("&" -> "&#x26;"), so "&#x2211;" misses the
+      # UNICODE_SYMBOLS lookup and falls through to a plain Symbol whose
+      # value is the mangled entity.
+      it "mangles an already-encoded entity string into a plain Symbol" do
+        result = described_class.mathml_unary_classes(["&#x2211;"], lang: :mathml)
+
+        expect(result).to eq(Plurimath::Math::Symbols::Symbol.new("&#x26;#x2211;"))
+      end
+
+      it "joins multiple string fragments before resolving" do
+        result = described_class.mathml_unary_classes(["si", "n"], lang: :mathml)
+
+        expect(result).to eq(Plurimath::Math::Function::Sin.new)
+      end
+    end
+
+    context "branch 2: word in CLASSES" do
+      it "resolves \"sin\" to Function::Sin for lang: :mathml" do
+        result = described_class.mathml_unary_classes(["sin"], lang: :mathml)
+
+        expect(result).to eq(Plurimath::Math::Function::Sin.new)
+      end
+
+      # quirk: the bare word "frac" resolves to an argument-less
+      # Function::Frac in MathML even though a bare <mi>frac</mi> is an
+      # identifier, not a fraction.
+      it "resolves \"frac\" to an empty Function::Frac for lang: :mathml" do
+        result = described_class.mathml_unary_classes(["frac"], lang: :mathml)
+
+        expect(result).to eq(Plurimath::Math::Function::Frac.new)
+      end
+
+      it "resolves \"frac\" to an empty Function::Frac for lang: :omml with omml: true" do
+        result = described_class.mathml_unary_classes(
+          ["frac"], lang: :omml, omml: true
+        )
+
+        expect(result).to eq(Plurimath::Math::Function::Frac.new)
+      end
+    end
+
+    context "accent-word guard (PR #450)" do
+      it "keeps \"bar\" a literal Symbol for lang: :mathml" do
+        result = described_class.mathml_unary_classes(["bar"], lang: :mathml)
+
+        expect(result).to eq(Plurimath::Math::Symbols::Symbol.new("bar"))
+      end
+
+      # quirk: the accent-word guard is scoped to lang == :mathml only, so
+      # the same bare word "bar" still promotes to Function::Bar on the OMML
+      # path. Known bug — pinned as-is.
+      it "still promotes \"bar\" to Function::Bar for lang: :omml with omml: true" do
+        result = described_class.mathml_unary_classes(
+          ["bar"], lang: :omml, omml: true
+        )
+
+        expect(result).to eq(Plurimath::Math::Function::Bar.new)
+      end
+    end
+
+    context "branch 3: omml: true fallback through text_classes" do
+      it "wraps a non-CLASSES word in Function::Text" do
+        result = described_class.mathml_unary_classes(
+          ["hello"], lang: :omml, omml: true
+        )
+
+        expect(result).to eq(Plurimath::Math::Function::Text.new("hello", lang: :omml))
+      end
+
+      it "wraps digits in Math::Number" do
+        result = described_class.mathml_unary_classes(
+          ["123"], lang: :omml, omml: true
+        )
+
+        expect(result).to eq(Plurimath::Math::Number.new("123"))
+      end
+
+      # quirk: "" has zero digits and zero length, so the digits check
+      # ("".scan(/[[:digit:]]/).length == "".length) is 0 == 0 and an empty
+      # string becomes Math::Number.new("").
+      it "turns an empty string into an empty Math::Number" do
+        result = described_class.mathml_unary_classes(
+          [""], lang: :omml, omml: true
+        )
+
+        expect(result).to eq(Plurimath::Math::Number.new(""))
+      end
+    end
+
+    context "branch 4: default fallback without omml: true" do
+      it "wraps a non-CLASSES word in Symbols::Symbol for lang: :mathml" do
+        result = described_class.mathml_unary_classes(["hello"], lang: :mathml)
+
+        expect(result).to eq(Plurimath::Math::Symbols::Symbol.new("hello"))
+      end
+    end
+
+    context "unicode_only: true (early symbols_class return)" do
+      it "resolves the summation character to the Symbols::Sum class, not Function::Sum" do
+        result = described_class.mathml_unary_classes(
+          ["∑"], unicode_only: true, lang: :mathml
+        )
+
+        expect(result).to eq(Plurimath::Math::Symbols::Sum.new)
+      end
+
+      it "returns a plain Symbol for a function word, bypassing CLASSES" do
+        result = described_class.mathml_unary_classes(
+          ["sin"], unicode_only: true, lang: :mathml
+        )
+
+        expect(result).to eq(Plurimath::Math::Symbols::Symbol.new("sin"))
+      end
+    end
+
+    context "edge cases" do
+      it "returns [] for an empty array" do
+        expect(described_class.mathml_unary_classes([], lang: :mathml)).to eq([])
+      end
+
+      # quirk: [nil] is not empty, so it skips the early [] return; after
+      # compact the filter_values fallback returns nil, not [].
+      it "returns nil for [nil]" do
+        expect(described_class.mathml_unary_classes([nil], lang: :mathml)).to be_nil
+      end
+
+      it "unwraps a single non-String Math object via filter_values (same object)" do
+        number = Plurimath::Math::Number.new("2")
+
+        result = described_class.mathml_unary_classes([number], lang: :mathml)
+
+        expect(result).to be(number)
+      end
+
+      it "wraps multiple non-String Math objects in a Formula via filter_values" do
+        number = Plurimath::Math::Number.new("2")
+        symbol = Plurimath::Math::Symbols::Symbol.new("x")
+
+        result = described_class.mathml_unary_classes([number, symbol], lang: :mathml)
+
+        expect(result).to eq(Plurimath::Math::Formula.new([number, symbol]))
+      end
+
+      it "compacts nils away before filtering non-String values" do
+        number = Plurimath::Math::Number.new("2")
+
+        result = described_class.mathml_unary_classes([nil, number], lang: :mathml)
+
+        expect(result).to be(number)
+      end
+    end
+
+    context "with omml: true and non-alphanumeric text (text_classes symbol branch)" do
+      it "resolves a known operator character to its symbol class" do
+        result = described_class.mathml_unary_classes(["+"], omml: true, lang: :omml)
+
+        expect(result).to eq(Plurimath::Math::Symbols::Plus.new)
+      end
+
+      it "falls back to a generic Symbol for entity-normalized characters" do
+        result = described_class.mathml_unary_classes(["<"], omml: true, lang: :omml)
+
+        expect(result).to eq(Plurimath::Math::Symbols::Symbol.new("<"))
+      end
+    end
+  end
+
+  describe ".symbols_class" do
+    it "resolves a known symbol string to its symbol class instance" do
+      expect(described_class.symbols_class("+", lang: :mathml))
+        .to eq(Plurimath::Math::Symbols::Plus.new)
+    end
+
+    it "strips surrounding whitespace before the lookup" do
+      expect(described_class.symbols_class(" + ", lang: :mathml))
+        .to eq(Plurimath::Math::Symbols::Plus.new)
+    end
+
+    it "wraps an unknown string in Symbols::Symbol with the original value" do
+      expect(described_class.symbols_class("zzunknownzz", lang: :mathml))
+        .to eq(Plurimath::Math::Symbols::Symbol.new("zzunknownzz"))
+    end
+
+    it "passes a non-String object through untouched" do
+      number = Plurimath::Math::Number.new("1")
+
+      expect(described_class.symbols_class(number, lang: :mathml)).to be(number)
+    end
+
+    it "passes nil through untouched" do
+      expect(described_class.symbols_class(nil, lang: :mathml)).to be_nil
+    end
+
+    context "with table: true, lang: :latex (latex_table_curly_paren)" do
+      it "maps \"{\" to Paren::Lcurly" do
+        expect(described_class.symbols_class("{", lang: :latex, table: true))
+          .to eq(Plurimath::Math::Symbols::Paren::Lcurly.new)
+      end
+
+      it "maps \"}\" to Paren::Rcurly" do
+        expect(described_class.symbols_class("}", lang: :latex, table: true))
+          .to eq(Plurimath::Math::Symbols::Paren::Rcurly.new)
+      end
+
+      it "falls back to the normal latex lookup for other paren strings" do
+        expect(described_class.symbols_class("(", lang: :latex, table: true))
+          .to eq(Plurimath::Math::Symbols::Paren::Lround.new)
+      end
+
+      it "falls back to Symbols::Symbol for non-paren strings" do
+        expect(described_class.symbols_class("x", lang: :latex, table: true))
+          .to eq(Plurimath::Math::Symbols::Symbol.new("x"))
+      end
+    end
+
+    it "ignores table: true for non-latex langs and uses the normal lookup" do
+      expect(described_class.symbols_class("{", lang: :mathml, table: true))
+        .to eq(Plurimath::Math::Symbols::Paren::Lcurly.new)
+    end
+  end
+
+  describe ".get_class" do
+    it "resolves \"sin\" to the Function::Sin class object" do
+      expect(described_class.get_class("sin")).to be(Plurimath::Math::Function::Sin)
+    end
+
+    it "resolves \"frac\" to the Function::Frac class object" do
+      expect(described_class.get_class("frac")).to be(Plurimath::Math::Function::Frac)
+    end
+
+    it "resolves \"lim\" to the Function::Lim class object" do
+      expect(described_class.get_class("lim")).to be(Plurimath::Math::Function::Lim)
+    end
+
+    it "capitalize-joins underscored names" do
+      expect(described_class.get_class("power_base"))
+        .to be(Plurimath::Math::Function::PowerBase)
+    end
+
+    it "accepts symbols via to_s" do
+      expect(described_class.get_class(:sum)).to be(Plurimath::Math::Function::Sum)
+    end
+
+    it "raises NameError for names without a Function class" do
+      expect { described_class.get_class("nope_missing") }.to raise_error(NameError)
+    end
+  end
+
+  describe ".symbols_hash" do
+    it "returns a Hash mapping input strings to symbol class objects" do
+      hash = described_class.symbols_hash(:mathml)
+
+      expect(hash).to be_a(Hash)
+      expect(hash["+"]).to be(Plurimath::Math::Symbols::Plus)
+    end
+
+    it "builds the same mapping for other langs" do
+      expect(described_class.symbols_hash(:omml)["+"])
+        .to be(Plurimath::Math::Symbols::Plus)
+    end
+
+    it "memoizes per lang, returning the identical Hash object" do
+      first_call = described_class.symbols_hash(:mathml)
+      second_call = described_class.symbols_hash(:mathml)
+
+      expect(first_call).to be(second_call)
+    end
+
+    it "orders keys by descending string length" do
+      keys = described_class.symbols_hash(:mathml).keys
+
+      expect(keys.each_cons(2).all? { |a, b| a.length >= b.length }).to be(true)
+    end
+
+    it "does not contain function words like \"sin\"" do
+      expect(described_class.symbols_hash(:mathml)).not_to have_key("sin")
+    end
+
+    it "returns nil for unknown keys" do
+      expect(described_class.symbols_hash(:mathml)["zzunknownzz"]).to be_nil
+    end
+  end
+
+  describe ".filter_values" do
+    it "unwraps a single-element array to its (identical) element" do
+      number = Plurimath::Math::Number.new("7")
+
+      expect(described_class.filter_values([number])).to be(number)
+    end
+
+    it "wraps a multi-element array in a Formula" do
+      one = Plurimath::Math::Number.new("1")
+      two = Plurimath::Math::Number.new("2")
+
+      expect(described_class.filter_values([one, two]))
+        .to eq(Plurimath::Math::Formula.new([one, two]))
+    end
+
+    it "returns the multi-element array itself with new_formula: false" do
+      one = Plurimath::Math::Number.new("1")
+      two = Plurimath::Math::Number.new("2")
+
+      expect(described_class.filter_values([one, two], new_formula: false))
+        .to eq([one, two])
+    end
+
+    it "flattens nested arrays and compacts nils before unwrapping" do
+      number = Plurimath::Math::Number.new("1")
+
+      expect(described_class.filter_values([[number], nil])).to be(number)
+    end
+
+    it "returns nil for an empty array" do
+      expect(described_class.filter_values([])).to be_nil
+    end
+
+    it "passes non-Array, non-Formula input through untouched" do
+      number = Plurimath::Math::Number.new("1")
+
+      expect(described_class.filter_values(number)).to be(number)
+      expect(described_class.filter_values("abc")).to eq("abc")
+      expect(described_class.filter_values(nil)).to be_nil
+    end
+
+    it "rewraps a multi-value Formula's value in a new Formula" do
+      one = Plurimath::Math::Number.new("1")
+      two = Plurimath::Math::Number.new("2")
+      formula = Plurimath::Math::Formula.new([one, two])
+
+      result = described_class.filter_values(formula)
+
+      expect(result).to eq(Plurimath::Math::Formula.new([one, two]))
+      expect(result).not_to be(formula)
+    end
+
+    it "unwraps a single-value Formula to its element" do
+      number = Plurimath::Math::Number.new("1")
+      formula = Plurimath::Math::Formula.new([number])
+
+      expect(described_class.filter_values(formula)).to be(number)
+    end
+  end
+
+  describe ".string_to_html_entity" do
+    it "encodes a unicode character hexadecimally" do
+      expect(described_class.string_to_html_entity("∑")).to eq("&#x2211;")
+    end
+
+    it "leaves plain ASCII words unchanged" do
+      expect(described_class.string_to_html_entity("bar")).to eq("bar")
+      expect(described_class.string_to_html_entity("abc")).to eq("abc")
+      expect(described_class.string_to_html_entity("+")).to eq("+")
+    end
+
+    # quirk: an already-encoded entity is encoded again — the leading "&"
+    # becomes "&#x26;", producing a mangled double-encoded string.
+    it "double-encodes an already-encoded entity string" do
+      expect(described_class.string_to_html_entity("&#x2211;"))
+        .to eq("&#x26;#x2211;")
+    end
+
+    it "handles frozen strings without raising" do
+      expect(described_class.string_to_html_entity("∑".freeze)).to eq("&#x2211;")
+    end
+  end
+
+  describe ".html_entity_to_unicode" do
+    it "decodes a hexadecimal entity to its unicode character" do
+      expect(described_class.html_entity_to_unicode("&#x2211;")).to eq("∑")
+    end
+
+    it "decodes named entities" do
+      expect(described_class.html_entity_to_unicode("&sum;")).to eq("∑")
+    end
+
+    it "returns strings without \"&\" untouched (same object)" do
+      string = "bar"
+
+      expect(described_class.html_entity_to_unicode(string)).to be(string)
+    end
+
+    it "leaves a bare ampersand as-is" do
+      expect(described_class.html_entity_to_unicode("a & b")).to eq("a & b")
+    end
+
+    it "returns nil for nil" do
+      expect(described_class.html_entity_to_unicode(nil)).to be_nil
+    end
+
+    it "round-trips through string_to_html_entity" do
+      encoded = described_class.string_to_html_entity("∑")
+
+      expect(described_class.html_entity_to_unicode(encoded)).to eq("∑")
+    end
+  end
+
+  describe ".symbol_object" do
+    # quirk: "ℒ" and "ℛ" are remapped to the asciimath open/close table
+    # tokens "{:" and ":}", which have no symbol class for lang: :omml, so
+    # they end up as plain Symbols with those literal values.
+    it "remaps \"ℒ\" to a Symbol with value \"{:\"" do
+      expect(described_class.symbol_object("ℒ", lang: :omml))
+        .to eq(Plurimath::Math::Symbols::Symbol.new("{:"))
+    end
+
+    it "remaps \"ℛ\" to a Symbol with value \":}\"" do
+      expect(described_class.symbol_object("ℛ", lang: :omml))
+        .to eq(Plurimath::Math::Symbols::Symbol.new(":}"))
+    end
+
+    it "remaps \"ᑕ\" to Paren::Langle via the &#x2329; entity" do
+      expect(described_class.symbol_object("ᑕ", lang: :omml))
+        .to eq(Plurimath::Math::Symbols::Paren::Langle.new)
+    end
+
+    it "remaps \"ᑐ\" to Paren::Rangle via the &#x232a; entity" do
+      expect(described_class.symbol_object("ᑐ", lang: :omml))
+        .to eq(Plurimath::Math::Symbols::Paren::Rangle.new)
+    end
+
+    it "resolves other values through symbols_class" do
+      expect(described_class.symbol_object("+", lang: :omml))
+        .to eq(Plurimath::Math::Symbols::Plus.new)
+    end
+
+    # Mirrors the OMML call site: symbol_object(string_to_html_entity(value)).
+    it "resolves an entity-encoded character to its symbol class" do
+      encoded = described_class.string_to_html_entity("∑")
+
+      expect(described_class.symbol_object(encoded, lang: :omml))
+        .to eq(Plurimath::Math::Symbols::Sum.new)
+    end
+
+    it "wraps unknown values in Symbols::Symbol" do
+      expect(described_class.symbol_object("zzz", lang: :omml))
+        .to eq(Plurimath::Math::Symbols::Symbol.new("zzz"))
+    end
+  end
+
+  describe ".populate_function_classes" do
+    # Mirrors the m:func flow at Omml::Translator#function_to_plurimath:
+    # [f_name value, e value] with lang: :omml.
+    it "resolves a leading function-name String and gives it the next element" do
+      result = described_class.populate_function_classes(
+        ["sin", Plurimath::Math::Number.new("2")], lang: :omml
+      )
+
+      expect(result).to eq(
+        [Plurimath::Math::Function::Sin.new(Plurimath::Math::Number.new("2"))],
+      )
+    end
+
+    # quirk (critical pin): String resolution here calls
+    # mathml_unary_classes WITHOUT omml: true, so a non-CLASSES word falls
+    # through to Symbols::Symbol — NOT Function::Text as the omml: true
+    # fallback would produce.
+    it "resolves an unknown word String to Symbols::Symbol, not Function::Text" do
+      result = described_class.populate_function_classes(
+        ["hello", Plurimath::Math::Number.new("2")], lang: :omml
+      )
+
+      expect(result).to eq(
+        [
+          Plurimath::Math::Symbols::Symbol.new("hello"),
+          Plurimath::Math::Number.new("2"),
+        ],
+      )
+    end
+
+    # quirk (critical pin): same dual-fallback distinction for digits — a
+    # digits-only String becomes Symbols::Symbol here, NOT Math::Number.
+    it "resolves a digits-only String to Symbols::Symbol, not Math::Number" do
+      result = described_class.populate_function_classes(["123"], lang: :omml)
+
+      expect(result).to eq([Plurimath::Math::Symbols::Symbol.new("123")])
+    end
+
+    # quirk: the accent-word guard is mathml-only, so a "bar" String on the
+    # :omml path becomes Function::Bar and consumes the next element.
+    it "promotes a \"bar\" String to Function::Bar consuming the next element" do
+      result = described_class.populate_function_classes(
+        ["bar", Plurimath::Math::Number.new("2")], lang: :omml
+      )
+
+      expect(result).to eq(
+        [Plurimath::Math::Function::Bar.new(Plurimath::Math::Number.new("2"))],
+      )
+    end
+
+    # quirk: "frac" resolves to an empty Function::Frac, but the binary pass
+    # only slots parameters for classes present in UNICODE_SYMBOLS (or Mod),
+    # so the Frac stays empty and the arguments are left alongside it.
+    it "leaves a resolved Frac empty without slotting the trailing arguments" do
+      result = described_class.populate_function_classes(
+        ["frac", Plurimath::Math::Number.new("1"), Plurimath::Math::Number.new("2")],
+        lang: :omml,
+      )
+
+      expect(result).to eq(
+        [
+          Plurimath::Math::Function::Frac.new,
+          Plurimath::Math::Number.new("1"),
+          Plurimath::Math::Number.new("2"),
+        ],
+      )
+    end
+
+    it "slots both operands around a \"mod\" String" do
+      result = described_class.populate_function_classes(
+        [Plurimath::Math::Number.new("1"), "mod", Plurimath::Math::Number.new("2")],
+        lang: :omml,
+      )
+
+      expect(result).to eq(
+        [
+          Plurimath::Math::Function::Mod.new(
+            Plurimath::Math::Number.new("1"),
+            Plurimath::Math::Number.new("2"),
+          ),
+        ],
+      )
+    end
+
+    # quirk: a leading "mod" (index 0) skips the parameter_one branch and
+    # then `mrow.delete_at(0)` removes the Mod object itself, assigning it
+    # as its own parameter_two — the Mod vanishes from the result entirely.
+    it "drops a leading Mod from the mrow" do
+      result = described_class.populate_function_classes(
+        ["mod", Plurimath::Math::Number.new("1"), Plurimath::Math::Number.new("2")],
+        lang: :omml,
+      )
+
+      expect(result).to eq(
+        [Plurimath::Math::Number.new("1"), Plurimath::Math::Number.new("2")],
+      )
+    end
+
+    it "fills parameter_three of a partially-filled ternary from the next element" do
+      ternary = Plurimath::Math::Function::Underover.new(
+        Plurimath::Math::Symbols::Sum.new,
+        Plurimath::Math::Number.new("1"),
+        nil,
+      )
+
+      result = described_class.populate_function_classes(
+        [ternary, Plurimath::Math::Number.new("9")], lang: :omml
+      )
+
+      expect(result).to eq(
+        [
+          Plurimath::Math::Function::Underover.new(
+            Plurimath::Math::Symbols::Sum.new,
+            Plurimath::Math::Number.new("1"),
+            Plurimath::Math::Number.new("9"),
+          ),
+        ],
+      )
+    end
+
+    it "flattens nested arrays and compacts nils before processing" do
+      result = described_class.populate_function_classes(
+        [["sin"], nil, [Plurimath::Math::Number.new("2")]], lang: :omml
+      )
+
+      expect(result).to eq(
+        [Plurimath::Math::Function::Sin.new(Plurimath::Math::Number.new("2"))],
+      )
+    end
+
+    it "returns [] for an empty mrow" do
+      expect(described_class.populate_function_classes([], lang: :omml)).to eq([])
+    end
+
+    it "passes non-String, non-function elements through untouched" do
+      formula = Plurimath::Math::Formula.new([Plurimath::Math::Function::Text.new("sin")])
+      argument = Plurimath::Math::Number.new("2")
+
+      result = described_class.populate_function_classes([formula, argument], lang: :omml)
+
+      expect(result[0]).to be(formula)
+      expect(result[1]).to be(argument)
+    end
+
+    it "only lets a unary function at index 0 consume the following element" do
+      result = described_class.populate_function_classes(
+        [
+          Plurimath::Math::Number.new("3"),
+          "sin",
+          Plurimath::Math::Number.new("2"),
+        ],
+        lang: :omml,
+      )
+
+      expect(result).to eq(
+        [
+          Plurimath::Math::Number.new("3"),
+          Plurimath::Math::Function::Sin.new,
+          Plurimath::Math::Number.new("2"),
+        ],
+      )
+    end
+
+    it "fills an already-instantiated empty unary function at index 0" do
+      result = described_class.populate_function_classes(
+        [Plurimath::Math::Function::Sin.new, Plurimath::Math::Number.new("2")],
+        lang: :omml,
+      )
+
+      expect(result).to eq(
+        [Plurimath::Math::Function::Sin.new(Plurimath::Math::Number.new("2"))],
+      )
+    end
+  end
+
+  describe ".binary_function_classes" do
+    # Direct-call pins: via populate_function_classes the unary pass converts
+    # every String first, so the binary pass's own String-conversion line is
+    # reachable only by calling this method directly (it is public surface and
+    # moves with the OMML helper in A1).
+    it "converts a String element to its class during the binary pass" do
+      mrow = ["sum", Plurimath::Math::Symbols::Symbol.new("x")]
+
+      described_class.binary_function_classes(mrow, lang: :omml)
+
+      expect(mrow[0]).to eq(Plurimath::Math::Function::Sum.new)
+      expect(mrow[1]).to eq(Plurimath::Math::Symbols::Symbol.new("x"))
+    end
+
+    # NOTE: the UNICODE_SYMBOLS-slotting branch (utility.rb:711-715, incl. the
+    # `under:` keyword path) is unreachable in practice: no BinaryFunction
+    # descendant has a UNICODE_SYMBOLS-invertible class_name (sum/prod/int/oint
+    # are TernaryFunction; bar/vec/hat/obrace/... are UnaryFunction; Mod is
+    # handled by its own earlier branch). Verified empirically 2026-07-07;
+    # dead-branch candidate for the A4 TODO flags.
+    it "leaves a TernaryFunction converted from a String unslotted (no binary branch applies)" do
+      operand = Plurimath::Math::Symbols::Symbol.new("x")
+      mrow = [operand.dup, Plurimath::Math::Function::Sum.new]
+
+      described_class.binary_function_classes(mrow, lang: :omml, under: true)
+
+      expect(mrow).to eq([operand, Plurimath::Math::Function::Sum.new])
+    end
+  end
+
+  describe ".get_table_class" do
+    it "resolves environment names to Table subclasses" do
+      {
+        "matrix" => Plurimath::Math::Function::Table::Matrix,
+        "pmatrix" => Plurimath::Math::Function::Table::Pmatrix,
+        "bmatrix" => Plurimath::Math::Function::Table::Bmatrix,
+        "vmatrix" => Plurimath::Math::Function::Table::Vmatrix,
+        "array" => Plurimath::Math::Function::Table::Array,
+        "align" => Plurimath::Math::Function::Table::Align,
+        "split" => Plurimath::Math::Function::Table::Split,
+        "multline" => Plurimath::Math::Function::Table::Multline,
+        "cases" => Plurimath::Math::Function::Table::Cases,
+        "eqarray" => Plurimath::Math::Function::Table::Eqarray,
+      }.each do |name, klass|
+        expect(described_class.get_table_class(name)).to eq(klass)
+      end
+    end
+
+    it "accepts Parslet::Slice input" do
+      expect(described_class.get_table_class(slice("matrix"))).to eq(
+        Plurimath::Math::Function::Table::Matrix,
+      )
+    end
+
+    it "raises NameError for an unknown environment" do
+      expect { described_class.get_table_class("nope") }.to raise_error(NameError)
+    end
+  end
+
+  describe ".parens_hash" do
+    it "maps asciimath paren tokens to Paren classes" do
+      hash = described_class.parens_hash(:asciimath)
+
+      expect(hash).to be_a(Hash)
+      expect(hash["("]).to eq(Plurimath::Math::Symbols::Paren::Lround)
+      expect(hash[")"]).to eq(Plurimath::Math::Symbols::Paren::Rround)
+      expect(hash["["]).to eq(Plurimath::Math::Symbols::Paren::Lsquare)
+      expect(hash["|"]).to eq(Plurimath::Math::Symbols::Paren::Vert)
+      expect(hash["{:"]).to eq(Plurimath::Math::Symbols::Paren::OpenParen)
+    end
+
+    it "sorts keys by descending length" do
+      keys = described_class.parens_hash(:asciimath).keys
+
+      expect(keys.each_cons(2).all? { |a, b| a.length >= b.length }).to be(true)
+    end
+
+    # quirk: the per-language memo means skipables are only honored on the
+    # first build — later calls return the memoized hash unchanged.
+    it "ignores skipables once the language table is memoized" do
+      first = described_class.parens_hash(:asciimath)
+      second = described_class.parens_hash(:asciimath, skipables: ["lround"])
+
+      expect(second).to be(first)
+      expect(second["("]).to eq(Plurimath::Math::Symbols::Paren::Lround)
+    end
+
+    it "omits skipable paren classes when building a language table" do
+      # Memo plumbing: force a fresh :latex build so the skipables branch is
+      # exercised deterministically, then restore the prior memo entry.
+      described_class.parens_hash(:asciimath)
+      memo = described_class.class_variable_get(:@@parens)
+      original = memo.delete(:latex)
+      begin
+        built = described_class.parens_hash(:latex, skipables: ["lcurly"])
+
+        expect(built.values).not_to include(Plurimath::Math::Symbols::Paren::Lcurly)
+        expect(built).not_to have_key("\\{")
+        expect(built["("]).to eq(Plurimath::Math::Symbols::Paren::Lround)
+      ensure
+        memo[:latex] = original if original
+      end
+    end
+
+    it "includes every paren class when built without skipables" do
+      described_class.parens_hash(:asciimath)
+      memo = described_class.class_variable_get(:@@parens)
+      original = memo.delete(:latex)
+      begin
+        built = described_class.parens_hash(:latex)
+
+        expect(built["\\{"]).to eq(Plurimath::Math::Symbols::Paren::Lcurly)
+      ensure
+        # Never leave the skipables-free build memoized: production builds
+        # :latex with skipables ["lcurly"] (Latex::Constants).
+        memo.delete(:latex)
+        memo[:latex] = original if original
+      end
+    end
+
+    it "returns an empty hash for a language with no paren inputs" do
+      expect(described_class.parens_hash(:no_such_language)).to eq({})
+    end
+  end
+
+  describe ".symbol_value" do
+    it "matches Comma objects when the value contains a comma" do
+      expect(described_class.symbol_value(Plurimath::Math::Symbols::Comma.new, ",")).to be(true)
+    end
+
+    # quirk: any value merely CONTAINING "," matches a Comma object, the value
+    # is not compared to the symbol at all
+    it "matches Comma objects for any value containing a comma" do
+      expect(described_class.symbol_value(Plurimath::Math::Symbols::Comma.new, "a,b")).to be(true)
+    end
+
+    it "matches Minus objects when the value contains a minus" do
+      expect(described_class.symbol_value(Plurimath::Math::Symbols::Minus.new, "-")).to be(true)
+    end
+
+    it "matches Paren::Vert objects when the value contains a pipe" do
+      expect(described_class.symbol_value(Plurimath::Math::Symbols::Paren::Vert.new, "|")).to be(true)
+    end
+
+    it "matches generic Symbol objects whose value contains the string" do
+      expect(described_class.symbol_value(Plurimath::Math::Symbols::Symbol.new("|"), "|")).to be(true)
+    end
+
+    # quirk: substring match, not equality ("ab" contains "b")
+    it "matches generic Symbol objects by substring inclusion" do
+      expect(described_class.symbol_value(Plurimath::Math::Symbols::Symbol.new("ab"), "b")).to be(true)
+    end
+
+    it "matches Linebreak objects against the literal \\\\ value" do
+      expect(described_class.symbol_value(Plurimath::Math::Function::Linebreak.new, "\\\\")).to be(true)
+    end
+
+    it "returns false for non-symbol objects" do
+      expect(described_class.symbol_value(Plurimath::Math::Number.new("1"), ",")).to be(false)
+    end
+
+    it "returns false for a nil object" do
+      expect(described_class.symbol_value(nil, "|")).to be(false)
+    end
+
+    it "returns false when the symbol value does not contain the string" do
+      expect(described_class.symbol_value(Plurimath::Math::Symbols::Symbol.new("x"), "y")).to be(false)
+    end
+
+    it "returns false for a Symbol whose value is nil" do
+      expect(described_class.symbol_value(Plurimath::Math::Symbols::Symbol.new, "x")).to be(false)
+    end
+
+    # quirk: nil value crashes on String#include?(nil) once a Symbol object
+    # reaches the value-inclusion branch
+    it "raises TypeError for a Symbol object and nil value" do
+      expect { described_class.symbol_value(Plurimath::Math::Symbols::Symbol.new("a"), nil) }
+        .to raise_error(TypeError)
+    end
+  end
+
+  describe ".table_separator" do
+    def build_tr
+      Plurimath::Math::Function::Tr.new(
+        [
+          Plurimath::Math::Function::Td.new([Plurimath::Math::Number.new("1")]),
+          Plurimath::Math::Function::Td.new([Plurimath::Math::Number.new("2")]),
+        ],
+      )
+    end
+
+    def vert_td
+      Plurimath::Math::Function::Td.new([Plurimath::Math::Symbols::Paren::Vert.new])
+    end
+
+    it "inserts a vert Td AFTER the matching column for the default solid symbol" do
+      tr = build_tr
+      described_class.table_separator(["solid", "none"], [tr])
+
+      expected = Plurimath::Math::Function::Tr.new(
+        [
+          Plurimath::Math::Function::Td.new([Plurimath::Math::Number.new("1")]),
+          vert_td,
+          Plurimath::Math::Function::Td.new([Plurimath::Math::Number.new("2")]),
+        ],
+      )
+      expect(tr).to eq(expected)
+    end
+
+    it "inserts a vert Td AT the matching column index for the | symbol" do
+      tr = build_tr
+      described_class.table_separator(["|"], [tr], symbol: "|")
+
+      expected = Plurimath::Math::Function::Tr.new(
+        [
+          vert_td,
+          Plurimath::Math::Function::Td.new([Plurimath::Math::Number.new("1")]),
+          Plurimath::Math::Function::Td.new([Plurimath::Math::Number.new("2")]),
+        ],
+      )
+      expect(tr).to eq(expected)
+    end
+
+    it "mutates and returns the same value array" do
+      tr = build_tr
+      value = [tr]
+      result = described_class.table_separator(["solid"], value)
+
+      expect(result).to be(value)
+      expect(result.first).to be(tr)
+    end
+
+    it "returns the value unchanged for a nil separator" do
+      tr = build_tr
+      expect(described_class.table_separator(nil, [tr])).to eq([build_tr])
+      expect(tr.parameter_one.length).to eq(2)
+    end
+
+    it "returns the value unchanged when no separator entry matches the symbol" do
+      tr = build_tr
+      described_class.table_separator(["none"], [tr])
+      expect(tr).to eq(build_tr)
+    end
+  end
+
+  describe ".validate_left_right" do
+    it "flags formulas whose first value is Function::Left" do
+      formula = Plurimath::Math::Formula.new(
+        [Plurimath::Math::Function::Left.new("("), Plurimath::Math::Number.new("2")],
+      )
+      # Formula#initialize resets the wrapper to false when it starts with Left
+      expect(formula.left_right_wrapper).to be(false)
+
+      described_class.validate_left_right([formula])
+      expect(formula.left_right_wrapper).to be(true)
+    end
+
+    it "returns the fields array itself, tolerating nils and non-formulas" do
+      formula = Plurimath::Math::Formula.new(
+        [Plurimath::Math::Function::Left.new("("), Plurimath::Math::Number.new("2")],
+      )
+      fields = [formula, nil, Plurimath::Math::Number.new("3")]
+
+      result = described_class.validate_left_right(fields)
+      expect(result).to be(fields)
+      expect(result.length).to eq(3)
+    end
+
+    it "leaves formulas not starting with Function::Left untouched" do
+      formula = Plurimath::Math::Formula.new([Plurimath::Math::Number.new("2")], false)
+      described_class.validate_left_right([formula])
+      expect(formula.left_right_wrapper).to be(false)
+    end
+
+    it "returns an empty array when called with no fields" do
+      expect(described_class.validate_left_right).to eq([])
+    end
+  end
+
+  describe ".validate_math_zone" do
+    it "returns false for nil" do
+      expect(described_class.validate_math_zone(nil, lang: :asciimath)).to be(false)
+    end
+
+    it "returns false for text-classed objects (number)" do
+      expect(described_class.validate_math_zone(Plurimath::Math::Number.new("2"), lang: :asciimath)).to be(false)
+    end
+
+    it "returns false for text-classed objects (text)" do
+      expect(described_class.validate_math_zone(Plurimath::Math::Function::Text.new("hi"), lang: :asciimath)).to be(false)
+    end
+
+    it "returns false for symbols" do
+      expect(described_class.validate_math_zone(Plurimath::Math::Symbols::Symbol.new("x"), lang: :asciimath)).to be(false)
+    end
+
+    it "returns true for non-text objects such as Frac" do
+      frac = Plurimath::Math::Function::Frac.new(
+        Plurimath::Math::Number.new("1"), Plurimath::Math::Number.new("2")
+      )
+      expect(described_class.validate_math_zone(frac, lang: :asciimath)).to be(true)
+    end
+
+    # quirk: the formula branch returns Enumerable#find results, so an
+    # all-text formula yields nil (falsy) rather than false
+    it "returns nil for a formula containing only text-like values" do
+      formula = Plurimath::Math::Formula.new(
+        [Plurimath::Math::Symbols::Symbol.new("a"), Plurimath::Math::Number.new("1")],
+      )
+      expect(described_class.validate_math_zone(formula, lang: :asciimath)).to be_nil
+    end
+
+    it "returns nil for an empty formula" do
+      expect(described_class.validate_math_zone(Plurimath::Math::Formula.new([]), lang: :asciimath)).to be_nil
+    end
+
+    # quirk: for a formula the found object (a dup, not the original instance)
+    # is returned, not true
+    it "returns a dup of the first non-text value for a mixed formula" do
+      frac = Plurimath::Math::Function::Frac.new(
+        Plurimath::Math::Number.new("1"), Plurimath::Math::Number.new("2")
+      )
+      formula = Plurimath::Math::Formula.new(
+        [Plurimath::Math::Symbols::Symbol.new("a"), frac],
+      )
+
+      result = described_class.validate_math_zone(formula, lang: :asciimath)
+      expect(result).to eq(frac)
+      expect(result).not_to be(frac)
+    end
+  end
+
+  describe ".filter_math_zone_values" do
+    it "returns an empty array for an empty value" do
+      expect(described_class.filter_math_zone_values([], lang: :asciimath)).to eq([])
+    end
+
+    # quirk: nil is not guarded (nil&.empty? is falsy), so it crashes
+    it "raises NoMethodError for nil" do
+      expect { described_class.filter_math_zone_values(nil, lang: :asciimath) }
+        .to raise_error(NoMethodError)
+    end
+
+    it "merges consecutive text-like values into one space-joined Text" do
+      result = described_class.filter_math_zone_values(
+        [Plurimath::Math::Symbols::Symbol.new("a"), Plurimath::Math::Symbols::Symbol.new("b")],
+        lang: :asciimath,
+      )
+      expect(result).to eq([Plurimath::Math::Function::Text.new("a b")])
+    end
+
+    it "keeps non-text values and flushes pending text before them" do
+      frac = Plurimath::Math::Function::Frac.new(
+        Plurimath::Math::Number.new("1"), Plurimath::Math::Number.new("2")
+      )
+      result = described_class.filter_math_zone_values(
+        [Plurimath::Math::Symbols::Symbol.new("a"), frac],
+        lang: :asciimath,
+      )
+      expect(result).to eq(
+        [Plurimath::Math::Function::Text.new("a"), frac],
+      )
+    end
+
+    it "uses #value for numbers" do
+      result = described_class.filter_math_zone_values(
+        [Plurimath::Math::Number.new("42")], lang: :asciimath
+      )
+      expect(result).to eq([Plurimath::Math::Function::Text.new("42")])
+    end
+
+    it "renders generic symbols through the :omml branch of symbol_to_text" do
+      result = described_class.filter_math_zone_values(
+        [Plurimath::Math::Symbols::Symbol.new("abc")], lang: :omml
+      )
+      expect(result).to eq([Plurimath::Math::Function::Text.new("abc")])
+      expect(result.first.parameter_one).to eq("abc")
+    end
+
+    it "renders generic symbols through the :unicodemath branch of symbol_to_text" do
+      result = described_class.filter_math_zone_values(
+        [Plurimath::Math::Symbols::Symbol.new("abc")], lang: :unicodemath
+      )
+      expect(result).to eq([Plurimath::Math::Function::Text.new("abc")])
+      expect(result.first.parameter_one).to eq("abc")
+    end
+
+    it "renders generic symbols through the requested language (latex)" do
+      result = described_class.filter_math_zone_values(
+        [Plurimath::Math::Symbols::Symbol.new("a")], lang: :latex
+      )
+      expect(result).to eq([Plurimath::Math::Function::Text.new("a")])
+    end
+
+    it "renders generic symbols through the requested language (mathml)" do
+      result = described_class.filter_math_zone_values(
+        [Plurimath::Math::Symbols::Symbol.new("a"), Plurimath::Math::Symbols::Symbol.new("b")],
+        lang: :mathml,
+      )
+      expect(result).to eq([Plurimath::Math::Function::Text.new("a b")])
+    end
+
+    # quirk: only class_name "symbol"/"number"/"text" (plus plus/minus/circ/
+    # equal display objects) count as text; named symbol subclasses such as
+    # Alpha (class_name "alpha") pass through untouched
+    it "passes named symbol subclasses through untouched" do
+      result = described_class.filter_math_zone_values(
+        [Plurimath::Math::Symbols::Alpha.new], lang: :latex
+      )
+      expect(result).to eq([Plurimath::Math::Symbols::Alpha.new])
+    end
+
+    it "treats display-text symbols like Plus as mergeable text" do
+      result = described_class.filter_math_zone_values(
+        [Plurimath::Math::Symbols::Plus.new, Plurimath::Math::Number.new("1")],
+        lang: :asciimath,
+      )
+      expect(result).to eq([Plurimath::Math::Function::Text.new("+ 1")])
+    end
+  end
+
+  describe ".primes_constants" do
+    it "returns the prefixed primes merged with sprime" do
+      expect(described_class.primes_constants).to eq(
+        pppprime: "&#x2057;",
+        ppprime: "&#x2034;",
+        pprime: "&#x2033;",
+        prime: "&#x2032;",
+        sprime: "&#x27;",
+      )
+    end
+
+    it "returns a fresh unfrozen hash on every call" do
+      first = described_class.primes_constants
+      second = described_class.primes_constants
+      expect(first).not_to be(second)
+      expect(first).not_to be_frozen
+    end
+  end
+
+  describe ".hexcode_in_input" do
+    it "returns the first &#x...; entry of the symbol's unicodemath input" do
+      expect(described_class.hexcode_in_input(Plurimath::Math::Symbols::Comma.new)).to eq("&#x2c;")
+      expect(described_class.hexcode_in_input(Plurimath::Math::Symbols::Prime.new)).to eq("&#x2032;")
+      expect(described_class.hexcode_in_input(Plurimath::Math::Symbols::Alpha.new)).to eq("&#x3b1;")
+    end
+
+    it "returns nil when the unicodemath input has no hex entity entry" do
+      # Bar's unicodemath INPUT is [["¯"]] — no &#x..; entry
+      expect(described_class.hexcode_in_input(Plurimath::Math::Symbols::Bar.new)).to be_nil
+    end
+
+    it "returns nil when the symbol has no unicodemath input at all" do
+      # the Paren base class has INPUT == {}
+      expect(described_class.hexcode_in_input(Plurimath::Math::Symbols::Paren.new)).to be_nil
+    end
+  end
+
+  describe ".notations_to_mask" do
+    it "maps single known notations to their inverted mask" do
+      expect(described_class.notations_to_mask("top")).to eq(14)
+      expect(described_class.notations_to_mask("bottom")).to eq(13)
+      expect(described_class.notations_to_mask("left")).to eq(11)
+      expect(described_class.notations_to_mask("horizontalstrike")).to eq(31)
+    end
+
+    it "sums multiple notations before inverting the low nibble" do
+      expect(described_class.notations_to_mask("top bottom left right")).to eq(0)
+      expect(described_class.notations_to_mask("updiagonalstrike downdiagonalstrike")).to eq(207)
+    end
+
+    # quirk: a single unknown notation yields nil, and NilClass#^ turns
+    # `nil ^ 15` into literal true instead of raising
+    it "returns true for a single unknown notation" do
+      expect(described_class.notations_to_mask("unknown")).to be(true)
+    end
+
+    # quirk: an unknown notation mixed with known ones crashes on nil + Integer
+    it "raises NoMethodError when an unknown notation is mixed with known ones" do
+      expect { described_class.notations_to_mask("unknown top") }
+        .to raise_error(NoMethodError)
+    end
+  end
+
+  describe ".ox_element" do
+    it "builds an element with the given name and no attributes or children" do
+      element = described_class.ox_element("mi")
+      expect(element.name).to eq("mi")
+      expect(element.attributes).to eq({})
+      expect(element.nodes).to eq([])
+      expect(dumped(element)).to eq("<mi/>")
+    end
+
+    it "prefixes the name with the namespace" do
+      element = described_class.ox_element("mo", namespace: "m")
+      expect(element.name).to eq("m:mo")
+      expect(dumped(element)).to eq("<m:mo/>")
+    end
+
+    it "sets plain attributes readable via #attributes and #[]" do
+      element = described_class.ox_element(
+        "mstyle", attributes: { mathvariant: "bold", displaystyle: "true" }
+      )
+      expect(element.attributes).to eq("mathvariant" => "bold", "displaystyle" => "true")
+      expect(element["mathvariant"]).to eq("bold")
+      expect(dumped(element)).to eq('<mstyle mathvariant="bold" displaystyle="true"/>')
+    end
+
+    it "serializes namespaced attributes identically on both engines" do
+      element = described_class.ox_element(
+        "naryPr", namespace: "m", attributes: { "m:val": "1" }
+      )
+      expect(dumped(element)).to eq('<m:naryPr m:val="1"/>')
+      # engine-stable composite lookup: exactly one of the two keys hits
+      expect(element["m:val"] || element["val"]).to eq("1")
+    end
+
+    # quirk: the in-memory attribute key for namespaced attributes is
+    # engine-dependent — Ox keeps the "m:" prefix, Oga strips it (and its []
+    # only answers to the stripped name). Serialization is identical.
+    it "exposes namespaced attribute hash keys differently per engine" do
+      element = described_class.ox_element(
+        "naryPr", namespace: "m", attributes: { "m:val": "1" }
+      )
+      if oga_engine?
+        expect(element.attributes).to eq("val" => "1")
+        expect(element["val"]).to eq("1")
+        expect(element["m:val"]).to be_nil
+      else
+        expect(element.attributes).to eq("m:val" => "1")
+        expect(element["m:val"]).to eq("1")
+        expect(element["val"]).to be_nil
+      end
+    end
+
+    it "decodes HTML entities in attribute values to unicode" do
+      element = described_class.ox_element(
+        "chr", namespace: "m", attributes: { "m:val": "&#x2211;" }
+      )
+      expect(dumped(element)).to eq('<m:chr m:val="∑"/>')
+      expect(element["m:val"] || element["val"]).to eq("∑")
+    end
+
+    it "accepts the default empty-array attributes" do
+      element = described_class.ox_element("mrow", attributes: [])
+      expect(element.attributes).to eq({})
+      expect(dumped(element)).to eq("<mrow/>")
+    end
+  end
+
+  describe ".update_nodes" do
+    it "appends nodes in order and returns the same element" do
+      row = described_class.ox_element("mrow")
+      mi = described_class.ox_element("mi") << "x"
+      mo = described_class.ox_element("mo") << "+"
+      mn = described_class.ox_element("mn") << "1"
+
+      result = described_class.update_nodes(row, [mi, mo, mn])
+      expect(result).to be(row)
+      expect(result.nodes.map(&:name)).to eq(%w[mi mo mn])
+      expect(dumped(result)).to eq("<mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow>")
+    end
+
+    it "skips nils and flattens nested arrays recursively" do
+      # mirrors Nary#omml_nary_tag, where omml_parameter entries can be nil
+      # and nested arrays of elements
+      row = described_class.ox_element("mrow")
+      mi = described_class.ox_element("mi") << "x"
+      mo = described_class.ox_element("mo") << "+"
+      mn = described_class.ox_element("mn") << "1"
+
+      described_class.update_nodes(row, [mi, nil, [mo, nil, [mn]], nil])
+      expect(row.nodes.map(&:name)).to eq(%w[mi mo mn])
+      expect(dumped(row)).to eq("<mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow>")
+    end
+
+    it "returns the element unchanged for a nil node list" do
+      row = described_class.update_nodes(described_class.ox_element("mrow"), nil)
+      expect(row.name).to eq("mrow")
+      expect(row.nodes).to eq([])
+    end
+
+    it "returns the element unchanged for a list of nils" do
+      row = described_class.update_nodes(described_class.ox_element("mrow"), [nil, nil])
+      expect(row.nodes).to eq([])
+    end
+
+    it "appends plain strings as text children" do
+      element = described_class.update_nodes(
+        described_class.ox_element("mtext"), ["hello", nil, "world"]
+      )
+      expect(element.nodes).to eq(%w[hello world])
+      expect(dumped(element)).to eq("<mtext>helloworld</mtext>")
+    end
+  end
+
+  describe ".rpr_element" do
+    it "builds a w:rPr with a Cambria Math w:rFonts child by default" do
+      rpr = described_class.rpr_element
+      expect(rpr.name).to eq("w:rPr")
+      expect(rpr.nodes.map(&:name)).to eq(%w[w:rFonts])
+      expect(dumped(rpr)).to eq(
+        '<w:rPr><w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/></w:rPr>',
+      )
+    end
+
+    it "appends a w:i child when wi_tag is true" do
+      rpr = described_class.rpr_element(wi_tag: true)
+      expect(rpr.nodes.map(&:name)).to eq(%w[w:rFonts w:i])
+      expect(dumped(rpr)).to eq(
+        '<w:rPr><w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/><w:i/></w:rPr>',
+      )
+    end
+  end
+
+  describe ".pr_element" do
+    it "builds <main>Pr in the given namespace wrapping an rpr element" do
+      # mirrors the pervasive Utility.pr_element("ctrl", true, namespace: "m")
+      pr = described_class.pr_element("ctrl", true, namespace: "m")
+      expect(pr.name).to eq("m:ctrlPr")
+      expect(pr.nodes.map(&:name)).to eq(%w[w:rPr])
+      expect(dumped(pr)).to eq(
+        "<m:ctrlPr>" \
+        '<w:rPr><w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/><w:i/></w:rPr>' \
+        "</m:ctrlPr>",
+      )
+    end
+
+    it "omits the w:i tag when wi_tag is not passed" do
+      pr = described_class.pr_element("d", namespace: "m")
+      expect(pr.name).to eq("m:dPr")
+      expect(dumped(pr)).to eq(
+        "<m:dPr>" \
+        '<w:rPr><w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/></w:rPr>' \
+        "</m:dPr>",
+      )
+    end
+
+    it "builds an unprefixed tag for the default empty namespace" do
+      pr = described_class.pr_element("box")
+      expect(pr.name).to eq("boxPr")
+    end
+  end
+
+  describe ".capitalize" do
+    it "camelizes underscore-separated names" do
+      expect(described_class.capitalize("some_name")).to eq("SomeName")
+    end
+
+    it "capitalizes single words" do
+      expect(described_class.capitalize("hello")).to eq("Hello")
+    end
+
+    it "accepts symbols via to_s" do
+      expect(described_class.capitalize(:foo_bar)).to eq("FooBar")
+    end
+
+    # quirk: String#capitalize downcases the rest of each segment, so
+    # already-camelized or uppercased input is squashed
+    it "downcases the tail of each segment" do
+      expect(described_class.capitalize("SomeName")).to eq("Somename")
+      expect(described_class.capitalize("UPPER_case")).to eq("UpperCase")
+    end
+
+    it "returns an empty string for nil" do
+      expect(described_class.capitalize(nil)).to eq("")
+    end
+
+    it "collapses consecutive underscores" do
+      expect(described_class.capitalize("double__underscore")).to eq("DoubleUnderscore")
+    end
+  end
+
+  describe ".paren_files" do
+    it "returns the static list of paren classes" do
+      files = described_class.paren_files
+      expect(files).to be_an(Array)
+      expect(files.length).to eq(24)
+      expect(files).to all(be_a(Class))
+    end
+
+    it "contains only direct Paren subclasses" do
+      files = described_class.paren_files
+      expect(files).to include(
+        Plurimath::Math::Symbols::Paren::Lround,
+        Plurimath::Math::Symbols::Paren::Vert,
+      )
+      expect(files.all? { |klass| klass < Plurimath::Math::Symbols::Paren }).to be(true)
+    end
+  end
+
+  describe ".symbols_files" do
+    it "returns the static list of symbol classes" do
+      files = described_class.symbols_files
+      expect(files).to be_an(Array)
+      expect(files.length).to eq(1436)
+      expect(files).to all(be_a(Class))
+    end
+
+    it "includes named symbol classes" do
+      expect(described_class.symbols_files).to include(
+        Plurimath::Math::Symbols::Comma,
+        Plurimath::Math::Symbols::Minus,
+        Plurimath::Math::Symbols::Alpha,
+      )
+    end
+
+    # quirk: descendants tracking only records DIRECT subclasses, so the list
+    # includes the Paren base class itself but none of the paren leaf classes
+    it "includes the Paren base class but not paren leaf classes" do
+      files = described_class.symbols_files
+      expect(files).to include(Plurimath::Math::Symbols::Paren)
+      expect(files).not_to include(Plurimath::Math::Symbols::Paren::Lround)
+    end
+  end
+end

--- a/spec/plurimath/utility_spec.rb
+++ b/spec/plurimath/utility_spec.rb
@@ -751,6 +751,10 @@ RSpec.describe Plurimath::Utility do
         expect(built).not_to have_key("\\{")
         expect(built["("]).to eq(Plurimath::Math::Symbols::Paren::Lround)
       ensure
+        # Restore the exact prior memo state: drop the entry this example built,
+        # then put back the original only if there was one. Leaving a freshly
+        # memoized :latex entry behind would leak state across examples.
+        memo.delete(:latex)
         memo[:latex] = original if original
       end
     end


### PR DESCRIPTION

This PR moves the markup-specific helpers out of the shared `Plurimath::Utility` into per-language modules, so each format's helpers live with that format and `Utility` keeps only cross-format code.

## Changes

- Move UnicodeMath, LaTeX, AsciiMath, HTML, and OMML helper methods out of `Plurimath::Utility` into per-language `Plurimath::<Lang>::Utility` modules (31 methods across the five formats).
- Keep only cross-format generics — class/symbol lookup, value filtering, entity encoding, and shared model-serialization helpers — in `Utility`, shrinking it from 1,123 to 734 lines.
- Subclass `Utility` from each new module so existing bareword `Utility.<method>` calls resolve unchanged: moved methods on the subclass, retained generics inherited. No call sites change.
- Reorganize the `Utility` specs to mirror `lib/`: one `utility_spec.rb` per module, each with a single top-level `describe`.
- Add characterization specs pinning the current behavior of every relocated and retained method.

No public API, output, or behavior change. First in a short series cleaning up `Utility`; later PRs consolidate the XML helpers, redesign function-name resolution, and remove flagged dead code.
