### PR TITLE
Return the wrapped text from `FontStyle#extract_class_name_from_text`

### DIFF
--- a/lib/plurimath/math/function/font_style.rb
+++ b/lib/plurimath/math/function/font_style.rb
@@ -63,7 +63,8 @@ module Plurimath
         end
 
         def extract_class_name_from_text
-          parameter_one.parameter_one if parameter_one.is_a?(Text)
+          return parameter_one.parameter_one if parameter_one.is_a?(Text)
+
           parameter_one.class_name
         end
 

--- a/spec/plurimath/omml/utility_spec.rb
+++ b/spec/plurimath/omml/utility_spec.rb
@@ -57,12 +57,20 @@ RSpec.describe Plurimath::Omml::Utility do
       expect(described_class.valid_class(formula)).to be(false)
     end
 
-    # quirk: FontStyle#extract_class_name_from_text always returns
-    # parameter_one.class_name ("text" for Text params — its first line is a
-    # no-op), so even FontStyle(Text("lim")) is not a valid class.
-    it "returns false for a FontStyle wrapping Text(\"lim\")" do
+    # FontStyle#extract_class_name_from_text now returns the wrapped text, so a
+    # font-styled function word validates just like a bare one.
+    it "returns true for a FontStyle wrapping Text(\"lim\")" do
       font_style = Plurimath::Math::Function::FontStyle.new(
         Plurimath::Math::Function::Text.new("lim"), "mathrm"
+      )
+
+      expect(described_class.valid_class(font_style)).to be(true)
+    end
+
+    # The non-Text branch still falls back to the class name.
+    it "returns false for a FontStyle wrapping a non-Text value" do
+      font_style = Plurimath::Math::Function::FontStyle.new(
+        Plurimath::Math::Number.new("3"), "mathrm"
       )
 
       expect(described_class.valid_class(font_style)).to be(false)

--- a/spec/plurimath/omml_spec.rb
+++ b/spec/plurimath/omml_spec.rb
@@ -37,6 +37,30 @@ RSpec.describe Plurimath::Omml do
       end
     end
 
+    context "sSubSup whose base is a font-styled function word" do
+      let(:string) do
+        <<~OMML
+          <m:oMath xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math">
+            <m:sSubSup>
+              <m:e><m:r><m:rPr><m:sty m:val="p"/></m:rPr><m:t>lim</m:t></m:r></m:e>
+              <m:sub><m:r><m:t>x</m:t></m:r></m:sub>
+              <m:sup><m:r><m:t>y</m:t></m:r></m:sup>
+            </m:sSubSup>
+          </m:oMath>
+        OMML
+      end
+
+      # Built here rather than through the memoized subject: the suite reruns
+      # each example for Ox and Oga on the same instance, so a memoized formula
+      # would be parsed once and an engine-specific regression would slip by.
+      it "resolves the styled word to its function rather than leaving it text" do
+        parsed = described_class.new(string).to_formula
+
+        expect(parsed.value.first).to be_a(Plurimath::Math::Function::Lim)
+        expect(parsed.to_latex).to eq('\lim_{\text{x}}^{\text{y}}')
+      end
+    end
+
     context "sSubSup with a multi-run (compound) base" do
       let(:string) do
         <<~OMML


### PR DESCRIPTION
This PR fixes an unresolved OMML function word. `FontStyle#extract_class_name_from_text` discarded the result of its own first line, so it always returned `parameter_one.class_name` — `"text"` for a `Text` parameter — instead of the wrapped word. A font-styled function word in an OMML `<m:sSubSup>` therefore never resolved to its function: Word's `lim` with a subscript and superscript converted to `\mathrm{\text{lim}}_{\text{x}}^{\text{y}}` (styled text with scripts) rather than `\lim_{\text{x}}^{\text{y}}`.

## Changes

- Return the wrapped text from `FontStyle#extract_class_name_from_text` when `parameter_one` is a `Text`; a non-`Text` value still falls back to the class name. The method's first line already computed this value and threw it away.
- Flip the pinned `# quirk:` spec — `Omml::Utility.valid_class(FontStyle(Text("lim")))` is now `true` — and add a negative pinning the class-name fallback for a non-`Text` value.
- Add an OMML conversion regression: an `<m:sSubSup>` whose base is a font-styled `lim` resolves to the `Lim` function and renders `\lim_{\text{x}}^{\text{y}}`.

The method feeds `Omml::Utility.valid_class` and `script_class_for`, which only `<m:sSubSup>` consults, so `<m:sSub>` and every other path are unaffected.

Depends on #466 
