### PR TITLE
Harden `Utility`/helper methods against nil and unknown inputs

### DIFF
--- a/lib/plurimath/math/model_helper.rb
+++ b/lib/plurimath/math/model_helper.rb
@@ -36,7 +36,7 @@ module Plurimath
         end
 
         def filter_math_zone_values(value, lang:, intent: false, options: nil)
-          return [] if value && value.empty?
+          return [] if value.nil? || value.empty?
 
           new_arr = []
           temp_array = []
@@ -72,7 +72,7 @@ module Plurimath
           mask = notations.split.map do |notation|
             Utility::MASK_CLASSES.key(notation)
           end
-          mask.inject(*:+) ^ 15
+          mask.compact.sum ^ 15
         end
 
         private

--- a/lib/plurimath/omml/utility.rb
+++ b/lib/plurimath/omml/utility.rb
@@ -14,7 +14,7 @@ module Plurimath
         def valid_class(object)
           text = object.extract_class_name_from_text
           (object.extractable? && Asciimath::Constants::SUB_SUP_CLASSES.include?(text)) ||
-            Latex::Constants::SYMBOLS[text.to_sym] == :power_base
+            Latex::Constants::SYMBOLS[text&.to_sym] == :power_base
         end
 
         def resolve_text_token(value)

--- a/lib/plurimath/utility.rb
+++ b/lib/plurimath/utility.rb
@@ -200,6 +200,8 @@ module Plurimath
       end
 
       def symbol_value(object, value)
+        return false if value.nil?
+
         (object.is_a?(Math::Symbols::Comma) if value&.include?(",")) ||
           (object.is_a?(Math::Symbols::Minus) if value&.include?("-")) ||
           (object.is_a?(Math::Symbols::Paren::Vert) if value&.include?("|")) ||

--- a/spec/plurimath/math/model_helper_spec.rb
+++ b/spec/plurimath/math/model_helper_spec.rb
@@ -97,10 +97,9 @@ RSpec.describe Plurimath::Math::ModelHelper do
       expect(described_class.filter_math_zone_values([], lang: :asciimath)).to eq([])
     end
 
-    # quirk: nil is not guarded (nil&.empty? is falsy), so it crashes
-    it "raises NoMethodError for nil" do
-      expect { described_class.filter_math_zone_values(nil, lang: :asciimath) }
-        .to raise_error(NoMethodError)
+    it "returns [] for nil" do
+      expect(described_class.filter_math_zone_values(nil, lang: :asciimath))
+        .to eq([])
     end
 
     it "merges consecutive text-like values into one space-joined Text" do
@@ -194,16 +193,12 @@ RSpec.describe Plurimath::Math::ModelHelper do
       expect(described_class.notations_to_mask("updiagonalstrike downdiagonalstrike")).to eq(207)
     end
 
-    # quirk: a single unknown notation yields nil, and NilClass#^ turns
-    # `nil ^ 15` into literal true instead of raising
-    it "returns true for a single unknown notation" do
-      expect(described_class.notations_to_mask("unknown")).to be(true)
+    it "returns the empty-mask default (15) for a single unrecognized notation" do
+      expect(described_class.notations_to_mask("unknown")).to eq(15)
     end
 
-    # quirk: an unknown notation mixed with known ones crashes on nil + Integer
-    it "raises NoMethodError when an unknown notation is mixed with known ones" do
-      expect { described_class.notations_to_mask("unknown top") }
-        .to raise_error(NoMethodError)
+    it "drops unrecognized notations mixed with known ones" do
+      expect(described_class.notations_to_mask("unknown top")).to eq(14)
     end
   end
 end

--- a/spec/plurimath/math_zone_spec.rb
+++ b/spec/plurimath/math_zone_spec.rb
@@ -291,6 +291,18 @@ RSpec.describe Plurimath::Math do
         expect(formula).to eql(expected_value)
       end
     end
+
+    context "AsciiMath Math zone of an empty fence (nil fenced content)" do
+      let(:exp) { "()" }
+
+      it "renders the empty fence instead of crashing" do
+        expected_value = <<~MATHZONE
+          |_ Math zone
+            |_ "()"
+        MATHZONE
+        expect(formula).to eql(expected_value)
+      end
+    end
   end
 
   describe ".to_display(:mathml)" do

--- a/spec/plurimath/omml/utility_spec.rb
+++ b/spec/plurimath/omml/utility_spec.rb
@@ -51,13 +51,10 @@ RSpec.describe Plurimath::Omml::Utility do
         .to be(false)
     end
 
-    # quirk: Formula#extract_class_name_from_text returns nil when the
-    # single value is not a Function::Text, and valid_class calls
-    # nil.to_sym — raising NoMethodError instead of returning false.
-    it "raises NoMethodError for a Formula wrapping a non-Text value" do
+    it "returns false for a Formula wrapping a non-Text value" do
       formula = Plurimath::Math::Formula.new([Plurimath::Math::Number.new("3")])
 
