### PR TITLE
Match `symbol_value` against the exact symbol instead of a substring

### DIFF
--- a/lib/plurimath/utility.rb
+++ b/lib/plurimath/utility.rb
@@ -202,10 +202,10 @@ module Plurimath
       def symbol_value(object, value)
         return false if value.nil?
 
-        (object.is_a?(Math::Symbols::Comma) if value&.include?(",")) ||
-          (object.is_a?(Math::Symbols::Minus) if value&.include?("-")) ||
-          (object.is_a?(Math::Symbols::Paren::Vert) if value&.include?("|")) ||
-          (object.is_a?(Math::Symbols::Symbol) && object&.value&.include?(value)) ||
+        (object.is_a?(Math::Symbols::Comma) if value == ",") ||
+          (object.is_a?(Math::Symbols::Minus) if value == "-") ||
+          (object.is_a?(Math::Symbols::Paren::Vert) if value == "|") ||
+          (object.is_a?(Math::Symbols::Symbol) && object&.value == value) ||
           (value == "\\\\" && object.is_a?(Math::Function::Linebreak))
       end
 

--- a/lib/plurimath/utility.rb
+++ b/lib/plurimath/utility.rb
@@ -205,7 +205,7 @@ module Plurimath
         (object.is_a?(Math::Symbols::Comma) if value == ",") ||
           (object.is_a?(Math::Symbols::Minus) if value == "-") ||
           (object.is_a?(Math::Symbols::Paren::Vert) if value == "|") ||
-          (object.is_a?(Math::Symbols::Symbol) && object&.value == value) ||
+          (object.is_a?(Math::Symbols::Symbol) && object.value == value) ||
           (value == "\\\\" && object.is_a?(Math::Function::Linebreak))
       end
 

--- a/spec/plurimath/asciimath/utility_spec.rb
+++ b/spec/plurimath/asciimath/utility_spec.rb
@@ -38,6 +38,18 @@ RSpec.describe Plurimath::Asciimath::Utility do
       expect(result).to eq([td([number("1")]), td([number("2")])])
     end
 
