### PR TITLE
Resolve slash-prefixed prime symbols to standard primes

### DIFF
--- a/lib/plurimath/unicode_math/transform.rb
+++ b/lib/plurimath/unicode_math/transform.rb
@@ -116,7 +116,11 @@ module Plurimath
       end
 
       rule(prefixed_prime: simple(:prime)) do
-        Utility.updated_primes(prime)
+        # Normalize the slash-prefixed name (\prime, \pprime, ...) to its entity
+        # so the enclosing prime_accent_symbols handling resolves it like the
+        # direct entity forms. Resolving to a node here instead would be dropped
+        # by the outer updated_primes re-scan (which only matches entities).
+        Constants::PREFIXED_PRIMES[prime.to_s.to_sym] || prime
       end
 
       rule(unary_functions: simple(:unary)) do

--- a/spec/plurimath/unicode_math/parser_spec.rb
+++ b/spec/plurimath/unicode_math/parser_spec.rb
@@ -158,5 +158,41 @@ RSpec.describe Plurimath::UnicodeMath::Parser do
         expect(formula.to_latex).to eq("\\overset{\\tilde}{a}")
       end
     end
+
+    # Regression: a slash-prefixed prime (\prime, \pprime, ...) reaches the
+    # prime handling as its bare name. Before the fix it resolved to nil,
+    # leaving an empty exponent ("a^{}"); it now maps to the matching prime
+    # symbol like the direct entity form does.
+    context "with a prefixed prime (\\prime)" do
+      let(:string) { "a\\prime" }
+
+      it "resolves to a Prime exponent" do
+        expect(formula.to_latex).to eq("a^{\\prime}")
+      end
+    end
+
+    context "with a repeated prefixed prime (\\prime\\prime)" do
+      let(:string) { "a\\prime\\prime" }
+
+      it "resolves each prefixed prime in the exponent" do
+        expect(formula.to_latex).to eq("a^{\\prime \\prime}")
+      end
+    end
+
+    context "with an accent followed by a prefixed prime" do
+      let(:string) { "#{[0x0061, 0x0302].pack('U*')}\\prime" }
+
+      it "resolves the prefixed prime instead of leaving an empty exponent" do
+        expect(formula.to_latex).to eq("\\overset{^}{a}^{\\prime}")
+      end
+    end
+
+    context "with the higher-order prefixed primes" do
+      it "maps each name to its prime symbol" do
+        expect(described_class.new("a\\pprime").parse.to_latex).to eq("a^{\\dprime}")
+        expect(described_class.new("a\\ppprime").parse.to_latex).to eq("a^{\\trprime}")
+        expect(described_class.new("a\\pppprime").parse.to_latex).to eq("a^{\\fourth}")
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR fixes an empty exponent. A slash-prefixed prime (`\prime`, `\pprime`, `\ppprime`, `\pppprime`) reached the prime handling as its bare name, which `updated_primes` (entity-only) resolved to `nil` — leaving `a\prime` → `a^{}` and the accent form → `\overset{^}{a}^{}`.

## Changes

- In the `prefixed_prime` transform rule, normalize the name to its `PREFIXED_PRIMES` entity (`:prime → &#x2032;`) so the enclosing `updated_primes` resolves it like the direct entity forms. (Resolving to a node in the rule would be dropped by the outer re-scan — that double-processing was the bug.)
- Add parser-level regressions: `a\prime` → `a^{\prime}`, `a\prime\prime` → `a^{\prime \prime}`, `â\prime` → `\overset{^}{a}^{\prime}`, and the `\pprime`/`\ppprime`/`\pppprime` mappings.

Non-prefixed primes are unaffected, as is `\prime` outside postfix syntax (`\prime` alone, `a^(\prime)`), which goes through the generic `slashed_value` path rather than this rule. A multi-atom base with a prefixed prime (`ab\prime`) still raises `TypeError` on a `sequence+sequence` shape no `Power` rule covers — unchanged from the parent branch, and out of scope here.

Depends on #465
