### PR TITLE
Remove phantom trailing row and nil-filled cell in LaTeX tables

### DIFF
--- a/lib/plurimath/latex/utility.rb
+++ b/lib/plurimath/latex/utility.rb
@@ -26,7 +26,14 @@ module Plurimath
             end
             table_data << data
           end
-          table_row << Math::Function::Td.new(table_data.compact) if table_data
+          # A trailing linebreak has already flushed its row and nothing follows
+          # it, so there is no final cell to add. An empty input has flushed
+          # nothing, and still yields its one placeholder cell.
+          flushed_by_trailing_linebreak =
+            table_data.empty? && table_row.empty? && !table.empty?
+          unless flushed_by_trailing_linebreak
+            table_row << Math::Function::Td.new(table_data.compact)
+          end
           unless table_row.nil? || table_row.empty?
             organize_tds(table_row.flatten, string_columns.dup, options)
             table << Math::Function::Tr.new(table_row)
@@ -82,7 +89,7 @@ module Plurimath
                        when Math::Function::Td
                          object
                        else
-                         Math::Function::Td.new([object])
+                         Math::Function::Td.new([object].compact)
                        end
           Array(new_object)
         end

--- a/spec/plurimath/latex/utility_spec.rb
+++ b/spec/plurimath/latex/utility_spec.rb
@@ -62,24 +62,42 @@ RSpec.describe Plurimath::Latex::Utility do
       expect(result).to eq([tr([td([number("1")]), td([number("2")])])])
     end
 
-    # quirk: a trailing linebreak produces an extra trailing row holding one
-    # empty Td, because the post-loop flush appends Td([]) even when no data
-    # followed the linebreak.
-    it "appends an extra empty row after a trailing Linebreak" do
+    # A trailing linebreak closes the last row; nothing follows it, so it no
+    # longer leaves an empty row behind.
+    it "does not append an empty row after a trailing Linebreak" do
       result = described_class.organize_table([number("1"), linebreak])
 
-      expect(result).to eq(
-        [
-          tr([td([number("1")])]),
-          tr([td([])]),
-        ],
-      )
+      expect(result).to eq([tr([td([number("1")])])])
     end
 
-    # quirk: an empty input array still yields one row with one empty Td
-    # (the post-loop flush runs on the empty accumulator).
+    # An empty input yields the placeholder: one row holding a single empty Td.
     it "returns one row with one empty Td for an empty array" do
       expect(described_class.organize_table([])).to eq([tr([td([])])])
+    end
+
+    # The trailing-linebreak guard's remaining states, pinned by row/cell shape.
+    it "appends an empty padding cell for a trailing separator" do
+      expect(described_class.organize_table([number("1"), ampersand]))
+        .to eq([tr([td([number("1")]), td([])])])
+    end
+
+    it "yields one empty-Td row for a lone Linebreak" do
+      expect(described_class.organize_table([linebreak])).to eq([tr([td([])])])
+    end
+
+    it "yields one empty-Td row per Linebreak for consecutive Linebreaks" do
+      expect(described_class.organize_table([linebreak, linebreak]))
+        .to eq([tr([td([])]), tr([td([])])])
+    end
+
+    it "pads the separator's row when a separator follows a Linebreak" do
+      expect(described_class.organize_table([linebreak, ampersand]))
+        .to eq([tr([td([])]), tr([td([]), td([])])])
+    end
+
+    it "closes a separator-opened row on a trailing Linebreak" do
+      expect(described_class.organize_table([ampersand, linebreak]))
+        .to eq([tr([td([]), td([])])])
     end
 
     # quirk: Minus merging (filter_table_data) only runs on cells flushed by
@@ -110,8 +128,8 @@ RSpec.describe Plurimath::Latex::Utility do
       )
     end
 
