### PR TITLE
Handle typed Word namespace elements in OMML runs

### DIFF
--- a/lib/plurimath/omml/formula_transformation.rb
+++ b/lib/plurimath/omml/formula_transformation.rb
@@ -102,7 +102,15 @@ module Plurimath
       end
 
       def linebreak_child?(node, child)
+        return true if ct_br_child?(child)
+
         child == "" && node.respond_to?(:br) && node.br == ""
+      end
+
+      def ct_br_child?(child)
+        return false unless child.is_a?(Object)
+
+        Lutaml::Model::Utils.base_class_name(child.class.name) == "CTBr"
       end
 
       def styled_run?(children)
@@ -110,11 +118,18 @@ module Plurimath
       end
 
       def styled_run_value(children)
-        font = children.first
+        fonts, content = children.partition do |child|
+          font_style_class?(child)
+        end
+        font = fonts.first
         font.new(
-          Utility.filter_values(children.drop(1)),
+          Utility.filter_values(content),
           Utility::FONT_STYLES.key(font).to_s,
         )
+      end
+
+      def font_style_class?(value)
+        value.is_a?(Class) && value <= Math::Function::FontStyle
       end
 
       def script_function_value(script_class, node)

--- a/lib/plurimath/omml/translator.rb
+++ b/lib/plurimath/omml/translator.rb
@@ -58,6 +58,8 @@ module Plurimath
              "CTCtrlPr", "CTBoxPr" then nil
         when "CTRPr" then word_run_properties_to_plurimath(node)
         when "CTRPR" then math_run_properties_to_plurimath(node)
+        when "CTBr" then Math::Function::Linebreak.new
+        when "CTWordprocessingEmpty", "CTWordprocessingText" then nil
         else
           unsupported_node!(node)
         end

--- a/plurimath.gemspec
+++ b/plurimath.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "htmlentities"
   spec.add_dependency "lutaml-model", "~> 0.8.0"
   spec.add_dependency "mml", "~> 2.3.6"
-  spec.add_dependency "omml", "~> 0.2.0"
+  spec.add_dependency "omml", "~> 0.2.5"
   spec.add_dependency "ostruct"
   spec.add_dependency "ox"
   spec.add_dependency "parslet"

--- a/spec/plurimath/omml/translator_spec.rb
+++ b/spec/plurimath/omml/translator_spec.rb
@@ -110,5 +110,131 @@ RSpec.describe Plurimath::Omml::Translator do
       expect(Plurimath::Omml.new(omml).to_formula.to_asciimath)
         .to eq('frac("x")("y") 2')
     end