+    # Regression: a Symbol whose value merely CONTAINS the slicer is not the
+    # separator, so it stays as cell content instead of slicing the row.
+    it "keeps a Symbol whose value only contains the slicer as content" do
+      symbol = Plurimath::Math::Symbols::Symbol.new("a,b")
+      result = described_class.td_values(
+        [number("1"), symbol, number("2")],
+        ",",
+      )
+
+      expect(result).to eq([td([number("1"), symbol, number("2")])])
+    end
+
     # quirk: a trailing separator appends an extra empty Td.
     it "appends an empty Td when the last object is a separator" do
       result = described_class.td_values(

--- a/spec/plurimath/asciimath/utility_spec.rb
+++ b/spec/plurimath/asciimath/utility_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Plurimath::Asciimath::Utility do
       expect(result).to eq([td([number("1")]), td([number("2")])])
     end
 
-    it "slices on a generic Symbol whose value contains the slicer" do
+    it "slices on a generic Symbol whose value is the slicer" do
       result = described_class.td_values(
         [number("1"), Plurimath::Math::Symbols::Symbol.new(","), number("2")],
         ",",

--- a/spec/plurimath/asciimath/utility_spec.rb
+++ b/spec/plurimath/asciimath/utility_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Plurimath::Asciimath::Utility do
 
     # Regression: a Symbol whose value merely CONTAINS the slicer is not the
     # separator, so it stays as cell content instead of slicing the row.
-    it "keeps a Symbol whose value only contains the slicer as content" do
+    it "keeps a Symbol whose value contains the slicer but is not the slicer as content" do
       symbol = Plurimath::Math::Symbols::Symbol.new("a,b")
       result = described_class.td_values(
         [number("1"), symbol, number("2")],

--- a/spec/plurimath/math/function/td_spec.rb
+++ b/spec/plurimath/math/function/td_spec.rb
@@ -130,6 +130,17 @@ RSpec.describe Plurimath::Math::Function::Td do
       end
     end
 
+    # Regression: a leading Symbol whose value merely CONTAINS a pipe is not the
+    # "|" column separator, so the cell renders its content instead of collapsing
+    # to an empty string.
+    context "contains a Symbol whose value only contains a pipe" do
+      let(:first_value) { Plurimath::Math::Symbols::Symbol.new("x|y") }
+
+      it "renders the content rather than an empty separator cell" do
+        expect(formula).to eql("x|y")
+      end
+    end
+
     context "contains Number as value" do
       let(:first_value) { Plurimath::Math::Number.new("70") }
 

--- a/spec/plurimath/math/function/td_spec.rb
+++ b/spec/plurimath/math/function/td_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Plurimath::Math::Function::Td do
     # Regression: a leading Symbol whose value merely CONTAINS a pipe is not the
     # "|" column separator, so the cell renders its content instead of collapsing
     # to an empty string.
-    context "contains a Symbol whose value only contains a pipe" do
+    context "contains a Symbol whose value has a pipe but is not the separator" do
       let(:first_value) { Plurimath::Math::Symbols::Symbol.new("x|y") }
 
       it "renders the content rather than an empty separator cell" do

--- a/spec/plurimath/utility_spec.rb
+++ b/spec/plurimath/utility_spec.rb
@@ -383,31 +383,32 @@ RSpec.describe Plurimath::Utility do
   end
 
   describe ".symbol_value" do
-    it "matches Comma objects when the value contains a comma" do
+    it "matches a Comma object when the value is a comma" do
       expect(described_class.symbol_value(Plurimath::Math::Symbols::Comma.new, ",")).to be(true)
     end
 
-    # quirk: any value merely CONTAINING "," matches a Comma object, the value
-    # is not compared to the symbol at all
-    it "matches Comma objects for any value containing a comma" do
-      expect(described_class.symbol_value(Plurimath::Math::Symbols::Comma.new, "a,b")).to be(true)
+    # The value is the symbol being looked for, so it has to be that symbol —
+    # merely containing one no longer matches.
+    it "does not match a Comma object for a value that merely contains a comma" do
+      expect(described_class.symbol_value(Plurimath::Math::Symbols::Comma.new, "a,b")).to be(false)
     end
 
-    it "matches Minus objects when the value contains a minus" do
+    it "matches a Minus object when the value is a minus" do
       expect(described_class.symbol_value(Plurimath::Math::Symbols::Minus.new, "-")).to be(true)
     end
 
-    it "matches Paren::Vert objects when the value contains a pipe" do
+    it "matches a Paren::Vert object when the value is a pipe" do
       expect(described_class.symbol_value(Plurimath::Math::Symbols::Paren::Vert.new, "|")).to be(true)
     end
 
-    it "matches generic Symbol objects whose value contains the string" do
+    it "matches generic Symbol objects whose value is the string" do
       expect(described_class.symbol_value(Plurimath::Math::Symbols::Symbol.new("|"), "|")).to be(true)
     end
 
-    # quirk: substring match, not equality ("ab" contains "b")
-    it "matches generic Symbol objects by substring inclusion" do
-      expect(described_class.symbol_value(Plurimath::Math::Symbols::Symbol.new("ab"), "b")).to be(true)
+    # Equality, not substring inclusion: a two-character symbol is not the
+    # single-character separator being looked for.
+    it "does not match a generic Symbol object by substring inclusion" do
+      expect(described_class.symbol_value(Plurimath::Math::Symbols::Symbol.new("ab"), "b")).to be(false)
     end
 
     it "matches Linebreak objects against the literal \\\\ value" do


### PR DESCRIPTION
This PR fixes a separator test that answered yes too often. `Utility.symbol_value(object, value)` answers "is this object the separator `value`?" — every caller passes a single-character separator (`","` when splitting fraction/table arguments, `"|"` when finding table bars). It tested containment rather than identity:

- A value merely *containing* a comma matched a `Comma`, without ever comparing the value to the symbol.
- A generic `Symbol` matched by substring, so `Symbol("ab")` matched the separator `"b"`.

## Changes

- Compare the value to the symbol it names (`==`) in the `Comma`, `Minus`, and `Paren::Vert` arms, and compare a generic `Symbol`'s value for equality rather than inclusion. The `Linebreak` arm already compared exactly.
- Flip the two pinned `# quirk:` specs to the exact-match behavior and rename the exact-match example, which previously read as a containment test.

Both quirks were latent — no caller passes a multi-character separator today.

Depends on #468
