### PR TITLE
Fix the `base_is_sub_or_sup?` mini-sup typo and drop a stray debug print

### DIFF
--- a/lib/plurimath/math/function/nary.rb
+++ b/lib/plurimath/math/function/nary.rb
@@ -140,7 +140,7 @@ module Plurimath
             next unless sym_instance.is_nary_symbol?
 
             intent_name = sym_instance.nary_intent_name
-            next pp symbol.const_source_location(:INPUT) if intent_name.nil?
+            next if intent_name.nil?
 
             hash[intent_name.gsub(/\s|-/, "_").to_sym] = intent_name
           end

--- a/lib/plurimath/unicode_math/utility.rb
+++ b/lib/plurimath/unicode_math/utility.rb
@@ -195,7 +195,7 @@ module Plurimath
           when Math::Function::Fenced
             base_is_sub_or_sup?(base.parameter_two.first)
           when Math::Symbols::Symbol, Math::Number
-            base.mini_sub_sized || base_mini_sup_sized
+            base.mini_sub_sized || base.mini_sup_sized
           end
         end
 

--- a/spec/plurimath/unicode_math/utility_spec.rb
+++ b/spec/plurimath/unicode_math/utility_spec.rb
@@ -498,22 +498,29 @@ RSpec.describe Plurimath::UnicodeMath::Utility do
       end
     end
 
-    # quirk: the second operand of the || is the typo `base_mini_sup_sized`
-    # (instead of `base.mini_sup_sized`), which is undefined on Utility. Any
-    # Symbol/Number whose mini_sub_sized is falsy therefore raises NameError
-    # — including mini_SUP_sized values, which can never return true.
-    context "with a Symbol that is not mini-sub-sized" do
-      it "raises NameError from the base_mini_sup_sized typo" do
-        expect { described_class.base_is_sub_or_sup?(symbol("a")) }
-          .to raise_error(NameError, /base_mini_sup_sized/)
+    context "with a Symbol that is neither mini-sub- nor mini-sup-sized" do
+      it "returns nil" do
+        expect(described_class.base_is_sub_or_sup?(symbol("a"))).to be_nil
       end
+    end
 
-      it "raises NameError even when the symbol is mini-sup-sized" do
-        expect do
+    context "with a mini-sup-sized Symbol" do
+      it "returns true" do
+        expect(
           described_class.base_is_sub_or_sup?(
             symbol("a", mini_sup_sized: true),
-          )
-        end.to raise_error(NameError, /base_mini_sup_sized/)
+          ),
+        ).to be(true)
+      end
+    end
+
+    context "with a mini-sup-sized Number" do
+      it "returns true" do
+        expect(
+          described_class.base_is_sub_or_sup?(
+            number("2", mini_sup_sized: true),
+          ),
+        ).to be(true)
       end
     end
 


### PR DESCRIPTION
This PR fixes two small bugs that the characterization specs had pinned as `# quirk:` during the behavior-preserving `Utility` dissolution, and flips those specs to the corrected behavior.

## Changes

- Fix the `base_is_sub_or_sup?` typo in `unicode_math/utility.rb` — the second operand of the `||` was the bareword `base_mini_sup_sized` instead of `base.mini_sup_sized`, so any base that was not mini-sub-sized raised `NameError` and a mini-sup-sized base could never be detected. It now uses the same `mini_sub_sized || mini_sup_sized` form as `Math::Number`.
- Remove a stray `pp` debug print from `Nary`'s `@@names` memoization in `math/function/nary.rb`; the printed value was discarded by the enclosing `with_object` block, so only the debug output is gone.
- Update the two `base_is_sub_or_sup?` characterization specs to assert the corrected `nil` / `true` results for both Symbol and Number.

Depends on #459
