### PR TITLE
Resolve combining-tilde accent to Tilde in UnicodeMath, OMML, and MathML

### DIFF
--- a/lib/plurimath/math/symbols/tilde.rb
+++ b/lib/plurimath/math/symbols/tilde.rb
@@ -3,7 +3,7 @@ module Plurimath
     module Symbols
       class Tilde < Symbol
         INPUT = {
-          unicodemath: [["~"]],
+          unicodemath: [["&#x303;", "~"]],
           asciimath: [["~"]],
           mathml: ["~"],
           latex: [["~"]],

--- a/lib/plurimath/mathml/constants.rb
+++ b/lib/plurimath/mathml/constants.rb
@@ -155,6 +155,16 @@ module Plurimath
         "¯": "bar",
         _: "ul",
       }.freeze
+
+      # Accent characters promoted to their function class ONLY in an accent
+      # position (MathML <mover>, OMML <m:acc>). Kept separate from
+      # UNICODE_SYMBOLS because Text#value= consumes that map as a global
+      # substitution table, so an entry there would also rewrite the character
+      # inside ordinary text runs and bare tokens.
+      CONTEXTUAL_ACCENT_FUNCTIONS = {
+        "&#x303;": "tilde",
+      }.freeze
+
       SYMBOLS = {
         "|": "|",
         "/": "//",

--- a/lib/plurimath/mathml/translator.rb
+++ b/lib/plurimath/mathml/translator.rb
@@ -122,6 +122,12 @@ module Plurimath
         children = content_children(mover)
         base = filter_child(mml_to_plurimath(children[0]))
         overscript = filter_child(mml_to_plurimath(children[1]))
+        # An accent character that has no function mapping arrives as a plain
+        # symbol; promote it here, where it is unambiguously an accent.
+        if overscript.instance_of?(Plurimath::Math::Symbols::Symbol)
+          overscript =
+            Utility.contextual_accent_from_token(overscript.value) || overscript
+        end
         options = {}
         options[:accent] = true if truthy_mathml_bool?(mover.accent)
 

--- a/lib/plurimath/mathml/utility.rb
+++ b/lib/plurimath/mathml/utility.rb
@@ -3,6 +3,19 @@
 module Plurimath
   class Mathml
     module FunctionTokenResolver
+      # Promotes an accent character to its function class. Callers must only
+      # use this from an accent position; elsewhere the character has to stay a
+      # plain symbol/text. Decode-then-encode normalizes both call sites: MathML
+      # passes an already-encoded "&#x303;", OMML passes the raw U+0303.
+      def contextual_accent_from_token(value)
+        return nil if value.nil?
+
+        entity = string_to_html_entity(html_entity_to_unicode(value.to_s))
+        function_name =
+          Mathml::Constants::CONTEXTUAL_ACCENT_FUNCTIONS[entity.strip.to_sym]
+        get_class(function_name).new if function_name
+      end
+
       private
 
       def function_from_token(value)

--- a/lib/plurimath/omml/translator.rb
+++ b/lib/plurimath/omml/translator.rb
@@ -203,7 +203,13 @@ module Plurimath
       def accent_to_plurimath(node)
         pr = first_omml_child(node.acc_pr)
         chr = first_omml_child(pr&.chr)&.val
-        accent = chr ? Utility.resolve_symbol_token(chr) : Math::Function::Hat.new
+        accent =
+          if chr
+            Utility.contextual_accent_from_token(chr) ||
+              Utility.resolve_symbol_token(chr)
+          else
+            Math::Function::Hat.new
+          end
         accent_value(accent, omml_argument_value(node.e))
       end
 

--- a/spec/plurimath/fixtures/formula_modules/unicode_math_transform_values.rb
+++ b/spec/plurimath/fixtures/formula_modules/unicode_math_transform_values.rb
@@ -13435,7 +13435,7 @@ module UnicodeMathTransformValues
                                                Plurimath::Math::Function::Overset.new(
                                                  Plurimath::Math::Symbols::Acute.new,
                                                  Plurimath::Math::Function::Overset.new(
-                                                   Plurimath::Math::Symbols::Symbol.new("&#x303;"),
+                                                   Plurimath::Math::Symbols::Tilde.new,
                                                    Plurimath::Math::Function::Overset.new(
                                                      Plurimath::Math::Symbols::Check.new,
                                                      Plurimath::Math::Function::Overset.new(
@@ -18374,7 +18374,7 @@ module UnicodeMathTransformValues
                                                Plurimath::Math::Formula.new([
                                                                               Plurimath::Math::Symbols::Symbol.new("&#x1d44f;"),
                                                                               Plurimath::Math::Function::Overset.new(
-                                                                                Plurimath::Math::Symbols::Symbol.new("&#x303;"),
+                                                                                Plurimath::Math::Symbols::Tilde.new,
                                                                                 Plurimath::Math::Symbols::Symbol.new("&#x1d450;"),
                                                                                 { accent: true },
                                                                               ),

--- a/spec/plurimath/mathml/parser_spec.rb
+++ b/spec/plurimath/mathml/parser_spec.rb
@@ -24,6 +24,60 @@ RSpec.describe Plurimath::Mathml::Parser do
     end
   end
 
+  # The combining tilde has no function mapping, so it used to leak into the
+  # accent slot as a raw entity. It is now promoted to the Tilde function in an
+  # accent position, mirroring &#x302; -> Hat.
+  context "contains a combining tilde in an mover accent position" do
+    let(:exp) do
+      <<~MATHML
+        <math xmlns='http://www.w3.org/1998/Math/MathML'>
+          <mover accent='true'><mi>c</mi><mo>&#x303;</mo></mover>
+        </math>
+      MATHML
+    end
+
+    it "resolves the combining tilde to the Tilde function" do
+      expected_value = Plurimath::Math::Formula.new([
+                                                      Plurimath::Math::Function::Tilde.new(
+                                                        Plurimath::Math::Symbols::Symbol.new("c"),
+                                                        { accent: true },
+                                                      ),
+                                                    ])
+      expect(formula).to eq(expected_value)
+    end
+
+    it "renders the tilde accent in LaTeX" do
+      expect(formula.to_latex).to eq("\\tilde{c}")
+    end
+  end
+
+  # The promotion above must stay confined to accent positions: outside one, a
+  # combining tilde is ordinary content and has to survive untouched.
+  context "contains a combining tilde outside an accent position" do
+    it "leaves it alone inside a text run" do
+      mathml = "<math xmlns='http://www.w3.org/1998/Math/MathML'><mtext>a&#x303;b</mtext></math>"
+      expect(described_class.new(mathml).parse.to_latex).to eq("\\text{a&#x303;b}")
+    end
+
+    it "leaves a bare mo as a plain symbol" do
+      mathml = "<math xmlns='http://www.w3.org/1998/Math/MathML'><mo>&#x303;</mo></math>"
+      expect(described_class.new(mathml).parse).to eq(
+        Plurimath::Math::Formula.new([
+                                       Plurimath::Math::Symbols::Symbol.new("&#x303;"),
+                                     ]),
+      )
+    end
+
+    it "leaves a bare mi as a plain symbol" do
+      mathml = "<math xmlns='http://www.w3.org/1998/Math/MathML'><mi>&#x303;</mi></math>"
+      expect(described_class.new(mathml).parse).to eq(
+        Plurimath::Math::Formula.new([
+                                       Plurimath::Math::Symbols::Symbol.new("&#x303;"),
+                                     ]),
+      )
+    end
+  end
+
   context "contains mathml string of sum and prod formula" do
     let(:exp) do
       <<~MATHML

--- a/spec/plurimath/omml_spec.rb
+++ b/spec/plurimath/omml_spec.rb
@@ -421,6 +421,31 @@ RSpec.describe Plurimath::Omml do
       end
     end
 
+    context "contains m:acc with combining tilde (U+0303)" do
+      let(:string) do
+        '<m:oMath xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math">' \
+          '<m:acc><m:accPr><m:chr m:val="&#x303;"/></m:accPr>' \
+          "<m:e><m:r><m:t>c</m:t></m:r></m:e></m:acc></m:oMath>"
+      end
+
+      it "resolves the combining tilde to the Tilde function, like the hat accent" do
+        expect(formula).to eq(
+          Plurimath::Math::Formula.new([
+                                         Plurimath::Math::Function::Tilde.new(
+                                           Plurimath::Math::Function::Text.new(
+                                             "c", lang: :omml
+                                           ),
+                                           { accent: true },
+                                         ),
+                                       ]),
+        )
+      end
+
+      it "converts the tilde accent to LaTeX \\tilde" do
+        expect(formula.to_latex).to eq("\\tilde{\\text{c}}")
+      end
+    end
+
     context "contains m:acc with combining overline (U+0305) from plurimath/plurimath#engageny" do
       let(:string) do
         '<m:oMath xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">' \

--- a/spec/plurimath/unicode_math/parser_spec.rb
+++ b/spec/plurimath/unicode_math/parser_spec.rb
@@ -147,5 +147,16 @@ RSpec.describe Plurimath::UnicodeMath::Parser do
         expect(formula.to_latex).to eq("\\overset{^}{a}^{\\prime \\prime}")
       end
     end
+
+    # Regression: "a" + combining tilde (U+0061 U+0303). The combining tilde
+    # had no symbols_class mapping and leaked the raw "&#x303;" entity into the
+    # accent slot; it now resolves to the Tilde symbol.
+    context "with a combining tilde accent" do
+      let(:string) { [0x0061, 0x0303].pack("U*") }
+
+      it "resolves the combining tilde to Tilde with no raw entity in to_latex" do
+        expect(formula.to_latex).to eq("\\overset{\\tilde}{a}")
+      end
+    end
   end
 end

--- a/spec/plurimath/unicode_math/utility_spec.rb
+++ b/spec/plurimath/unicode_math/utility_spec.rb
@@ -98,18 +98,19 @@ RSpec.describe Plurimath::UnicodeMath::Utility do
       end
     end
 
-    # quirk: "&#x303;" (combining tilde) has no dedicated symbols_class
-    # mapping on the :unicodemath path, so — unlike "&#x302;" → Hat — the
-    # accent lands as a generic Symbol carrying the raw entity string.
-    context "with the combining-tilde entity (input like 'ã')" do
-      it "uses a generic Symbol holding the raw entity as the accent" do
+    # "&#x303;" (combining tilde) now resolves through symbols_class to the
+    # Tilde symbol on the :unicodemath path, mirroring "&#x302;" → Hat, so it
+    # no longer leaks the raw entity string into the accent slot. (Reached by
+    # the decomposed form "a" + U+0303, not precomposed NFC "ã" = U+00E3.)
+    context "with the combining-tilde entity (decomposed 'a' + U+0303)" do
+      it "resolves the combining tilde to the Tilde symbol as the accent" do
         accents = [
           { first_value: symbol("a") },
           { accent_symbols: "&#x303;" },
         ]
 
         expect(described_class.unicode_accents(accents))
-          .to eq(overset(symbol("&#x303;"), symbol("a")))
+          .to eq(overset(Plurimath::Math::Symbols::Tilde.new, symbol("a")))
       end
     end
 
@@ -139,7 +140,7 @@ RSpec.describe Plurimath::UnicodeMath::Utility do
         ]
 
         expect(described_class.unicode_accents(accents)).to eq(
-          overset(symbol("&#x303;"), overset(hat, symbol("a"))),
+          overset(Plurimath::Math::Symbols::Tilde.new, overset(hat, symbol("a"))),
         )
       end
     end


### PR DESCRIPTION
This PR fixes an unresolved accent. The combining tilde `&#x303;` had no accent mapping, so — unlike `&#x302;` (hat) — it fell through to a generic `Symbol` carrying the raw entity and leaked into rendered output (`\overset{&#x303;}{…}`). It now resolves to a tilde in every format, matching how each format already handles `&#x302;`.

Each format represents accents differently, and this follows that: UnicodeMath uses the Symbol+Overset form (hat → `\overset{^}{a}`), while MathML and OMML resolve accents to `Function::` classes (hat → `\hat{c}`).

## Changes

- Add `&#x303;` to `Symbols::Tilde`'s `:unicodemath` INPUT (mirroring `Hat`'s `&#x302;`), so `"a"` + U+0303 renders `\overset{\tilde}{a}`.
- Add `Mathml::Constants::CONTEXTUAL_ACCENT_FUNCTIONS`, a small accent-only map kept **separate** from `UNICODE_SYMBOLS` (which `Text#value=` consumes as a global substitution table over ~150 entries — an entry there would rewrite the character inside ordinary text runs and bare tokens).
- Add `Mathml::Utility.contextual_accent_from_token`, used **only** by the two accent positions, so the promotion cannot leak elsewhere.
- Promote a generic accent symbol to its function in `Mathml::Translator#mover_to_overset` and `Omml::Translator#accent_to_plurimath`. MathML `<mover>` now yields `\tilde{c}` and OMML `<m:acc>` yields `\tilde{\text{c}}`, both consistent with their hat handling.
- Add per-format regressions (MathML and OMML: AST + LaTeX), plus negative specs pinning the untouched behavior: `<mtext>a&#x303;b</mtext>` stays `\text{a&#x303;b}`, and a bare `<mo>`/`<mi>` stays a plain `Symbol`.

Outside an accent position the character is unchanged — text runs, bare tokens, and the OMML `limUpp` base (fixture 108) all behave exactly as before, so no fixture needed updating. Two other combining marks in the same table, `&#x20d0;` (lhvec) and `&#x33f;` (Bar), still fall through to a generic `Symbol` — neither has an existing symbol class to resolve to, so both are left for separate work.

Depends on #462
