### PR TITLE
Document the binary functions in the catalog

### DIFF
--- a/lib/plurimath/catalog.rb
+++ b/lib/plurimath/catalog.rb
@@ -15,7 +15,7 @@ module Plurimath
     def classes
       ensure_documentable_classes_loaded
       documentable_bases
-        .flat_map(&:descendants)
+        .flat_map { |base| descendants_of(base) }
         .uniq
         .select(&:documented?)
         .sort_by(&:catalog_name)
@@ -33,7 +33,7 @@ module Plurimath
     # Base classes whose documented descendants are catalogued. Grows as later
     # PRs document the other arities and the symbols.
     def documentable_bases
-      [Math::Function::TernaryFunction]
+      [Math::Function::TernaryFunction, Math::Function::BinaryFunction]
     end
 
     # descendants only sees loaded classes, so require the source files of every
@@ -52,6 +52,14 @@ module Plurimath
       @documentable_classes_loaded = true
     end
 
-    private_class_method :documentable_bases, :ensure_documentable_classes_loaded
+    # descendants lists only direct subclasses, so walk the whole subtree —
+    # nested families (e.g. FontStyle's styles) live below the arity bases.
+    def descendants_of(klass)
+      Array(klass.descendants)
+        .flat_map { |descendant| [descendant, *descendants_of(descendant)] }
+    end
+
+    private_class_method :documentable_bases, :ensure_documentable_classes_loaded,
+                         :descendants_of
   end
 end

--- a/lib/plurimath/documentation.rb
+++ b/lib/plurimath/documentation.rb
@@ -4,8 +4,9 @@ module Plurimath
   # Per-class documentation metadata for the symbol/function catalog
   # (see Plurimath::Catalog, which powers the plurimath.org "Functions" and
   # "Symbols" pages). A documentable base class extends this module — so far
-  # TernaryFunction, with the other arities and Symbols::Symbol to follow — and
-  # every descendant then inherits the shared, derivable machinery (name, type,
+  # TernaryFunction and BinaryFunction, with the remaining arities and
+  # Symbols::Symbol to follow — and every descendant then inherits the shared,
+  # derivable machinery (name, type,
   # the four renderings) while each concrete class "explains itself" with three
   # declarations: DESCRIPTION, REFERENCE, and an EXAMPLE lambda.
   module Documentation

--- a/lib/plurimath/math/function/arg.rb
+++ b/lib/plurimath/math/function/arg.rb
@@ -4,6 +4,12 @@ module Plurimath
   module Math
     module Function
       class Arg < BinaryFunction
+        # --- Catalog documentation (see Plurimath::Documentation) ---
+        DESCRIPTION = "An expression given an `arg` name for reference from an ancestor MathML `intent` annotation."
+        REFERENCE = "https://www.w3.org/TR/mathml4/#mixing_intent"
+        EXAMPLE = -> { new(sym("x"), sym("x")) }
+        # --- end catalog documentation ---
+
         def to_mathml_without_math_tag(intent, options:)
           first_value = parameter_one.to_mathml_without_math_tag(intent,
                                                                  options: options)

--- a/lib/plurimath/math/function/base.rb
+++ b/lib/plurimath/math/function/base.rb
@@ -4,6 +4,12 @@ module Plurimath
   module Math
     module Function
       class Base < BinaryFunction
