### PR TITLE
Bump mml to ~> 2.4.0 and lutaml-model to ~> 0.8.17

### DIFF
--- a/plurimath.gemspec
+++ b/plurimath.gemspec
@@ -29,8 +29,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.add_dependency "bigdecimal"
   spec.add_dependency "htmlentities"
-  spec.add_dependency "lutaml-model", "~> 0.8.0"
-  spec.add_dependency "mml", ">= 2.3"
+  spec.add_dependency "lutaml-model", "~> 0.8.17"
+  spec.add_dependency "mml", "~> 2.4.0"
   spec.add_dependency "omml", "~> 0.2.5"
   spec.add_dependency "ostruct"
   spec.add_dependency "ox"


### PR DESCRIPTION
## Summary

- `mml` ~> 2.4.0 — track latest mml release line
- `lutaml-model` ~> 0.8.17 — track latest patch

## Notes

`bundle install` currently fails because all released `unitsml` versions (0.6.0–0.6.7) pin `mml ~> 2.3.6`. A coordinated unitsml release is needed before CI will pass; do not merge until that lands.