+
+    context "when an m:r carries both m:rPr and w:rPr styling" do
+      let(:omml) do
+        <<~OMML
+          <m:oMath xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math"
+                   xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+            <m:r>
+              <m:rPr><m:sty m:val="p"/></m:rPr>
+              <w:rPr><w:i/></w:rPr>
+              <m:t>x</m:t>
+            </m:r>
+          </m:oMath>
+        OMML
+      end
+
+      it "prefers the math-namespace style and renders without raising" do
+        formula = Plurimath::Omml.new(omml).to_formula
+        expect(formula.to_asciimath).to eq('rm("x")')
+        expect(formula.to_latex).to eq("\\mathrm{\\text{x}}")
+      end
+    end
+
+    context "when m:rPr/m:sty=b coexists with w:rPr/w:i" do
+      let(:omml) do
+        <<~OMML
+          <m:oMath xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math"
+                   xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+            <m:r>
+              <m:rPr><m:sty m:val="b"/></m:rPr>
+              <w:rPr><w:i/></w:rPr>
+              <m:t>x</m:t>
+            </m:r>
+          </m:oMath>
+        OMML
+      end
+
+      it "prefers the math-namespace style (bold) over the Word-namespace italic" do
+        expect(Plurimath::Omml.new(omml).to_formula.to_asciimath)
+          .to eq('mathbf("x")')
+      end
+    end
+
+    context "when an m:r carries WordprocessingML run inner content" do
+      shared_examples "round-trips without raising" do
+        it "parses and renders without raising UnsupportedNodeError" do
+          formula = Plurimath::Omml.new(omml).to_formula
+          expect { formula.to_asciimath }.not_to raise_error
+          expect { formula.to_latex }.not_to raise_error
+          expect { formula.to_mathml }.not_to raise_error
+        end
+      end
+
+      context "with <w:br/> (line break)" do
+        let(:omml) do
+          <<~OMML
+            <m:oMath xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math"
+                     xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <m:r><m:t>x</m:t><w:br/></m:r>
+            </m:oMath>
+          OMML
+        end
+
+        include_examples "round-trips without raising"
+
+        it "emits a Linebreak node for the break" do
+          formula = Plurimath::Omml.new(omml).to_formula
+          expect(formula.to_asciimath).to include("\\")
+        end
+      end
+
+      context "with text on both sides of <w:br/>" do
+        let(:omml) do
+          <<~OMML
+            <m:oMath xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math"
+                     xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <m:r><m:t>x</m:t><w:br/><m:t>y</m:t></m:r>
+            </m:oMath>
+          OMML
+        end
+
+        it "preserves the text after the line break" do
+          formula = Plurimath::Omml.new(omml).to_formula
+          expect(formula.to_asciimath).to eq("\"x\" \\\n  \"y\"")
+          expect(formula.to_latex).to eq("\\text{x} \\\\  \\text{y}")
+        end
+      end
+
+      context "with <w:tab/>" do
+        let(:omml) do
+          <<~OMML
+            <m:oMath xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math"
+                     xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <m:r><m:t>a</m:t><w:tab/><m:t>b</m:t></m:r>
+            </m:oMath>
+          OMML
+        end
+
+        include_examples "round-trips without raising"
+      end
+
+      context "with <w:cr/> (carriage return)" do
+        let(:omml) do
+          <<~OMML
+            <m:oMath xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math"
+                     xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <m:r><m:t>a</m:t><w:cr/><m:t>b</m:t></m:r>
+            </m:oMath>
+          OMML
+        end
+
+        include_examples "round-trips without raising"
+      end
+
+      context "with <w:noBreakHyphen/>" do
+        let(:omml) do
+          <<~OMML
+            <m:oMath xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math"
+                     xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <m:r><m:t>a</m:t><w:noBreakHyphen/><m:t>b</m:t></m:r>
+            </m:oMath>
+          OMML
+        end
+
+        include_examples "round-trips without raising"
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

omml 0.2.5 typed WordprocessingML elements that appear inside `<m:r>` (math runs) as proper model classes (`CTBr`, `CTWordprocessingEmpty`, `CTWordprocessingText`). Plurimath's OMML translator needed to catch up.

- **Translator dispatch** (`lib/plurimath/omml/translator.rb`): `CTBr` → `Math::Function::Linebreak.new`; `CTWordprocessingEmpty` / `CTWordprocessingText` → `nil` (Word-only formatting/revision markers, not math content).
- **`linebreak_child?`** (`lib/plurimath/omml/formula_transformation.rb`): also recognizes typed `CTBr` instances in addition to the legacy empty-string form.
- **`styled_run_value`** (`lib/plurimath/omml/formula_transformation.rb`): partitions children into font-style classes vs. content so that a single `<m:r>` carrying both `<m:rPr><m:sty>` and `<w:rPr>` no longer leaks a bare `FontStyle::*` class into the formula tree. Math-namespace style wins per OMML spec.
- **`plurimath.gemspec`**: requires `omml ~> 0.2.5` so consumers get the typed namespace handling plus the upstream fix that preserves `<m:t>` text after `<w:br/>`.

## Test plan

- [x] `bundle exec rspec spec/plurimath/omml/ spec/plurimath/math/formula/omml_spec.rb spec/plurimath/math/function/font_style_spec.rb` — 491 examples, 0 failures
- [x] New regression contexts in `spec/plurimath/omml/translator_spec.rb` cover `<w:br/>`, `<w:tab/>`, `<w:cr/>`, `<w:noBreakHyphen/>`, text-after-`<w:br/>`, and the `m:rPr/m:sty + w:rPr` styling combo
- [x] Manual repro on real-world Word OMML patterns: `sSubSup`/`sSub`/`bar`/`acc`/`f`/`nary` with `<m:ctrlPr><w:rPr>` all parse and render