+        # --- Catalog documentation (see Plurimath::Documentation) ---
+        DESCRIPTION = "A base carrying a subscript."
+        REFERENCE = "https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/msub"
+        EXAMPLE = -> { new(sym("x"), sym("y")) }
+        # --- end catalog documentation ---
+
         attr_accessor :options
 
         FUNCTION = {

--- a/lib/plurimath/math/function/binary_function.rb
+++ b/lib/plurimath/math/function/binary_function.rb
@@ -4,6 +4,10 @@ module Plurimath
   module Math
     module Function
       class BinaryFunction < Core
+        extend Documentation
+
+        CATALOG_TYPE = :binary
+
         attr_accessor :parameter_one, :parameter_two, :hide_function_name
 
         def initialize(parameter_one = nil, parameter_two = nil)

--- a/lib/plurimath/math/function/color.rb
+++ b/lib/plurimath/math/function/color.rb
@@ -4,6 +4,12 @@ module Plurimath
   module Math
     module Function
       class Color < BinaryFunction
+        # --- Catalog documentation (see Plurimath::Documentation) ---
+        DESCRIPTION = "An expression rendered in a specified color."
+        REFERENCE = "https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mstyle"
+        EXAMPLE = -> { new(sym("red"), sym("x")) }
+        # --- end catalog documentation ---
+
         attr_accessor :options
 
         FUNCTION = {

--- a/lib/plurimath/math/function/font_style.rb
+++ b/lib/plurimath/math/function/font_style.rb
@@ -20,6 +20,10 @@ module Plurimath
         autoload :SansSerifItalic, "#{__dir__}/font_style/sans-serif-italic"
         autoload :Script, "#{__dir__}/font_style/script"
 
+        # Font styles wrap a single visible argument, so the catalog lists them
+        # as unary (overriding BinaryFunction's :binary) to match the site.
+        CATALOG_TYPE = :unary
+
         def to_asciimath(options:)
           parameter_one&.to_asciimath(options: options)
         end

--- a/lib/plurimath/math/function/font_style/bold-fraktur.rb
+++ b/lib/plurimath/math/function/font_style/bold-fraktur.rb
@@ -5,6 +5,12 @@ module Plurimath
     module Function
       class FontStyle
         class BoldFraktur < FontStyle
+          # --- Catalog documentation (see Plurimath::Documentation) ---
+          DESCRIPTION = "Renders its argument in a bold Fraktur (blackletter) font."
+          REFERENCE = "https://en.wikipedia.org/wiki/Mathematical_Alphanumeric_Symbols"
+          EXAMPLE = -> { new(sym("x")) }
+          # --- end catalog documentation ---
+
           def to_omml_without_math_tag(display_style, options:)
             font_styles(display_style, sty: "b", scr: "fraktur",
                                        options: options)

--- a/lib/plurimath/math/function/font_style/bold-italic.rb
+++ b/lib/plurimath/math/function/font_style/bold-italic.rb
@@ -5,6 +5,12 @@ module Plurimath
     module Function
       class FontStyle
         class BoldItalic < FontStyle
+          # --- Catalog documentation (see Plurimath::Documentation) ---
+          DESCRIPTION = "Renders its argument in a bold italic font."
+          REFERENCE = "https://en.wikipedia.org/wiki/Mathematical_Alphanumeric_Symbols"
+          EXAMPLE = -> { new(sym("x")) }
+          # --- end catalog documentation ---
+
           def to_omml_without_math_tag(display_style, options:)
             font_styles(display_style, sty: "bi", options: options)
           end

--- a/lib/plurimath/math/function/font_style/bold-sans-serif.rb
+++ b/lib/plurimath/math/function/font_style/bold-sans-serif.rb
@@ -5,6 +5,12 @@ module Plurimath
     module Function
       class FontStyle
         class BoldSansSerif < FontStyle
+          # --- Catalog documentation (see Plurimath::Documentation) ---
+          DESCRIPTION = "Renders its argument in a bold sans-serif font."
+          REFERENCE = "https://en.wikipedia.org/wiki/Mathematical_Alphanumeric_Symbols"
+          EXAMPLE = -> { new(sym("x")) }
+          # --- end catalog documentation ---
+
           def to_omml_without_math_tag(display_style, options:)
             font_styles(display_style, sty: "b", scr: "sans-serif",
                                        options: options)

--- a/lib/plurimath/math/function/font_style/bold-script.rb
+++ b/lib/plurimath/math/function/font_style/bold-script.rb
@@ -5,6 +5,12 @@ module Plurimath
     module Function
       class FontStyle
         class BoldScript < FontStyle
+          # --- Catalog documentation (see Plurimath::Documentation) ---
+          DESCRIPTION = "Renders its argument in a bold script (calligraphic) font."
+          REFERENCE = "https://en.wikipedia.org/wiki/Mathematical_Alphanumeric_Symbols"
+          EXAMPLE = -> { new(sym("x")) }
+          # --- end catalog documentation ---
+
           def to_omml_without_math_tag(display_style, options:)
             font_styles(display_style, sty: "b", scr: "script",
                                        options: options)

--- a/lib/plurimath/math/function/font_style/bold.rb
+++ b/lib/plurimath/math/function/font_style/bold.rb
@@ -5,6 +5,12 @@ module Plurimath
     module Function
       class FontStyle
         class Bold < FontStyle
+          # --- Catalog documentation (see Plurimath::Documentation) ---
+          DESCRIPTION = "Renders its argument in a bold font."
+          REFERENCE = "https://en.wikipedia.org/wiki/Mathematical_Alphanumeric_Symbols"
+          EXAMPLE = -> { new(sym("x")) }
+          # --- end catalog documentation ---
+
           def initialize(parameter_one,
                          parameter_two = "bold")
             super

--- a/lib/plurimath/math/function/font_style/double_struck.rb
+++ b/lib/plurimath/math/function/font_style/double_struck.rb
@@ -5,6 +5,12 @@ module Plurimath
     module Function
       class FontStyle
         class DoubleStruck < FontStyle
+          # --- Catalog documentation (see Plurimath::Documentation) ---
+          DESCRIPTION = "Renders its argument in a double-struck (blackboard bold) font."
+          REFERENCE = "https://en.wikipedia.org/wiki/Mathematical_Alphanumeric_Symbols"
+          EXAMPLE = -> { new(sym("x")) }
+          # --- end catalog documentation ---
+
           def initialize(parameter_one,
                          parameter_two = "double-struck")
             super

--- a/lib/plurimath/math/function/font_style/fraktur.rb
+++ b/lib/plurimath/math/function/font_style/fraktur.rb
@@ -5,6 +5,12 @@ module Plurimath
     module Function
       class FontStyle
         class Fraktur < FontStyle
+          # --- Catalog documentation (see Plurimath::Documentation) ---
+          DESCRIPTION = "Renders its argument in a Fraktur (blackletter) font."
+          REFERENCE = "https://en.wikipedia.org/wiki/Mathematical_Alphanumeric_Symbols"
+          EXAMPLE = -> { new(sym("x")) }
+          # --- end catalog documentation ---
+
           def initialize(parameter_one,
                          parameter_two = "fraktur")
             super

--- a/lib/plurimath/math/function/font_style/italic.rb
+++ b/lib/plurimath/math/function/font_style/italic.rb
@@ -5,6 +5,12 @@ module Plurimath
     module Function
       class FontStyle
         class Italic < FontStyle
+          # --- Catalog documentation (see Plurimath::Documentation) ---
+          DESCRIPTION = "Renders its argument in an italic font."
+          REFERENCE = "https://en.wikipedia.org/wiki/Mathematical_Alphanumeric_Symbols"
+          EXAMPLE = -> { new(sym("x")) }
+          # --- end catalog documentation ---
+
           def initialize(parameter_one,
                          parameter_two = "italic")
             super

--- a/lib/plurimath/math/function/font_style/monospace.rb
+++ b/lib/plurimath/math/function/font_style/monospace.rb
@@ -5,6 +5,12 @@ module Plurimath
     module Function
       class FontStyle
         class Monospace < FontStyle
+          # --- Catalog documentation (see Plurimath::Documentation) ---
+          DESCRIPTION = "Renders its argument in a monospace font."
+          REFERENCE = "https://en.wikipedia.org/wiki/Mathematical_Alphanumeric_Symbols"
+          EXAMPLE = -> { new(sym("x")) }
+          # --- end catalog documentation ---
+
           def initialize(parameter_one,
                          parameter_two = "monospace")
             super

--- a/lib/plurimath/math/function/font_style/normal.rb
+++ b/lib/plurimath/math/function/font_style/normal.rb
@@ -5,6 +5,12 @@ module Plurimath
     module Function
       class FontStyle
         class Normal < FontStyle
+          # --- Catalog documentation (see Plurimath::Documentation) ---
+          DESCRIPTION = "Renders its argument in an upright (roman, non-italic) font."
+          REFERENCE = "https://en.wikipedia.org/wiki/Mathematical_Alphanumeric_Symbols"
+          EXAMPLE = -> { new(sym("x")) }
+          # --- end catalog documentation ---
+
           def initialize(parameter_one,
                          parameter_two = "rm")
             super

--- a/lib/plurimath/math/function/font_style/sans-serif-bold-italic.rb
+++ b/lib/plurimath/math/function/font_style/sans-serif-bold-italic.rb
@@ -5,6 +5,12 @@ module Plurimath
     module Function
       class FontStyle
         class SansSerifBoldItalic < FontStyle
+          # --- Catalog documentation (see Plurimath::Documentation) ---
+          DESCRIPTION = "Renders its argument in a bold italic sans-serif font."
+          REFERENCE = "https://en.wikipedia.org/wiki/Mathematical_Alphanumeric_Symbols"
+          EXAMPLE = -> { new(sym("x")) }
+          # --- end catalog documentation ---
+
           def to_omml_without_math_tag(display_style, options:)
             font_styles(display_style, sty: "bi", scr: "sans-serif",
                                        options: options)

--- a/lib/plurimath/math/function/font_style/sans-serif-italic.rb
+++ b/lib/plurimath/math/function/font_style/sans-serif-italic.rb
@@ -5,6 +5,12 @@ module Plurimath
     module Function
       class FontStyle
         class SansSerifItalic < FontStyle
+          # --- Catalog documentation (see Plurimath::Documentation) ---
+          DESCRIPTION = "Renders its argument in an italic sans-serif font."
+          REFERENCE = "https://en.wikipedia.org/wiki/Mathematical_Alphanumeric_Symbols"
+          EXAMPLE = -> { new(sym("x")) }
+          # --- end catalog documentation ---
+
           def to_omml_without_math_tag(display_style, options:)
             font_styles(display_style, sty: "i", scr: "sans-serif",
                                        options: options)

--- a/lib/plurimath/math/function/font_style/sans-serif.rb
+++ b/lib/plurimath/math/function/font_style/sans-serif.rb
@@ -5,6 +5,12 @@ module Plurimath
     module Function
       class FontStyle
         class SansSerif < FontStyle
+          # --- Catalog documentation (see Plurimath::Documentation) ---
+          DESCRIPTION = "Renders its argument in a sans-serif font."
+          REFERENCE = "https://en.wikipedia.org/wiki/Mathematical_Alphanumeric_Symbols"
+          EXAMPLE = -> { new(sym("x")) }
+          # --- end catalog documentation ---
+
           def initialize(parameter_one,
                          parameter_two = "sans-serif")
             super

--- a/lib/plurimath/math/function/font_style/script.rb
+++ b/lib/plurimath/math/function/font_style/script.rb
@@ -5,6 +5,12 @@ module Plurimath
     module Function
       class FontStyle
         class Script < FontStyle
+          # --- Catalog documentation (see Plurimath::Documentation) ---
+          DESCRIPTION = "Renders its argument in a script (calligraphic) font."
+          REFERENCE = "https://en.wikipedia.org/wiki/Mathematical_Alphanumeric_Symbols"
+          EXAMPLE = -> { new(sym("x")) }
+          # --- end catalog documentation ---
+
           def initialize(parameter_one,
                          parameter_two = "script")
             super

--- a/lib/plurimath/math/function/frac.rb
+++ b/lib/plurimath/math/function/frac.rb
@@ -4,6 +4,12 @@ module Plurimath
   module Math
     module Function
       class Frac < BinaryFunction
+        # --- Catalog documentation (see Plurimath::Documentation) ---
+        DESCRIPTION = "A fraction with a numerator over a denominator."
+        REFERENCE = "https://en.wikipedia.org/wiki/Fraction"
+        EXAMPLE = -> { new(sym("x"), sym("y")) }
+        # --- end catalog documentation ---
+
         attr_accessor :options
 
         FUNCTION = {

--- a/lib/plurimath/math/function/inf.rb
+++ b/lib/plurimath/math/function/inf.rb
@@ -4,6 +4,12 @@ module Plurimath
   module Math
     module Function
       class Inf < BinaryFunction
+        # --- Catalog documentation (see Plurimath::Documentation) ---
+        DESCRIPTION = "The infimum operator, carrying a subscript and superscript."
+        REFERENCE = "https://en.wikipedia.org/wiki/Infimum_and_supremum"
+        EXAMPLE = -> { new(sym("x"), sym("y")) }
+        # --- end catalog documentation ---
+
         def to_asciimath(options:)
           first_value = "_(#{parameter_one.to_asciimath(options: options)})" if parameter_one
           second_value = "^(#{parameter_two.to_asciimath(options: options)})" if parameter_two

--- a/lib/plurimath/math/function/intent.rb
+++ b/lib/plurimath/math/function/intent.rb
@@ -4,6 +4,12 @@ module Plurimath
   module Math
     module Function
       class Intent < BinaryFunction
+        # --- Catalog documentation (see Plurimath::Documentation) ---
+        DESCRIPTION = "An expression carrying an `intent` annotation for MathML accessibility semantics."
+        REFERENCE = "https://www.w3.org/TR/mathml4/#mixing_intent"
+        EXAMPLE = -> { new(expr(sym("x")), Text.new("variable")) }
+        # --- end catalog documentation ---
+
         def to_mathml_without_math_tag(intent, options:)
           first_value = parameter_one.to_mathml_without_math_tag(intent,
                                                                  options: options)

--- a/lib/plurimath/math/function/lim.rb
+++ b/lib/plurimath/math/function/lim.rb
@@ -4,6 +4,12 @@ module Plurimath
   module Math
     module Function
       class Lim < BinaryFunction
+        # --- Catalog documentation (see Plurimath::Documentation) ---
+        DESCRIPTION = "The limit operator, carrying a subscript and superscript."
+        REFERENCE = "https://en.wikipedia.org/wiki/Limit_(mathematics)"
+        EXAMPLE = -> { new(sym("x"), sym("y")) }
+        # --- end catalog documentation ---
+
         FUNCTION = {
           name: "limit",
           first_value: "limit subscript",

--- a/lib/plurimath/math/function/log.rb
+++ b/lib/plurimath/math/function/log.rb
@@ -4,6 +4,12 @@ module Plurimath
   module Math
     module Function
       class Log < BinaryFunction
+        # --- Catalog documentation (see Plurimath::Documentation) ---
+        DESCRIPTION = "The logarithm operator, carrying a subscript and superscript."
+        REFERENCE = "https://en.wikipedia.org/wiki/Logarithm"
+        EXAMPLE = -> { new(sym("x"), sym("y")) }
+        # --- end catalog documentation ---
+
         FUNCTION = {
           name: "function apply",
           first_value: "subscript",

--- a/lib/plurimath/math/function/menclose.rb
+++ b/lib/plurimath/math/function/menclose.rb
@@ -4,6 +4,15 @@ module Plurimath
   module Math
     module Function
       class Menclose < BinaryFunction
+        # --- Catalog documentation (see Plurimath::Documentation) ---
+        # Menclose wraps a single visible expression, so the catalog lists it as
+        # unary (overriding BinaryFunction's :binary) to match the site.
+        CATALOG_TYPE = :unary
+        DESCRIPTION = "An expression wrapped in an enclosing notation, such as a box, circle, or strike."
+        REFERENCE = "https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/menclose"
+        EXAMPLE = -> { new("box", sym("x")) }
+        # --- end catalog documentation ---
+
         FUNCTION = {
           name: "enclosure",
           first_value: "enclosure type",

--- a/lib/plurimath/math/function/mod.rb
+++ b/lib/plurimath/math/function/mod.rb
@@ -4,6 +4,12 @@ module Plurimath
   module Math
     module Function
       class Mod < BinaryFunction
+        # --- Catalog documentation (see Plurimath::Documentation) ---
+        DESCRIPTION = "The modulo operation between two operands."
+        REFERENCE = "https://en.wikipedia.org/wiki/Modulo"
+        EXAMPLE = -> { new(sym("x"), sym("y")) }
+        # --- end catalog documentation ---
+
         FUNCTION = {
           name: "mod",
           first_value: "base",

--- a/lib/plurimath/math/function/over.rb
+++ b/lib/plurimath/math/function/over.rb
@@ -4,6 +4,12 @@ module Plurimath
   module Math
     module Function
       class Over < BinaryFunction
+        # --- Catalog documentation (see Plurimath::Documentation) ---
+        DESCRIPTION = "A fraction formed with the LaTeX \\over primitive."
+        REFERENCE = "https://en.wikipedia.org/wiki/Fraction"
+        EXAMPLE = -> { new(sym("x"), sym("y")) }
+        # --- end catalog documentation ---
+
         FUNCTION = {
           name: "over",
           first_value: "numerator",

--- a/lib/plurimath/math/function/overset.rb
+++ b/lib/plurimath/math/function/overset.rb
@@ -4,6 +4,12 @@ module Plurimath
   module Math
     module Function
       class Overset < BinaryFunction
+        # --- Catalog documentation (see Plurimath::Documentation) ---
+        DESCRIPTION = "An expression set as an overscript above a base."
+        REFERENCE = "https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mover"
+        EXAMPLE = -> { new(sym("x"), sym("y")) }
+        # --- end catalog documentation ---
+
         attr_accessor :options
 
         FUNCTION = {

--- a/lib/plurimath/math/function/power.rb
+++ b/lib/plurimath/math/function/power.rb
@@ -4,6 +4,12 @@ module Plurimath
   module Math
     module Function
       class Power < BinaryFunction
+        # --- Catalog documentation (see Plurimath::Documentation) ---
+        DESCRIPTION = "A base raised to an exponent."
+        REFERENCE = "https://en.wikipedia.org/wiki/Exponentiation"
+        EXAMPLE = -> { new(sym("x"), sym("y")) }
+        # --- end catalog documentation ---
+
         FUNCTION = {
           name: "superscript",
           first_value: "base",

--- a/lib/plurimath/math/function/root.rb
+++ b/lib/plurimath/math/function/root.rb
@@ -4,6 +4,12 @@ module Plurimath
   module Math
     module Function
       class Root < BinaryFunction
+        # --- Catalog documentation (see Plurimath::Documentation) ---
+        DESCRIPTION = "A root of a radicand with an explicit index (degree)."
+        REFERENCE = "https://en.wikipedia.org/wiki/Nth_root"
+        EXAMPLE = -> { new(sym("x"), sym("y")) }
+        # --- end catalog documentation ---
+
         FUNCTION = {
           name: "root",
           first_value: "radicand",

--- a/lib/plurimath/math/function/semantics.rb
+++ b/lib/plurimath/math/function/semantics.rb
@@ -4,6 +4,12 @@ module Plurimath
   module Math
     module Function
       class Semantics < BinaryFunction
+        # --- Catalog documentation (see Plurimath::Documentation) ---
+        DESCRIPTION = "A presentation expression paired with its semantic annotations."
+        REFERENCE = "https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/semantics"
+        EXAMPLE = -> { new(sym("x"), [{ "annotation-xml": [sym("x")] }]) }
+        # --- end catalog documentation ---
+
         FUNCTION = {
           name: "semantics",
           first_value: "first argument",

--- a/lib/plurimath/math/function/stackrel.rb
+++ b/lib/plurimath/math/function/stackrel.rb
@@ -4,6 +4,12 @@ module Plurimath
   module Math
     module Function
       class Stackrel < BinaryFunction
+        # --- Catalog documentation (see Plurimath::Documentation) ---
+        DESCRIPTION = "An expression stacked above another, typically over a relation."
+        REFERENCE = "https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mover"
+        EXAMPLE = -> { new(sym("x"), sym("y")) }
+        # --- end catalog documentation ---
+
         FUNCTION = {
           name: "stackrel",
           first_value: "above",

--- a/lib/plurimath/math/function/underset.rb
+++ b/lib/plurimath/math/function/underset.rb
@@ -4,6 +4,12 @@ module Plurimath
   module Math
     module Function
       class Underset < BinaryFunction
+        # --- Catalog documentation (see Plurimath::Documentation) ---
+        DESCRIPTION = "An expression set as an underscript below a base."
+        REFERENCE = "https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/munder"
+        EXAMPLE = -> { new(sym("x"), sym("y")) }
+        # --- end catalog documentation ---
+
         attr_accessor :options
 
         FUNCTION = {

--- a/spec/plurimath/catalog_spec.rb
+++ b/spec/plurimath/catalog_spec.rb
@@ -1,11 +1,41 @@
 require "spec_helper"
 
 RSpec.describe Plurimath::Catalog do
-  it "enumerates the documented ternary functions in a stable, sorted order" do
-    expected = %w[
+  it "enumerates exactly the documented classes, sorted by catalog name" do
+    ternary = %w[
       fenced int limits multiscript oint powerbase prod rule sum underover
     ]
-    expect(described_class.classes.map(&:catalog_name)).to eq(expected)
+    # Grouped by declaring arity base (class hierarchy), not by catalog type:
+    # Menclose subclasses BinaryFunction but renders as unary (its catalog type
+    # is asserted below); the FontStyle subtree is listed separately.
+    binary = %w[
+      arg base color frac inf intent lim log menclose mod over overset power
+      root semantics stackrel underset
+    ]
+    font_styles = %w[
+      bold boldfraktur bolditalic boldsansserif boldscript doublestruck fraktur
+      italic monospace normal sansserif sansserifbolditalic sansserifitalic
+      script
+    ]
+    names = described_class.classes.map(&:catalog_name)
+    expect(names).to eq((ternary + binary + font_styles).sort)
+  end
+
+  it "overrides catalog_type to the site's semantic arity for font styles and menclose" do
+    type_of = described_class.classes.to_h { |k| [k.catalog_name, k.catalog_type] }
+    # Font styles (14) and Menclose subclass BinaryFunction but the site lists
+    # them as unary, so each overrides the inherited :binary type.
+    unary = %w[
+      menclose bold boldfraktur bolditalic boldsansserif boldscript
+      doublestruck fraktur italic monospace normal sansserif
+      sansserifbolditalic sansserifitalic script
+    ]
+    # The remaining un-excluded binary-arity classes keep the inherited :binary.
+    binary = %w[arg color intent overset semantics underset]
+    aggregate_failures do
+      unary.each { |name| expect(type_of[name]).to eq(:unary), "#{name} should be unary" }
+      binary.each { |name| expect(type_of[name]).to eq(:binary), "#{name} should be binary" }
+    end
   end
 
   it "renders every documented example across all four formats without error" do
@@ -26,7 +56,7 @@ RSpec.describe Plurimath::Catalog do
       aggregate_failures(entry["name"]) do
         expect(entry.keys).to match_array(keys)
         keys.each { |key| expect(entry[key]).not_to be_nil }
-        expect(entry["type"]).to eq("ternary")
+        expect(entry["type"]).not_to be_empty
         expect(entry["reference"]).to start_with("http")
       end
     end
@@ -53,12 +83,17 @@ RSpec.describe Plurimath::Catalog do
     end
   end
 
-  it "builds a full entry for a representative class end to end" do
-    entry = Plurimath::Math::Function::Sum.catalog_entry
+  it "builds full entries for representative classes end to end" do
+    sum = Plurimath::Math::Function::Sum.catalog_entry
+    expect(sum["name"]).to eq("sum")
+    expect(sum["type"]).to eq("ternary")
+    expect(sum["asciimath"]).to eq("sum_(x)^(y) z")
+    expect(sum["latexmath"]).to eq("\\sum_{x}^{y} z")
 
-    expect(entry["name"]).to eq("sum")
-    expect(entry["type"]).to eq("ternary")
-    expect(entry["asciimath"]).to eq("sum_(x)^(y) z")
-    expect(entry["latexmath"]).to eq("\\sum_{x}^{y} z")
+    frac = Plurimath::Math::Function::Frac.catalog_entry
+    expect(frac["name"]).to eq("frac")
+    expect(frac["type"]).to eq("binary")
+    expect(frac["asciimath"]).to eq("frac(x)(y)")
+    expect(frac["latexmath"]).to eq("\\frac{x}{y}")
   end
 end


### PR DESCRIPTION
This PR extends the documentation catalog (plurimath/plurimath.org#32) to the binary-arity functions, the font styles, and several previously-undocumented classes, on top of the ternary PR that introduced the machinery. It wires `BinaryFunction` as a documentable base, broadens catalog enumeration to walk the full subclass subtree so nested families like the font styles are reachable, and overrides `CATALOG_TYPE` where the gem's arity differs from the site's labelling.

## Changes

- Extend `Documentation` into `BinaryFunction` (`CATALOG_TYPE = :binary`) and declare `DESCRIPTION`/`REFERENCE`/`EXAMPLE` on the binary functions: `base`, `frac`, `inf`, `lim`, `log`, `mod`, `over`, `power`, `root`, `stackrel`.
- Switch `Catalog` enumeration to a recursive `descendants_of` walk so grandchild subclasses (the font styles) are catalogued.
- Document the 14 `FontStyle` subclasses (`bold`, `bold-fraktur`, `bold-italic`, `bold-sans-serif`, `bold-script`, `double_struck`, `fraktur`, `italic`, `monospace`, `normal`, `sans-serif`, `sans-serif-bold-italic`, `sans-serif-italic`, `script`); `FontStyle` overrides `CATALOG_TYPE = :unary` to match the site.
- Document seven previously-excluded classes — `arg`, `color`, `menclose`, `overset`, `underset`, `semantics`, `intent` — with `menclose` also overriding to `:unary`.
- Broaden the catalog specs to the merged set: exact sorted enumeration and a `catalog_type` assertion locking the arity overrides.

Every `type` matches the site's existing `function-type:` front-matter, verified page by page. A few un-excluded classes carry known cross-format serializer bugs — `overset`/`underset` OMML operand order, and `color`/`menclose`/`arg`/`intent`/`semantics` dropping an attribute or annotation outside MathML — tracked as follow-ups; every example still renders in all four formats.

Depends on #471