-      expect { described_class.valid_class(formula) }.to raise_error(NoMethodError)
+      expect(described_class.valid_class(formula)).to be(false)
     end
 
     # quirk: FontStyle#extract_class_name_from_text always returns

--- a/spec/plurimath/omml_spec.rb
+++ b/spec/plurimath/omml_spec.rb
@@ -37,6 +37,24 @@ RSpec.describe Plurimath::Omml do
       end
     end
 
+    context "sSubSup with a multi-run (compound) base" do
+      let(:string) do
+        <<~OMML
+          <m:oMath xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math">
+            <m:sSubSup>
+              <m:e><m:r><m:t>a</m:t></m:r><m:r><m:t>b</m:t></m:r></m:e>
+              <m:sub><m:r><m:t>1</m:t></m:r></m:sub>
+              <m:sup><m:r><m:t>2</m:t></m:r></m:sup>
+            </m:sSubSup>
+          </m:oMath>
+        OMML
+      end
+
+      it "converts the compound base instead of crashing" do
+        expect(formula.to_latex).to eq('\text{a} \text{b}_{1}^{2}')
+      end
+    end
+
     context "contains example #01" do
       let(:string) do
         <<~OMML

--- a/spec/plurimath/unicode_math_spec.rb
+++ b/spec/plurimath/unicode_math_spec.rb
@@ -165,4 +165,20 @@ RSpec.describe Plurimath::UnicodeMath do
       end
     end
   end
+
+  describe "#to_unicodemath MathML" do
+    subject(:string) { formula.to_unicodemath }
+
+    let(:formula) { Plurimath::Math.parse(mathml_string, :mathml) }
+
+    context "menclose mixing a known and an unrecognized notation" do
+      let(:mathml_string) do
+        '<math><menclose notation="top radical"><mi>x</mi></menclose></math>'
+      end
+
+      it "drops the unknown notation and masks on the known one" do
+        expect(string).to eq("▭(14&x)")
+      end
+    end
+  end
 end

--- a/spec/plurimath/utility_spec.rb
+++ b/spec/plurimath/utility_spec.rb
@@ -430,11 +430,9 @@ RSpec.describe Plurimath::Utility do
       expect(described_class.symbol_value(Plurimath::Math::Symbols::Symbol.new, "x")).to be(false)
     end
 
-    # quirk: nil value crashes on String#include?(nil) once a Symbol object
-    # reaches the value-inclusion branch
-    it "raises TypeError for a Symbol object and nil value" do
-      expect { described_class.symbol_value(Plurimath::Math::Symbols::Symbol.new("a"), nil) }
-        .to raise_error(TypeError)
+    it "returns false for a Symbol object and nil value" do
+      expect(described_class.symbol_value(Plurimath::Math::Symbols::Symbol.new("a"), nil))
+        .to be(false)
     end
   end
 


### PR DESCRIPTION
This PR fixes five nil/unknown-input quirks across four methods that should handle those inputs gracefully. Each was pinned as a `# quirk:` during the behavior-preserving `Utility` dissolution, and this flips them, and their specs, to the corrected behavior.

## Changes

- Guard `Omml::Utility#valid_class` with `text&.to_sym` so a `Formula` wrapping a non-`Text` value returns `false` instead of raising `NoMethodError` on `nil.to_sym` (reachable from OMML `<m:sSubSup>` with a multi-run base).
- Return `false` from `Utility.symbol_value` for a `nil` value, which previously hit `String#include?(nil)` → `TypeError`; the method already treats nil as false in its other branches.
- Return `[]` from `Math::ModelHelper.filter_math_zone_values` for `nil`, which previously fell through the guard → `NoMethodError` (reachable via `to_display("()")`, where an empty fence has a nil `parameter_two`).
- Drop unrecognized notation words in `Math::ModelHelper.notations_to_mask` (`compact`) and seed the sum from `0`, so it always returns an integer mask instead of crashing on `nil + Integer` or returning a bogus boolean (`nil ^ 15` → `true`); this matches how the rest of the codebase, and the inverse `enclosure_attrs`, treat unrecognized notations. (This is the fifth quirk — `notations_to_mask` had two: the mixed-crash and the single-unknown boolean.)
- Update each method's characterization spec to the corrected result, and add conversion-level specs for the three publicly-reachable cases: empty-fence `to_display("()")`, a menclose mixing known/unknown notations `to_unicodemath` (`▭(14&x)`), and an OMML `sSubSup` with a compound base `to_latex` (`\text{a} \text{b}_{1}^{2}`). (`symbol_value`-nil and the single-unknown `notations_to_mask` case are unreachable from the public API, so they stay method-level.)


Depends on #460
