### PR TITLE
Parse bare MathML/OMML names with a character or structural form as literal identifiers

### DIFF
--- a/lib/plurimath/mathml/constants.rb
+++ b/lib/plurimath/mathml/constants.rb
@@ -174,22 +174,25 @@ module Plurimath
         "+": "+",
         "-": "-",
       }.freeze
-      # Over/under accent decorations. In MathML these are only ever expressed
-      # as <mover>/<munder> with a base (recovered from their diacritic
-      # CHARACTER), never as a bare <mi>/<mo> identifier word. So a bare token
-      # whose text is one of these names is a literal identifier (e.g. the unit
-      # "bar"), not the accent. See unitsml/unitsdb#123.
-      ACCENT_WORDS = %w[
-        bar overline ul hat vec tilde dot ddot obrace ubrace overleftrightarrow
+      # Named operators that have no dedicated MathML/OMML representation — no
+      # unicode character and no structural element — so a bare <mi>/<mo>/<m:t>
+      # word (e.g. <mi>sin</mi>, <m:t>min</m:t>) is their only written form and
+      # resolves to the function class. Every other CLASSES entry has a proper
+      # form — a diacritic character (bar/hat/vec via <mover>), a unicode symbol
+      # (sum/prod/int via &#x2211; etc.), or a structural element (frac via
+      # <mfrac>/<m:f>, sqrt via <msqrt>) — so its bare word is a literal
+      # identifier, not the function. See PR #450 (which introduced this for accents).
+      NAMED_FUNCTION_WORDS = %w[
+        arccos arcsin arctan sin cos tan sec csc cot sinh cosh tanh coth sech
+        csch log ln exp det dim gcd lcm glb lub max min mod
       ].freeze
 
-      # True when +string+ is a bare word naming an over/under accent. Such
-      # tokens are literal identifiers in MathML (the accent itself is a
-      # diacritic character inside <mover>/<munder>), so callers must not
-      # promote them to accent operators. AsciiMath/LaTeX word forms
-      # (bar(x), \bar{x}) are parsed elsewhere and never reach this predicate.
-      def self.accent_word?(string)
-        ACCENT_WORDS.include?(string&.strip)
+      # True when +string+ is a bare word naming an operator that has no other
+      # MathML/OMML representation, so it legitimately resolves to its function
+      # class. Words for constructs that DO have a character/structural form
+      # (accents, sum/prod/int, frac/sqrt/...) return false and stay literal.
+      def self.named_function_word?(string)
+        NAMED_FUNCTION_WORDS.include?(string&.strip)
       end
 
       CLASSES = %w[

--- a/lib/plurimath/utility.rb
+++ b/lib/plurimath/utility.rb
@@ -337,7 +337,7 @@ lang: nil)
         symbol = Mathml::Constants::UNICODE_SYMBOLS[unicode.strip.to_sym]
         if classes.include?(symbol&.strip)
           get_class(symbol.strip).new
-        elsif classes.any?(string&.strip) && !(lang == :mathml && Mathml::Constants.accent_word?(string))
+        elsif classes.any?(string&.strip) && word_resolvable?(string, lang)
           get_class(string.strip).new
         elsif omml
           text_classes(string,
@@ -345,6 +345,18 @@ lang: nil)
         else
           symbols_class(unicode, lang: lang)
         end
+      end
+
+      # In MathML and OMML most constructs have a dedicated character or
+      # structural element (<mfrac>, <m:f>, &#x2211;, <mover> + diacritic), so a
+      # bare word token resolves to its function class only when the name has no
+      # such representation (sin, min, log, ...). Parslet-based languages
+      # (AsciiMath bar(x), LaTeX \frac{}{}) parse words in their own grammars and
+      # never reach this resolver, so they keep resolving every CLASSES word.
+      def word_resolvable?(string, lang)
+        return true unless %i[mathml omml].include?(lang)
+
+        Mathml::Constants.named_function_word?(string)
       end
 
       def symbols_class(string, lang:, table: false)

--- a/spec/plurimath/mathml/parser_spec.rb
+++ b/spec/plurimath/mathml/parser_spec.rb
@@ -921,13 +921,15 @@ RSpec.describe Plurimath::Mathml::Parser do
       MATHML
     end
 
-    it "returns formula of sum and frac" do
+    # A bare <mo>frac</mo> is a literal identifier (a fraction is <mfrac>), so it
+    # parses as a Symbol, not Function::Frac. See PR #450.
+    it "returns formula of sum with a literal frac identifier" do
       expected_value = Plurimath::Math::Formula.new([
                                                       Plurimath::Math::Function::Sum.new(
                                                         Plurimath::Math::Formula.new([
                                                                                        Plurimath::Math::Symbols::Symbol.new("i"),
                                                                                        Plurimath::Math::Symbols::Equal.new,
-                                                                                       Plurimath::Math::Function::Frac.new,
+                                                                                       Plurimath::Math::Symbols::Symbol.new("frac"),
                                                                                      ]),
                                                         Plurimath::Math::Number.new("33"),
                                                       ),

--- a/spec/plurimath/omml_spec.rb
+++ b/spec/plurimath/omml_spec.rb
@@ -22,6 +22,21 @@ RSpec.describe Plurimath::Omml do
   describe ".to_latex, to_mathml, to_asciimath" do
     subject(:formula) { described_class.new(string).to_formula }
 
+    context "a bare structural word ('frac') stays a literal identifier" do
+      let(:string) do
+        <<~OMML
+          <m:oMath xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math">
+            <m:r><m:t>frac</m:t></m:r>
+          </m:oMath>
+        OMML
+      end
+
+      it "resolves 'frac' as text, not the Frac function" do
+        expect(formula.to_latex).to eq('\text{frac}')
+        expect(formula.to_asciimath).to eq('"frac"')
+      end
+    end
+
     context "contains example #01" do
       let(:string) do
         <<~OMML

--- a/spec/plurimath/utility_spec.rb
+++ b/spec/plurimath/utility_spec.rb
@@ -60,40 +60,40 @@ RSpec.describe Plurimath::Utility do
         expect(result).to eq(Plurimath::Math::Function::Sin.new)
       end
 
-      # quirk: the bare word "frac" resolves to an argument-less
-      # Function::Frac in MathML even though a bare <mi>frac</mi> is an
-      # identifier, not a fraction.
-      it "resolves \"frac\" to an empty Function::Frac for lang: :mathml" do
+      # A bare "frac" is a literal identifier in MathML — a fraction is written
+      # structurally as <mfrac>, never as the word — so it stays a Symbol.
+      # See PR #450 (accent handling this generalizes).
+      it "keeps \"frac\" a literal Symbol for lang: :mathml" do
         result = described_class.mathml_unary_classes(["frac"], lang: :mathml)
 
-        expect(result).to eq(Plurimath::Math::Function::Frac.new)
+        expect(result).to eq(Plurimath::Math::Symbols::Symbol.new("frac"))
       end
 
-      it "resolves \"frac\" to an empty Function::Frac for lang: :omml with omml: true" do
+      it "keeps \"frac\" a literal Text for lang: :omml with omml: true" do
         result = described_class.mathml_unary_classes(
           ["frac"], lang: :omml, omml: true
         )
 
-        expect(result).to eq(Plurimath::Math::Function::Frac.new)
+        expect(result).to eq(Plurimath::Math::Function::Text.new("frac", lang: :omml))
       end
     end
 
-    context "accent-word guard (PR #450)" do
+    context "representation-aware word resolution" do
       it "keeps \"bar\" a literal Symbol for lang: :mathml" do
         result = described_class.mathml_unary_classes(["bar"], lang: :mathml)
 
         expect(result).to eq(Plurimath::Math::Symbols::Symbol.new("bar"))
       end
 
-      # quirk: the accent-word guard is scoped to lang == :mathml only, so
-      # the same bare word "bar" still promotes to Function::Bar on the OMML
-      # path. Known bug — pinned as-is.
-      it "still promotes \"bar\" to Function::Bar for lang: :omml with omml: true" do
+      # The rule applies to OMML too: "bar" is an accent (written as a diacritic
+      # character), so the bare word is a literal — now a Function::Text on the
+      # OMML text-run path, extending the MathML accent rule from PR #450.
+      it "keeps \"bar\" a literal Text for lang: :omml with omml: true" do
         result = described_class.mathml_unary_classes(
           ["bar"], lang: :omml, omml: true
         )
 
-        expect(result).to eq(Plurimath::Math::Function::Bar.new)
+        expect(result).to eq(Plurimath::Math::Function::Text.new("bar", lang: :omml))
       end
     end
 
@@ -514,22 +514,25 @@ RSpec.describe Plurimath::Utility do
       expect(result).to eq([Plurimath::Math::Symbols::Symbol.new("123")])
     end
 
-    # quirk: the accent-word guard is mathml-only, so a "bar" String on the
-    # :omml path becomes Function::Bar and consumes the next element.
-    it "promotes a \"bar\" String to Function::Bar consuming the next element" do
+    # "bar" is an accent (a diacritic character), so the bare word is a literal
+    # on the OMML path (mrow revalidation → symbols_class), not a Function::Bar;
+    # it no longer consumes the next element. See PR #450.
+    it "keeps a \"bar\" String a literal Symbol, not consuming the next element" do
       result = described_class.populate_function_classes(
         ["bar", Plurimath::Math::Number.new("2")], lang: :omml
       )
 
       expect(result).to eq(
-        [Plurimath::Math::Function::Bar.new(Plurimath::Math::Number.new("2"))],
+        [
+          Plurimath::Math::Symbols::Symbol.new("bar"),
+          Plurimath::Math::Number.new("2"),
+        ],
       )
     end
 
-    # quirk: "frac" resolves to an empty Function::Frac, but the binary pass
-    # only slots parameters for classes present in UNICODE_SYMBOLS (or Mod),
-    # so the Frac stays empty and the arguments are left alongside it.
-    it "leaves a resolved Frac empty without slotting the trailing arguments" do
+    # "frac" is written structurally (<m:f>), so the bare word is a literal
+    # Symbol on the OMML path and the trailing arguments are left alongside it.
+    it "keeps a \"frac\" String a literal Symbol, leaving trailing arguments" do
       result = described_class.populate_function_classes(
         ["frac", Plurimath::Math::Number.new("1"), Plurimath::Math::Number.new("2")],
         lang: :omml,
@@ -537,7 +540,7 @@ RSpec.describe Plurimath::Utility do
 
       expect(result).to eq(
         [
-          Plurimath::Math::Function::Frac.new,
+          Plurimath::Math::Symbols::Symbol.new("frac"),
           Plurimath::Math::Number.new("1"),
           Plurimath::Math::Number.new("2"),
         ],
@@ -652,16 +655,16 @@ RSpec.describe Plurimath::Utility do
   end
 
   describe ".binary_function_classes" do
-    # Direct-call pins: via populate_function_classes the unary pass converts
-    # every String first, so the binary pass's own String-conversion line is
-    # reachable only by calling this method directly (it is public surface and
-    # moves with the OMML helper in A1).
-    it "converts a String element to its class during the binary pass" do
+    # Direct-call pin: the binary pass converts a leading String via
+    # mathml_unary_classes. "sum" has a unicode representation (&#x2211;), so
+    # the bare word is now a literal Symbol rather than Function::Sum. The
+    # String-conversion line is still exercised. See PR #450.
+    it "converts a String element via the resolver during the binary pass" do
       mrow = ["sum", Plurimath::Math::Symbols::Symbol.new("x")]
 
       described_class.binary_function_classes(mrow, lang: :omml)
 
-      expect(mrow[0]).to eq(Plurimath::Math::Function::Sum.new)
+      expect(mrow[0]).to eq(Plurimath::Math::Symbols::Symbol.new("sum"))
       expect(mrow[1]).to eq(Plurimath::Math::Symbols::Symbol.new("x"))
     end
 


### PR DESCRIPTION
This PR makes MathML and OMML bare-token resolution representation-aware: a bare `<mi>`/`<mo>`/`<m:t>` token whose text matches a construct that the format already expresses another way is now parsed as a literal identifier, not the construct.

## Changes

- Keep a bare `frac`/`sqrt`/`root` token literal — these are written structurally (`<mfrac>`/`<msqrt>`/`<mroot>`, `<m:f>`/`<m:rad>`), never as the word.
- Keep a bare `sum`/`prod`/`int`/`oint` token literal — these are written as a character (`&#x2211;`/`&#x220f;`/`&#x222b;`/`&#x222e;`).
- Keep a bare accent token (`bar`/`hat`/`vec`/`tilde`/…) literal in OMML as well as MathML — these are written as a diacritic character inside `<mover>`/`<munder>` (`<m:acc>`); #450 already did this for MathML, this extends it to OMML.
- Keep resolving names that have no other representation — the trigonometric/hyperbolic operators and `log`/`ln`/`exp`/`det`/`dim`/`gcd`/`lcm`/`min`/`max`/`mod`, which are only ever written as the bare word — to their function class.
- Leave structural production untouched: `<mfrac>` still builds a fraction, `<mover>` still builds an accent, and `&#x2211;` still builds a sum — only bare-word resolution changes.

A construct that has a dedicated character or structural element is always written that way, so a bare token that merely matches its name is an ordinary identifier. #450 applied this rule to accent names; this PR extends the same rule to every name that has a representation — structural and character forms — and to OMML.

**Behavior change:** bare MathML/OMML tokens whose text is `frac`, `sqrt`, `sum`, `bar`, and the like now parse as literal identifiers (and, on the OMML text path, as `Text`) instead of the corresponding function. Correct documents are unaffected — they use the structural/character forms, which are untouched.

Extends #450
Depends on #453