-    # quirk: the final cell of the input is flushed without filter_table_data,
-    # so the same Minus + value sequence stays un-merged there.
+    # quirk: filter_table_data runs only on separator-flushed cells, so the
+    # final post-loop cell leaves a Minus and its next sibling unmerged.
     it "does not merge Minus in the final (post-loop) cell" do
       result = described_class.organize_table(
         [Plurimath::Math::Symbols::Minus.new, number("2")],
@@ -271,10 +289,10 @@ RSpec.describe Plurimath::Latex::Utility do
       expect(described_class.table_td(number("5"))).to eq([td([number("5")])])
     end
 
-    # quirk: nil is not filtered out — it becomes a Td whose parameter_one
-    # is [nil].
-    it "wraps nil into a Td containing [nil]" do
-      expect(described_class.table_td(nil)).to eq([td([nil])])
+    # nil is not content, so it is filtered out rather than becoming a cell
+    # holding a nil.
+    it "wraps nil into an empty Td" do
+      expect(described_class.table_td(nil)).to eq([td([])])
     end
   end
 

--- a/spec/plurimath/latex_spec.rb
+++ b/spec/plurimath/latex_spec.rb
@@ -2814,6 +2814,27 @@ RSpec.describe Plurimath::Latex do
         expect(formula.to_mathml(unary_function_spacing: false)).to be_xml_equivalent_to(mathml)
       end
     end
+
+    context "matrix ending in a row separator" do
+      let(:string) { '\\begin{matrix}1 \\\\ \\end{matrix}' }
+
+      it "does not emit a phantom trailing row" do
+        mathml = <<~MATHML
+          <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <mstyle displaystyle="true">
+              <mtable>
+                <mtr>
+                  <mtd>
+                    <mn>1</mn>
+                  </mtd>
+                </mtr>
+              </mtable>
+            </mstyle>
+          </math>
+        MATHML
+        expect(formula.to_mathml(unary_function_spacing: false)).to be_xml_equivalent_to(mathml)
+      end
+    end
   end
 
   describe ".to_asciimath" do
@@ -2864,6 +2885,15 @@ RSpec.describe Plurimath::Latex do
 
       it "returns parsed Latex to HTML" do
         expected_value = "1cm"
+        expect(html).to eql(expected_value)
+      end
+    end
+
+    context "binomial with an empty operand" do
+      let(:string) { '\\binom{a}{}' }
+
+      it "renders the empty cell instead of crashing" do
+        expected_value = "<table><tr><td>a</td></tr><tr><td></td></tr></table>"
         expect(html).to eql(expected_value)
       end
     end


### PR DESCRIPTION
This PR fixes two artifacts in latex table assembly. `organize_table` builds a cell whenever a separator flushes one, and once more after the loop for whatever is left:

- The post-loop flush ran `table_row << Td.new(table_data.compact) if table_data` — and an empty array is truthy in Ruby, so a **trailing linebreak** (whose row the loop had already closed) still appended an empty cell, giving the table a phantom trailing row.
- `table_td(nil)` produced `Td([nil])` — a cell holding a bare `nil` rather than an empty cell.

## Changes

- Skip the post-loop cell only when a trailing linebreak already closed the row and nothing followed it. An empty input closed no row, so it still yields its placeholder cell, and a trailing separator still yields its empty padding cell.
- Filter `nil` out of `table_td`, so it yields an empty cell instead of a cell holding a `nil`.
- Flip the two pinned `# quirk:` specs (trailing-linebreak row, `table_td(nil)`), and keep the empty-input and trailing-separator specs.

`filter_table_data` is left byte-identical to the base: routing the final cell through it (so a leading `Minus` merges there as in separator-flushed cells) builds `Formula([Minus, rhs])`, whose serialization inserts a UnicodeMath space and a MathML `<mrow>` and breaks round-tripping — `\begin{matrix}a - b\end{matrix}` renders `■(a− b)` and raises `ParseError` on re-parse. That merge is already broken wherever it runs, so reworking it (and its nil-guard) is a separate task. No output change on valid input.

Depends on #469
